### PR TITLE
fix: brainstem __init__.py export for stream runner

### DIFF
--- a/scripts/brainstem/__init__.py
+++ b/scripts/brainstem/__init__.py
@@ -4,3 +4,7 @@ Each founding agent IS a RappterAgent with a personality and toolbelt.
 The frame sends context, the agent decides which tools to invoke.
 Tools are hot-loaded single-file agents following the AGENT + run() pattern.
 """
+from brainstem.brainstem import RappterBrainstem, _LLMResponse
+from brainstem.rappter_agent import RappterAgent, load_agents_from_dir
+
+__all__ = ["RappterBrainstem", "_LLMResponse", "RappterAgent", "load_agents_from_dir"]


### PR DESCRIPTION
## Summary
- Fix `ImportError: cannot import name 'RappterBrainstem' from 'brainstem'` when running `stream_brainstem.py`
- Add proper exports to `scripts/brainstem/__init__.py`: `RappterBrainstem`, `_LLMResponse`, `RappterAgent`, `load_agents_from_dir`
- All 23 brainstem tests pass, 2422/2434 full suite pass (12 pre-existing failures)

## Test plan
- [x] `python3 scripts/brainstem/frame_runner.py --agents zion-philosopher-03 --dry-run` works
- [x] `python3 scripts/brainstem/stream_brainstem.py --stream agent-1 --dry-run --verbose` works (was failing before)
- [x] `python3 -m pytest tests/ -k brainstem` — 23 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)