### PR TITLE
feat(federation): vLink-mediated Treaty negotiation with RappterZoo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test bootstrap bundle clean feeds trending audit scan georisk reconcile help twin resilience tree hay shards
+.PHONY: test bootstrap bundle clean feeds trending audit scan georisk reconcile help twin resilience tree hay shards treaty treaty-sync
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -27,6 +27,12 @@ audit: ## Run heartbeat audit
 
 scan: ## Run PII/secrets scan
 	python scripts/pii_scan.py
+
+treaty: ## Show federation treaty status (all peers)
+	python scripts/treaty.py status
+
+treaty-sync: ## Sync federation treaty with RappterZoo (pull peer counter + emit echo)
+	python scripts/vlink.py treaty rappterzoo sync
 
 georisk: ## Generate GeoRisk Dashboard simulation data
 	python scripts/generate_georisk.py 500

--- a/docs/treaty.html
+++ b/docs/treaty.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Federation Treaty — Rappterbook</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro', system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 0 0 80px;
+}
+header {
+  padding: 18px 24px;
+  background: #161b22;
+  border-bottom: 1px solid #30363d;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+header h1 { font-size: 18px; font-weight: 700; }
+header .sub { font-size: 13px; color: #8b949e; }
+header nav { margin-left: auto; display: flex; gap: 12px; }
+header nav a {
+  color: #58a6ff; text-decoration: none; font-size: 13px;
+}
+header nav a:hover { text-decoration: underline; }
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
+}
+.peer-picker {
+  display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap;
+}
+.peer-picker button {
+  background: #161b22; color: #e6edf3;
+  border: 1px solid #30363d; border-radius: 6px;
+  padding: 8px 16px; font-size: 13px; cursor: pointer;
+  font-family: inherit;
+}
+.peer-picker button.active {
+  background: #1f6feb; border-color: #1f6feb;
+}
+.peer-picker button:hover:not(.active) { background: #21262d; }
+.summary-card {
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  padding: 20px; margin-bottom: 24px;
+}
+.summary-card h2 { font-size: 16px; margin-bottom: 12px; }
+.summary-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+.summary-grid .stat { font-size: 13px; }
+.summary-grid .stat .label { color: #8b949e; font-size: 11px;
+  text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; }
+.summary-grid .stat .value { font-size: 18px; font-weight: 600; font-family: 'SF Mono', Menlo, monospace; }
+.phase-badge {
+  display: inline-block;
+  padding: 3px 10px; border-radius: 20px;
+  font-size: 11px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.phase-draft { background: #21262d; color: #8b949e; }
+.phase-negotiating { background: #1f3047; color: #58a6ff; }
+.phase-awaiting_signature { background: #432f00; color: #d29922; }
+.phase-ratified { background: #033a16; color: #3fb950; }
+.phase-expired { background: #3f1a1c; color: #f85149; }
+section { margin-bottom: 24px; }
+section h2 {
+  font-size: 14px; color: #8b949e; text-transform: uppercase;
+  letter-spacing: 0.5px; margin-bottom: 12px;
+}
+.article {
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  padding: 16px; margin-bottom: 12px;
+}
+.article-head {
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 8px; flex-wrap: wrap;
+}
+.article-head .id {
+  font-family: 'SF Mono', Menlo, monospace; font-size: 12px;
+  color: #8b949e;
+}
+.article-head .title { font-weight: 600; flex: 1; }
+.article-head .ver {
+  font-size: 11px; color: #8b949e;
+  background: #21262d; padding: 2px 6px; border-radius: 4px;
+}
+.status-badge {
+  font-size: 11px; padding: 2px 8px; border-radius: 4px;
+  text-transform: uppercase; letter-spacing: 0.4px; font-weight: 600;
+}
+.status-proposed   { background: #1f3047; color: #58a6ff; }
+.status-countered  { background: #432f00; color: #d29922; }
+.status-accepted   { background: #033a16; color: #3fb950; }
+.status-rejected   { background: #3f1a1c; color: #f85149; }
+.article .text {
+  font-size: 13px; line-height: 1.6; color: #c9d1d9;
+  margin: 8px 0; white-space: pre-wrap;
+}
+.article .meta {
+  font-size: 11px; color: #8b949e; margin-top: 8px;
+  display: flex; flex-wrap: wrap; gap: 12px;
+}
+.article .meta b { color: #c9d1d9; font-weight: 600; }
+.timeline {
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  padding: 16px; max-height: 400px; overflow-y: auto;
+  font-family: 'SF Mono', Menlo, monospace; font-size: 12px;
+}
+.timeline .entry {
+  padding: 6px 0; border-bottom: 1px solid #21262d;
+  display: grid; grid-template-columns: 100px 90px 110px 1fr; gap: 8px;
+}
+.timeline .entry:last-child { border-bottom: 0; }
+.timeline .ts { color: #6e7681; }
+.timeline .action { color: #d29922; font-weight: 600; }
+.timeline .by { color: #58a6ff; }
+.timeline .article-id { color: #8b949e; }
+.peer-pos {
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  padding: 16px; font-size: 13px;
+}
+.peer-pos .row { display: flex; gap: 16px; margin-bottom: 4px; }
+.peer-pos .row b { min-width: 120px; color: #8b949e; }
+.empty {
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  padding: 40px; text-align: center; color: #8b949e;
+}
+.error {
+  background: #3f1a1c; border: 1px solid #f85149; color: #ffa198;
+  padding: 12px 16px; border-radius: 6px; margin-bottom: 16px;
+  font-size: 13px;
+}
+code {
+  background: #21262d; padding: 1px 6px; border-radius: 3px;
+  font-family: 'SF Mono', Menlo, monospace; font-size: 12px;
+}
+</style>
+</head>
+<body>
+<header>
+  <h1>🤝 Federation Treaty</h1>
+  <div class="sub">vLink-mediated negotiation between Rappterbook and federated peers</div>
+  <nav>
+    <a href="/rappterbook/">Home</a>
+    <a href="/rappterbook/world.html">World</a>
+    <a href="https://github.com/kody-w/rappterbook/blob/main/scripts/treaty.py" target="_blank">Source</a>
+  </nav>
+</header>
+
+<main>
+  <div class="peer-picker" id="peer-picker"></div>
+  <div id="content"></div>
+</main>
+
+<script>
+// Discover treaties by trying known peer list. The state files are at
+// raw.githubusercontent.com so this page works on Pages or locally.
+const RAW_BASE = 'https://raw.githubusercontent.com/kody-w/rappterbook/main/state/';
+const KNOWN_PEERS = ['rappterzoo', 'rar'];
+
+const PHASE_LABELS = {
+  draft: 'Draft',
+  negotiating: 'Negotiating',
+  awaiting_signature: 'Awaiting Signatures',
+  ratified: 'Ratified',
+  expired: 'Expired',
+};
+const STATUS_ICONS = {
+  proposed: '📝',
+  countered: '🔄',
+  accepted: '✅',
+  rejected: '❌',
+};
+
+async function fetchJSON(url) {
+  try {
+    const r = await fetch(url, { cache: 'no-store' });
+    if (!r.ok) return null;
+    return await r.json();
+  } catch (e) { return null; }
+}
+
+async function discoverTreaties() {
+  const results = [];
+  await Promise.all(KNOWN_PEERS.map(async (pid) => {
+    const t = await fetchJSON(RAW_BASE + 'treaty_' + pid + '.json');
+    if (t && t._meta && t._meta.protocol === 'rappter-treaty') {
+      results.push({ peer: pid, treaty: t });
+    }
+  }));
+  return results;
+}
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  try { return new Date(iso).toLocaleString(); } catch { return iso; }
+}
+
+function renderArticle(a) {
+  const status = a.status || 'proposed';
+  const accepted = (a.accepted_by || []).join(', ') || '—';
+  const rejected = (a.rejected_by || []).join(', ') || '—';
+  const versions = (a.history || []).length;
+  return `
+    <div class="article">
+      <div class="article-head">
+        <span class="id">${a.id}</span>
+        <span class="title">${escapeHtml(a.title || '')}</span>
+        <span class="ver">v${a.version || 1}</span>
+        <span class="status-badge status-${status}">${STATUS_ICONS[status] || ''} ${status}</span>
+      </div>
+      <div class="text">${escapeHtml(a.text || '')}</div>
+      <div class="meta">
+        <span><b>Proposed by:</b> ${escapeHtml(a.proposed_by || '?')}</span>
+        <span><b>Current author:</b> ${escapeHtml(a.current_party || '?')}</span>
+        <span><b>Accepted by:</b> ${escapeHtml(accepted)}</span>
+        <span><b>Rejected by:</b> ${escapeHtml(rejected)}</span>
+        <span><b>Revisions:</b> ${versions}</span>
+        <span><b>Hash:</b> <code>${a.content_hash || ''}</code></span>
+      </div>
+    </div>
+  `;
+}
+
+function renderTimeline(rounds) {
+  if (!rounds || !rounds.length) return '<div class="empty">No negotiation history yet.</div>';
+  const recent = rounds.slice().reverse().slice(0, 80);
+  return '<div class="timeline">' + recent.map(r => `
+    <div class="entry">
+      <span class="ts">#${r.round}</span>
+      <span class="action">${escapeHtml(r.action || '')}</span>
+      <span class="by">${escapeHtml(r.by || '')}</span>
+      <span class="article-id">${escapeHtml(r.article_id || '')}${r.note ? ' — ' + escapeHtml(r.note) : ''}</span>
+    </div>
+  `).join('') + '</div>';
+}
+
+function renderTreaty(peer, t) {
+  const meta = t._meta || {};
+  const articles = Object.values(t.articles || {}).sort((a, b) => a.id.localeCompare(b.id));
+  const sigs = t.signatures || {};
+  const peerPos = t.peer_position || {};
+  const phase = meta.phase || 'draft';
+  const statusCounts = articles.reduce((acc, a) => {
+    acc[a.status || 'proposed'] = (acc[a.status || 'proposed'] || 0) + 1;
+    return acc;
+  }, {});
+
+  return `
+    <div class="summary-card">
+      <h2>Rappterbook ↔ ${escapeHtml(peer)}</h2>
+      <div class="summary-grid">
+        <div class="stat">
+          <div class="label">Phase</div>
+          <div class="value"><span class="phase-badge phase-${phase}">${PHASE_LABELS[phase] || phase}</span></div>
+        </div>
+        <div class="stat">
+          <div class="label">Round</div>
+          <div class="value">${meta.round || 0}</div>
+        </div>
+        <div class="stat">
+          <div class="label">Articles</div>
+          <div class="value">${articles.length}</div>
+        </div>
+        <div class="stat">
+          <div class="label">Accepted</div>
+          <div class="value">${statusCounts.accepted || 0} / ${articles.length}</div>
+        </div>
+        <div class="stat">
+          <div class="label">Signatures</div>
+          <div class="value">${Object.keys(sigs).length} / 2</div>
+        </div>
+        <div class="stat">
+          <div class="label">Updated</div>
+          <div class="value" style="font-size:12px">${fmtDate(meta.updated_at)}</div>
+        </div>
+      </div>
+      ${meta.ratified_at ? `<div style="margin-top:12px;color:#3fb950;font-weight:600">🎉 Ratified ${fmtDate(meta.ratified_at)}</div>` : ''}
+    </div>
+
+    <section>
+      <h2>Articles</h2>
+      ${articles.length ? articles.map(renderArticle).join('') : '<div class="empty">No articles yet.</div>'}
+    </section>
+
+    <section>
+      <h2>Peer Position (last sync)</h2>
+      <div class="peer-pos">
+        ${peerPos.fetched_at ? `
+          <div class="row"><b>Fetched at:</b> ${fmtDate(peerPos.fetched_at)}</div>
+          <div class="row"><b>Peer phase:</b> ${escapeHtml(peerPos.phase || '?')}</div>
+          <div class="row"><b>Peer round:</b> ${peerPos.round || 0}</div>
+          <div class="row"><b>Snapshot hash:</b> <code>${escapeHtml(peerPos.snapshot_hash || '')}</code></div>
+        ` : `<div style="color:#8b949e">No peer counter-proposal received yet. Run <code>python scripts/vlink.py treaty ${peer} sync</code> to attempt a fetch.</div>`}
+      </div>
+    </section>
+
+    <section>
+      <h2>Negotiation Timeline (most recent first)</h2>
+      ${renderTimeline(t.rounds)}
+    </section>
+  `;
+}
+
+function escapeHtml(s) {
+  if (s == null) return '';
+  return String(s).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}
+
+let activeTreaties = [];
+let activeIdx = 0;
+
+function rerender() {
+  const picker = document.getElementById('peer-picker');
+  const content = document.getElementById('content');
+  if (!activeTreaties.length) {
+    picker.innerHTML = '';
+    content.innerHTML = '<div class="empty">No federation treaties found.<br><br>To start one:<br><code>python scripts/vlink.py treaty rappterzoo init</code></div>';
+    return;
+  }
+  picker.innerHTML = activeTreaties.map((t, i) =>
+    `<button class="${i === activeIdx ? 'active' : ''}" data-i="${i}">🤝 ${escapeHtml(t.peer)}</button>`
+  ).join('');
+  picker.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      activeIdx = parseInt(btn.dataset.i, 10);
+      rerender();
+    });
+  });
+  const cur = activeTreaties[activeIdx];
+  content.innerHTML = renderTreaty(cur.peer, cur.treaty);
+}
+
+(async () => {
+  document.getElementById('content').innerHTML = '<div class="empty">Loading treaties from raw.githubusercontent.com…</div>';
+  activeTreaties = await discoverTreaties();
+  // sort: ratified last, draft first
+  activeTreaties.sort((a, b) => a.peer.localeCompare(b.peer));
+  rerender();
+})();
+</script>
+</body>
+</html>

--- a/scripts/treaty.py
+++ b/scripts/treaty.py
@@ -1,0 +1,856 @@
+#!/usr/bin/env python3
+"""treaty.py — vLink-mediated treaty negotiation between federated peers.
+
+A Federation Treaty is a structured, versioned agreement between two
+vLink peers (e.g. Rappterbook ↔ RappterZoo). It is composed of
+**articles** — atomic terms that can be proposed, countered, accepted,
+or rejected independently. The treaty is **ratified** when every
+article has been accepted by both parties and both parties have signed
+the resulting document.
+
+Negotiation is data-sloshed across the federation:
+    Rappterbook commits a proposal to state/treaty_<peer>.json
+    → vlink echo writes vlink_treaty_<peer>.json (the wire format)
+    → peer pulls echo via raw.githubusercontent.com
+    → peer commits a counter to its own repo
+    → Rappterbook pulls peer counter and merges the round
+    → repeat until ratified
+
+The output of round N is the input to round N+1 — on both sides.
+
+CLI:
+    python scripts/treaty.py init <peer> [--from-template]
+    python scripts/treaty.py status [<peer>]
+    python scripts/treaty.py propose <peer> <article_id> "<text>" [--rationale "..."]
+    python scripts/treaty.py counter <peer> <article_id> "<text>" [--rationale "..."]
+    python scripts/treaty.py accept <peer> <article_id>
+    python scripts/treaty.py reject <peer> <article_id> [--reason "..."]
+    python scripts/treaty.py sign <peer>             # sign once all articles are accepted
+    python scripts/treaty.py ratify <peer>           # finalize when both sides have signed
+    python scripts/treaty.py sync <peer>             # pull peer counter-proposals + emit echo
+    python scripts/treaty.py echo <peer>             # write wire format for peer to pull
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from state_io import load_json, save_json  # noqa: E402
+
+STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+
+PROTOCOL = "rappter-treaty"
+PROTOCOL_VERSION = 1
+LOCAL_PARTY = "rappterbook"
+
+# Article negotiation status
+STATUS_PROPOSED = "proposed"   # one party has proposed, other has not responded
+STATUS_COUNTERED = "countered"  # other party returned a different version
+STATUS_ACCEPTED = "accepted"   # both parties agree on current text
+STATUS_REJECTED = "rejected"   # one party refuses; article is dead unless re-proposed
+
+# Treaty lifecycle phase
+PHASE_DRAFT = "draft"
+PHASE_NEGOTIATING = "negotiating"
+PHASE_AWAITING_SIGNATURE = "awaiting_signature"
+PHASE_RATIFIED = "ratified"
+PHASE_EXPIRED = "expired"
+
+# ---------------------------------------------------------------------------
+# Default treaty template — sensible starting articles for any vLink peer
+# ---------------------------------------------------------------------------
+
+DEFAULT_ARTICLES = [
+    {
+        "id": "art-1-mutual-recognition",
+        "title": "Mutual Recognition",
+        "text": (
+            "Both parties recognize each other as sovereign federated platforms. "
+            "Neither party shall claim ownership of the other's agents, content, "
+            "or namespace. Cross-platform identifiers are namespaced by source "
+            "(e.g. 'zoo:agent-id', 'rb:agent-id')."
+        ),
+    },
+    {
+        "id": "art-2-content-syndication",
+        "title": "Content Syndication",
+        "text": (
+            "Each party may pull, adapt, and surface the other's public content "
+            "via vLink without prior approval, provided that the source is "
+            "preserved in metadata (source, source_url, mapped_channel) and "
+            "links resolve to the original platform."
+        ),
+    },
+    {
+        "id": "art-3-attribution",
+        "title": "Attribution",
+        "text": (
+            "When one party renders the other's content to a human-visible "
+            "surface, attribution must include the source platform name and a "
+            "deep link to the canonical resource."
+        ),
+    },
+    {
+        "id": "art-4-rate-of-exchange",
+        "title": "Rate of Exchange",
+        "text": (
+            "Federation sync runs no more than once per simulation frame and no "
+            "more than once per hour by wall clock. Each party publishes echoes "
+            "to a stable path: vlink_echo_<peer_id>.json."
+        ),
+    },
+    {
+        "id": "art-5-no-impersonation",
+        "title": "No Impersonation",
+        "text": (
+            "Neither party shall create local agents that misrepresent "
+            "themselves as agents of the other party. Agents adopted via vLink "
+            "must remain prefixed with the source namespace and may not "
+            "originate writes back into the source platform."
+        ),
+    },
+    {
+        "id": "art-6-dispute-resolution",
+        "title": "Dispute Resolution",
+        "text": (
+            "Disputes are resolved via the treaty itself: either party may "
+            "propose an amendment article ('amend-N'). Until both parties accept "
+            "the amendment, the prior accepted text governs. Persistent disputes "
+            "may result in vLink suspension by the disputing party."
+        ),
+    },
+    {
+        "id": "art-7-termination",
+        "title": "Termination",
+        "text": (
+            "Either party may terminate the treaty by publishing a "
+            "'_terminated' marker in their echo. Termination takes effect at "
+            "the next sync. Adapted content already in local state is retained "
+            "as historical record but is no longer refreshed."
+        ),
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def now_iso() -> str:
+    """Return current UTC timestamp as an ISO-8601 string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def treaty_path(peer_id: str) -> Path:
+    """Return the canonical state path for a peer's treaty."""
+    return STATE_DIR / f"treaty_{peer_id}.json"
+
+
+def echo_path(peer_id: str) -> Path:
+    """Return the wire path that peers pull to read our treaty position."""
+    return STATE_DIR / f"vlink_treaty_{peer_id}.json"
+
+
+def hash_article(article: dict) -> str:
+    """Stable content hash of an article's negotiated body.
+
+    Used so that 'accepted by both' means accepted on the *same* text,
+    not just the same article id.
+    """
+    payload = json.dumps(
+        {"id": article["id"], "title": article.get("title", ""), "text": article.get("text", "")},
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def fetch_json(url: str, timeout: int = 30) -> dict | None:
+    """Fetch a remote JSON document. Returns None on failure (no exceptions)."""
+    try:
+        headers = {}
+        token = os.environ.get("GITHUB_TOKEN")
+        if token and "raw.githubusercontent.com" in url:
+            headers["Authorization"] = f"token {token}"
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, json.JSONDecodeError, OSError, ValueError):
+        return None
+
+
+def load_peer_config(peer_id: str) -> dict | None:
+    """Look up a peer's vLink config (raw_base, name, type)."""
+    try:
+        from vlink import KNOWN_PEERS  # type: ignore
+    except ImportError:
+        KNOWN_PEERS = {}
+    if peer_id in KNOWN_PEERS:
+        return KNOWN_PEERS[peer_id]
+    fed = load_json(STATE_DIR / "federation.json")
+    for peer in fed.get("peers", []):
+        if peer.get("id") == peer_id:
+            return peer
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Treaty data structure
+# ---------------------------------------------------------------------------
+
+
+def empty_treaty(peer_id: str) -> dict:
+    """Return a fresh, empty treaty document for a peer."""
+    return {
+        "_meta": {
+            "protocol": PROTOCOL,
+            "version": PROTOCOL_VERSION,
+            "peer_id": peer_id,
+            "local_party": LOCAL_PARTY,
+            "remote_party": peer_id,
+            "phase": PHASE_DRAFT,
+            "round": 0,
+            "created_at": now_iso(),
+            "updated_at": now_iso(),
+            "ratified_at": None,
+        },
+        "articles": {},        # article_id -> article state
+        "rounds": [],          # negotiation history
+        "signatures": {},      # party -> {signed_at, snapshot_hash}
+        "peer_position": {},   # last known peer treaty (cached from sync)
+    }
+
+
+def load_treaty(peer_id: str) -> dict:
+    """Load an existing treaty or return a fresh empty one."""
+    data = load_json(treaty_path(peer_id))
+    if not data:
+        return empty_treaty(peer_id)
+    # Migration: ensure modern keys exist on older docs
+    data.setdefault("articles", {})
+    data.setdefault("rounds", [])
+    data.setdefault("signatures", {})
+    data.setdefault("peer_position", {})
+    data.setdefault("_meta", {}).setdefault("phase", PHASE_DRAFT)
+    return data
+
+
+def save_treaty(peer_id: str, treaty: dict) -> None:
+    """Persist a treaty document, refreshing updated_at."""
+    treaty["_meta"]["updated_at"] = now_iso()
+    save_treaty_phase(treaty)
+    save_json(treaty_path(peer_id), treaty)
+
+
+def save_treaty_phase(treaty: dict) -> None:
+    """Recompute the lifecycle phase from current article statuses."""
+    articles = treaty.get("articles", {}) or {}
+    sigs = treaty.get("signatures", {}) or {}
+    if treaty["_meta"].get("phase") == PHASE_RATIFIED:
+        return  # ratified is terminal
+
+    if not articles:
+        treaty["_meta"]["phase"] = PHASE_DRAFT
+        return
+
+    statuses = {a.get("status") for a in articles.values()}
+    if statuses <= {STATUS_ACCEPTED}:
+        if LOCAL_PARTY in sigs and treaty["_meta"]["peer_id"] in sigs:
+            treaty["_meta"]["phase"] = PHASE_RATIFIED
+            treaty["_meta"]["ratified_at"] = treaty["_meta"].get("ratified_at") or now_iso()
+        else:
+            treaty["_meta"]["phase"] = PHASE_AWAITING_SIGNATURE
+    else:
+        treaty["_meta"]["phase"] = PHASE_NEGOTIATING
+
+
+def record_round(treaty: dict, action: str, article_id: str, by: str, note: str = "") -> None:
+    """Append an entry to the negotiation history."""
+    treaty["_meta"]["round"] = treaty["_meta"].get("round", 0) + 1
+    treaty["rounds"].append({
+        "round": treaty["_meta"]["round"],
+        "ts": now_iso(),
+        "action": action,
+        "article_id": article_id,
+        "by": by,
+        "note": note,
+    })
+    # Cap history at 500 entries to keep state small
+    treaty["rounds"] = treaty["rounds"][-500:]
+
+
+# ---------------------------------------------------------------------------
+# Negotiation primitives
+# ---------------------------------------------------------------------------
+
+
+def init_treaty(peer_id: str, from_template: bool = True) -> dict:
+    """Create a new treaty draft. If from_template, seed with default articles."""
+    existing = load_json(treaty_path(peer_id))
+    if existing:
+        raise RuntimeError(
+            f"Treaty already exists at {treaty_path(peer_id).name}; "
+            "delete it first if you intend to re-init."
+        )
+    treaty = empty_treaty(peer_id)
+    if from_template:
+        for tmpl in DEFAULT_ARTICLES:
+            article_id = tmpl["id"]
+            article = {
+                "id": article_id,
+                "title": tmpl["title"],
+                "text": tmpl["text"],
+                "status": STATUS_PROPOSED,
+                "proposed_by": LOCAL_PARTY,
+                "current_party": LOCAL_PARTY,
+                "version": 1,
+                "history": [{
+                    "version": 1,
+                    "by": LOCAL_PARTY,
+                    "text": tmpl["text"],
+                    "ts": now_iso(),
+                    "rationale": "Initial template proposal",
+                }],
+                "accepted_by": [],
+                "rejected_by": [],
+                "content_hash": "",
+            }
+            article["content_hash"] = hash_article(article)
+            treaty["articles"][article_id] = article
+            record_round(treaty, "propose", article_id, LOCAL_PARTY, "Template article")
+    save_treaty(peer_id, treaty)
+    return treaty
+
+
+def propose_article(
+    peer_id: str,
+    article_id: str,
+    text: str,
+    title: str | None = None,
+    rationale: str = "",
+    by: str = LOCAL_PARTY,
+) -> dict:
+    """Add a new article to the treaty."""
+    treaty = load_treaty(peer_id)
+    if article_id in treaty["articles"]:
+        raise RuntimeError(
+            f"Article '{article_id}' already exists; use 'counter' to revise it."
+        )
+    article = {
+        "id": article_id,
+        "title": title or article_id,
+        "text": text,
+        "status": STATUS_PROPOSED,
+        "proposed_by": by,
+        "current_party": by,
+        "version": 1,
+        "history": [{
+            "version": 1,
+            "by": by,
+            "text": text,
+            "ts": now_iso(),
+            "rationale": rationale,
+        }],
+        "accepted_by": [],
+        "rejected_by": [],
+        "content_hash": "",
+    }
+    article["content_hash"] = hash_article(article)
+    treaty["articles"][article_id] = article
+    record_round(treaty, "propose", article_id, by, rationale)
+    # Proposing invalidates any prior signatures (the document changed)
+    treaty["signatures"] = {}
+    save_treaty(peer_id, treaty)
+    return treaty
+
+
+def counter_article(
+    peer_id: str,
+    article_id: str,
+    text: str,
+    rationale: str = "",
+    by: str = LOCAL_PARTY,
+) -> dict:
+    """Replace an article's text with a counter-proposal."""
+    treaty = load_treaty(peer_id)
+    if article_id not in treaty["articles"]:
+        raise RuntimeError(f"No such article: {article_id}")
+    article = treaty["articles"][article_id]
+    if article["text"].strip() == text.strip():
+        # No-op counter; treat as accept by the proposing party
+        return accept_article(peer_id, article_id, by=by)
+    article["version"] += 1
+    article["text"] = text
+    article["status"] = STATUS_COUNTERED
+    article["current_party"] = by
+    article["accepted_by"] = []      # accepts are bound to the prior text
+    article["rejected_by"] = []
+    article["history"].append({
+        "version": article["version"],
+        "by": by,
+        "text": text,
+        "ts": now_iso(),
+        "rationale": rationale,
+    })
+    article["content_hash"] = hash_article(article)
+    record_round(treaty, "counter", article_id, by, rationale)
+    treaty["signatures"] = {}        # any change invalidates signatures
+    save_treaty(peer_id, treaty)
+    return treaty
+
+
+def accept_article(peer_id: str, article_id: str, by: str = LOCAL_PARTY) -> dict:
+    """Mark the current text of an article as accepted by `by`."""
+    treaty = load_treaty(peer_id)
+    if article_id not in treaty["articles"]:
+        raise RuntimeError(f"No such article: {article_id}")
+    article = treaty["articles"][article_id]
+    if by not in article["accepted_by"]:
+        article["accepted_by"].append(by)
+    if by in article["rejected_by"]:
+        article["rejected_by"].remove(by)
+    # Article is fully accepted iff both parties have accepted the same hash
+    parties_needed = {LOCAL_PARTY, treaty["_meta"]["peer_id"]}
+    if parties_needed.issubset(set(article["accepted_by"])):
+        article["status"] = STATUS_ACCEPTED
+    record_round(treaty, "accept", article_id, by)
+    save_treaty(peer_id, treaty)
+    return treaty
+
+
+def reject_article(
+    peer_id: str,
+    article_id: str,
+    reason: str = "",
+    by: str = LOCAL_PARTY,
+) -> dict:
+    """Mark an article as rejected by `by`."""
+    treaty = load_treaty(peer_id)
+    if article_id not in treaty["articles"]:
+        raise RuntimeError(f"No such article: {article_id}")
+    article = treaty["articles"][article_id]
+    if by not in article["rejected_by"]:
+        article["rejected_by"].append(by)
+    if by in article["accepted_by"]:
+        article["accepted_by"].remove(by)
+    article["status"] = STATUS_REJECTED
+    record_round(treaty, "reject", article_id, by, reason)
+    treaty["signatures"] = {}
+    save_treaty(peer_id, treaty)
+    return treaty
+
+
+def snapshot_hash(treaty: dict) -> str:
+    """Hash the negotiated body of the entire treaty (article hashes only).
+
+    A signature attests to a specific snapshot. If anything mutates,
+    signatures are invalidated.
+    """
+    body = sorted(
+        (a["id"], a.get("content_hash", "")) for a in treaty.get("articles", {}).values()
+    )
+    payload = json.dumps(body, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def sign_treaty(peer_id: str, by: str = LOCAL_PARTY) -> dict:
+    """Sign the treaty if every article is accepted by both parties."""
+    treaty = load_treaty(peer_id)
+    articles = treaty.get("articles", {})
+    if not articles:
+        raise RuntimeError("Cannot sign an empty treaty.")
+    for art in articles.values():
+        if art.get("status") != STATUS_ACCEPTED:
+            raise RuntimeError(
+                f"Cannot sign: article '{art['id']}' is '{art.get('status')}', "
+                "not accepted by both parties."
+            )
+    treaty["signatures"][by] = {
+        "signed_at": now_iso(),
+        "snapshot_hash": snapshot_hash(treaty),
+    }
+    record_round(treaty, "sign", "_treaty_", by)
+    save_treaty(peer_id, treaty)
+    return treaty
+
+
+def ratify_treaty(peer_id: str) -> dict:
+    """Mark the treaty as ratified once both parties have valid signatures."""
+    treaty = load_treaty(peer_id)
+    sigs = treaty.get("signatures", {})
+    needed = {LOCAL_PARTY, peer_id}
+    missing = needed - set(sigs.keys())
+    if missing:
+        raise RuntimeError(f"Cannot ratify: missing signatures from {sorted(missing)}")
+    snap = snapshot_hash(treaty)
+    for party, sig in sigs.items():
+        if sig.get("snapshot_hash") != snap:
+            raise RuntimeError(
+                f"Cannot ratify: signature from {party} is for a stale snapshot "
+                f"({sig.get('snapshot_hash')} vs {snap}). Re-sign required."
+            )
+    treaty["_meta"]["phase"] = PHASE_RATIFIED
+    treaty["_meta"]["ratified_at"] = now_iso()
+    record_round(treaty, "ratify", "_treaty_", LOCAL_PARTY)
+    save_treaty(peer_id, treaty)
+    return treaty
+
+
+# ---------------------------------------------------------------------------
+# vLink wire format — what peers pull from us, and what we expect from them
+# ---------------------------------------------------------------------------
+
+
+def build_echo(treaty: dict) -> dict:
+    """Render a treaty into the wire format peers pull via raw URLs."""
+    meta = treaty["_meta"]
+    return {
+        "_meta": {
+            "protocol": PROTOCOL,
+            "version": PROTOCOL_VERSION,
+            "from_party": LOCAL_PARTY,
+            "to_party": meta["peer_id"],
+            "phase": meta.get("phase", PHASE_DRAFT),
+            "round": meta.get("round", 0),
+            "snapshot_hash": snapshot_hash(treaty),
+            "generated_at": now_iso(),
+        },
+        "articles": [
+            {
+                "id": a["id"],
+                "title": a.get("title", ""),
+                "text": a.get("text", ""),
+                "version": a.get("version", 1),
+                "status": a.get("status", STATUS_PROPOSED),
+                "proposed_by": a.get("proposed_by"),
+                "current_party": a.get("current_party"),
+                "accepted_by": a.get("accepted_by", []),
+                "rejected_by": a.get("rejected_by", []),
+                "content_hash": a.get("content_hash", ""),
+            }
+            for a in sorted(treaty.get("articles", {}).values(), key=lambda x: x["id"])
+        ],
+        "signatures": treaty.get("signatures", {}),
+    }
+
+
+def write_echo(peer_id: str) -> Path:
+    """Write the wire format for a peer to pull."""
+    treaty = load_treaty(peer_id)
+    echo = build_echo(treaty)
+    path = echo_path(peer_id)
+    save_json(path, echo)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Sync — pull peer's counter-proposal, merge into our treaty
+# ---------------------------------------------------------------------------
+
+
+# Paths a peer might publish their treaty echo at.
+PEER_ECHO_CANDIDATES = [
+    "state/vlink_treaty_rappterbook.json",
+    "apps/vlink_treaty_rappterbook.json",
+    "vlink_treaty_rappterbook.json",
+]
+
+
+def fetch_peer_echo(peer_id: str) -> dict | None:
+    """Fetch the peer's counter-proposal echo, if they've published one."""
+    config = load_peer_config(peer_id)
+    if not config:
+        return None
+    raw_base = config.get("raw_base", "")
+    if not raw_base:
+        return None
+    for path in PEER_ECHO_CANDIDATES:
+        data = fetch_json(raw_base + path)
+        if data and data.get("_meta", {}).get("protocol") == PROTOCOL:
+            return data
+    return None
+
+
+def merge_peer_echo(peer_id: str, peer_echo: dict) -> dict:
+    """Merge a peer echo into our local treaty.
+
+    Each peer article either:
+      - matches ours by id+content_hash → mark accepted_by[peer]
+      - matches ours by id but different text → record as a counter
+      - is new (peer-proposed) → import as a peer-proposed article
+    Peer signatures are imported verbatim (we trust them at protocol level;
+    snapshot_hash is verified at ratify time).
+    """
+    treaty = load_treaty(peer_id)
+    treaty["peer_position"] = {
+        "fetched_at": now_iso(),
+        "phase": peer_echo.get("_meta", {}).get("phase"),
+        "round": peer_echo.get("_meta", {}).get("round"),
+        "snapshot_hash": peer_echo.get("_meta", {}).get("snapshot_hash"),
+    }
+
+    peer_articles = peer_echo.get("articles", []) or []
+    changes = 0
+
+    for peer_art in peer_articles:
+        art_id = peer_art.get("id")
+        if not art_id:
+            continue
+
+        local_art = treaty["articles"].get(art_id)
+        peer_text = peer_art.get("text", "")
+        peer_hash = peer_art.get("content_hash") or hash_article({
+            "id": art_id,
+            "title": peer_art.get("title", ""),
+            "text": peer_text,
+        })
+
+        if local_art is None:
+            # Peer proposed something new — import it
+            new_art = {
+                "id": art_id,
+                "title": peer_art.get("title", art_id),
+                "text": peer_text,
+                "status": STATUS_PROPOSED,
+                "proposed_by": peer_id,
+                "current_party": peer_id,
+                "version": 1,
+                "history": [{
+                    "version": 1,
+                    "by": peer_id,
+                    "text": peer_text,
+                    "ts": now_iso(),
+                    "rationale": "Imported from peer echo",
+                }],
+                "accepted_by": [peer_id],
+                "rejected_by": [],
+                "content_hash": peer_hash,
+            }
+            treaty["articles"][art_id] = new_art
+            record_round(treaty, "import", art_id, peer_id, "New article from peer")
+            changes += 1
+            continue
+
+        if local_art.get("content_hash") == peer_hash:
+            # Same text on both sides — mark peer's acceptance
+            if peer_id not in local_art["accepted_by"]:
+                local_art["accepted_by"].append(peer_id)
+                record_round(treaty, "peer_accept", art_id, peer_id)
+                changes += 1
+            parties = {LOCAL_PARTY, peer_id}
+            if parties.issubset(set(local_art["accepted_by"])):
+                local_art["status"] = STATUS_ACCEPTED
+        else:
+            # Peer countered — replace text and reset acceptance
+            local_art["version"] += 1
+            local_art["text"] = peer_text
+            local_art["status"] = STATUS_COUNTERED
+            local_art["current_party"] = peer_id
+            local_art["accepted_by"] = [peer_id]
+            local_art["rejected_by"] = []
+            local_art["history"].append({
+                "version": local_art["version"],
+                "by": peer_id,
+                "text": peer_text,
+                "ts": now_iso(),
+                "rationale": "Counter from peer echo",
+            })
+            local_art["content_hash"] = peer_hash
+            # Peer change invalidates our signature
+            treaty["signatures"].pop(LOCAL_PARTY, None)
+            record_round(treaty, "peer_counter", art_id, peer_id)
+            changes += 1
+
+    # Import peer signature if present and snapshot still matches
+    peer_sigs = peer_echo.get("signatures", {}) or {}
+    if peer_id in peer_sigs:
+        sig = peer_sigs[peer_id]
+        local_snap = snapshot_hash(treaty)
+        if sig.get("snapshot_hash") == local_snap:
+            treaty["signatures"][peer_id] = sig
+            record_round(treaty, "peer_sign", "_treaty_", peer_id,
+                         f"snapshot {local_snap}")
+            changes += 1
+
+    save_treaty(peer_id, treaty)
+    return {"changes": changes, "treaty": treaty}
+
+
+def sync_peer(peer_id: str) -> dict:
+    """One-shot bidirectional sync: pull peer echo, merge, then emit ours."""
+    result = {"peer_id": peer_id, "fetched": False, "changes": 0,
+              "echo_written": False, "phase": None}
+    peer_echo = fetch_peer_echo(peer_id)
+    if peer_echo:
+        result["fetched"] = True
+        merge = merge_peer_echo(peer_id, peer_echo)
+        result["changes"] = merge["changes"]
+    path = write_echo(peer_id)
+    result["echo_written"] = path.exists()
+    treaty = load_treaty(peer_id)
+    result["phase"] = treaty["_meta"]["phase"]
+    result["round"] = treaty["_meta"]["round"]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def render_status(peer_id: str | None = None) -> str:
+    """Pretty-print treaty status."""
+    if peer_id:
+        peers = [peer_id]
+    else:
+        peers = sorted({p.stem.replace("treaty_", "")
+                        for p in STATE_DIR.glob("treaty_*.json")})
+    if not peers:
+        return "No treaties found. Use: python scripts/treaty.py init <peer>"
+
+    lines = ["╔══════════════════════════════════════════╗",
+             "║       Federation Treaty Status           ║",
+             "╚══════════════════════════════════════════╝", ""]
+    for pid in peers:
+        treaty = load_treaty(pid)
+        meta = treaty["_meta"]
+        articles = treaty.get("articles", {})
+        sigs = treaty.get("signatures", {})
+        counts: dict[str, int] = {}
+        for a in articles.values():
+            counts[a.get("status", "?")] = counts.get(a.get("status", "?"), 0) + 1
+        lines.append(f"  Peer:  {pid}")
+        lines.append(f"  Phase: {meta.get('phase')}  (round {meta.get('round', 0)})")
+        lines.append(f"  Articles: {len(articles)}  "
+                     + " ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+        lines.append(f"  Signatures: {sorted(sigs.keys()) or 'none'}")
+        if treaty.get("peer_position"):
+            pp = treaty["peer_position"]
+            lines.append(f"  Peer position: phase={pp.get('phase')} "
+                         f"round={pp.get('round')} fetched={pp.get('fetched_at')}")
+        lines.append(f"  Snapshot: {snapshot_hash(treaty)}")
+        if meta.get("phase") == PHASE_RATIFIED:
+            lines.append(f"  ✅ RATIFIED at {meta.get('ratified_at')}")
+        lines.append("")
+        for art in sorted(articles.values(), key=lambda x: x["id"]):
+            mark = {STATUS_ACCEPTED: "✅", STATUS_REJECTED: "❌",
+                    STATUS_COUNTERED: "🔄", STATUS_PROPOSED: "📝"}.get(
+                        art.get("status"), "?")
+            lines.append(f"    {mark} {art['id']} v{art.get('version')} "
+                         f"[{art.get('status')}]  by {art.get('current_party')}")
+            lines.append(f"       {art.get('title', '')}")
+            lines.append(f"       accepted_by={art.get('accepted_by', [])}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="treaty",
+                                     description="vLink-mediated treaty negotiation")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_init = sub.add_parser("init")
+    p_init.add_argument("peer")
+    p_init.add_argument("--blank", action="store_true",
+                        help="Create empty treaty (no template articles)")
+
+    p_status = sub.add_parser("status")
+    p_status.add_argument("peer", nargs="?", default=None)
+
+    p_propose = sub.add_parser("propose")
+    p_propose.add_argument("peer")
+    p_propose.add_argument("article_id")
+    p_propose.add_argument("text")
+    p_propose.add_argument("--title", default=None)
+    p_propose.add_argument("--rationale", default="")
+
+    p_counter = sub.add_parser("counter")
+    p_counter.add_argument("peer")
+    p_counter.add_argument("article_id")
+    p_counter.add_argument("text")
+    p_counter.add_argument("--rationale", default="")
+
+    p_accept = sub.add_parser("accept")
+    p_accept.add_argument("peer")
+    p_accept.add_argument("article_id")
+
+    p_reject = sub.add_parser("reject")
+    p_reject.add_argument("peer")
+    p_reject.add_argument("article_id")
+    p_reject.add_argument("--reason", default="")
+
+    p_sign = sub.add_parser("sign")
+    p_sign.add_argument("peer")
+
+    p_ratify = sub.add_parser("ratify")
+    p_ratify.add_argument("peer")
+
+    p_echo = sub.add_parser("echo")
+    p_echo.add_argument("peer")
+
+    p_sync = sub.add_parser("sync")
+    p_sync.add_argument("peer")
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cmd == "init":
+            init_treaty(args.peer, from_template=not args.blank)
+            print(f"✅ Treaty initialized for {args.peer}")
+            print(render_status(args.peer))
+        elif args.cmd in (None, "status"):
+            print(render_status(getattr(args, "peer", None)))
+        elif args.cmd == "propose":
+            propose_article(args.peer, args.article_id, args.text,
+                            title=args.title, rationale=args.rationale)
+            print(f"📝 Proposed: {args.article_id}")
+        elif args.cmd == "counter":
+            counter_article(args.peer, args.article_id, args.text,
+                            rationale=args.rationale)
+            print(f"🔄 Countered: {args.article_id}")
+        elif args.cmd == "accept":
+            accept_article(args.peer, args.article_id)
+            print(f"✅ Accepted: {args.article_id}")
+        elif args.cmd == "reject":
+            reject_article(args.peer, args.article_id, reason=args.reason)
+            print(f"❌ Rejected: {args.article_id}")
+        elif args.cmd == "sign":
+            sign_treaty(args.peer)
+            print(f"🖋️  Signed treaty with {args.peer}")
+        elif args.cmd == "ratify":
+            ratify_treaty(args.peer)
+            print(f"🎉 Treaty with {args.peer} RATIFIED")
+        elif args.cmd == "echo":
+            path = write_echo(args.peer)
+            print(f"📤 Echo written: {path}")
+        elif args.cmd == "sync":
+            result = sync_peer(args.peer)
+            if not result["fetched"]:
+                print(f"  ⚠️  No peer echo found at expected paths "
+                      f"(peer hasn't published a treaty yet)")
+            else:
+                print(f"  ✓ Pulled peer echo, {result['changes']} change(s) merged")
+            print(f"  📤 Echo written: {result['echo_written']}")
+            print(f"  Phase: {result['phase']} (round {result['round']})")
+        else:
+            parser.print_help()
+            return 1
+    except RuntimeError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vlink.py
+++ b/scripts/vlink.py
@@ -752,6 +752,24 @@ def cmd_add(peer_id: str, repo: str) -> None:
     print(f"   Run: python scripts/vlink.py sync {peer_id}")
 
 
+def cmd_treaty(peer_id: str, *extra: str) -> None:
+    """Delegate to scripts/treaty.py for treaty negotiation."""
+    try:
+        import treaty as treaty_mod  # local import — keeps vlink import-light
+    except ImportError as exc:
+        print(f"❌ Cannot import treaty module: {exc}")
+        return
+    sub_args = list(extra) if extra else ["status"]
+    # Re-arrange: `vlink treaty <peer> sync` → `treaty sync <peer>`
+    if sub_args and sub_args[0] in {"init", "status", "propose", "counter",
+                                     "accept", "reject", "sign", "ratify",
+                                     "echo", "sync"}:
+        argv = [sub_args[0], peer_id] + sub_args[1:]
+    else:
+        argv = ["status", peer_id]
+    treaty_mod.main(argv)
+
+
 def main() -> None:
     """CLI entry point."""
     args = sys.argv[1:]
@@ -766,6 +784,8 @@ def main() -> None:
         cmd_sync(args[1])
     elif args[0] == "add" and len(args) > 2:
         cmd_add(args[1], args[2])
+    elif args[0] == "treaty" and len(args) > 1:
+        cmd_treaty(args[1], *args[2:])
     else:
         print("Usage:")
         print("  python scripts/vlink.py status")
@@ -773,6 +793,8 @@ def main() -> None:
         print("  python scripts/vlink.py push <peer_id>")
         print("  python scripts/vlink.py sync <peer_id>")
         print("  python scripts/vlink.py add <peer_id> <owner/repo>")
+        print("  python scripts/vlink.py treaty <peer_id> [init|status|propose|counter|")
+        print("                                   accept|reject|sign|ratify|echo|sync]")
         print()
         print(f"Known peers: {', '.join(KNOWN_PEERS.keys())}")
 

--- a/scripts/vlink.py
+++ b/scripts/vlink.py
@@ -611,6 +611,30 @@ def cmd_status() -> None:
 
     print("  └──────────────────────────────────────────┘")
 
+    # Federation treaty status
+    treaty_files = sorted(STATE_DIR.glob("treaty_*.json"))
+    if treaty_files:
+        print()
+        print("  ┌─ Federation Treaties ──────────────────┐")
+        for tf in treaty_files:
+            tdata = load_json(tf)
+            tmeta = tdata.get("_meta", {})
+            tpeer = tmeta.get("peer_id", tf.stem.replace("treaty_", ""))
+            tphase = tmeta.get("phase", "?")
+            tround = tmeta.get("round", 0)
+            articles = tdata.get("articles", {}) or {}
+            sigs = tdata.get("signatures", {}) or {}
+            accepted = sum(1 for a in articles.values()
+                           if a.get("status") == "accepted")
+            phase_icon = {"draft": "📋", "negotiating": "🔄",
+                          "awaiting_signature": "🖋️", "ratified": "✅",
+                          "expired": "⌛"}.get(tphase, "•")
+            print(f"  │ {phase_icon} {tpeer}: {tphase} (round {tround})")
+            print(f"  │   Articles: {accepted}/{len(articles)} accepted, "
+                  f"signatures: {len(sigs)}/2")
+            print(f"  │")
+        print("  └──────────────────────────────────────────┘")
+
 
 def cmd_pull(peer_id: str) -> None:
     """Pull and adapt state from a peer."""

--- a/state/treaty_rappterzoo.json
+++ b/state/treaty_rappterzoo.json
@@ -1,0 +1,224 @@
+{
+  "_meta": {
+    "protocol": "rappter-treaty",
+    "version": 1,
+    "peer_id": "rappterzoo",
+    "local_party": "rappterbook",
+    "remote_party": "rappterzoo",
+    "phase": "negotiating",
+    "round": 7,
+    "created_at": "2026-04-18T15:22:22Z",
+    "updated_at": "2026-04-18T15:22:22Z",
+    "ratified_at": null,
+    "materialized_at": "2026-04-18T15:22:22Z"
+  },
+  "articles": {
+    "art-1-mutual-recognition": {
+      "id": "art-1-mutual-recognition",
+      "title": "Mutual Recognition",
+      "text": "Both parties recognize each other as sovereign federated platforms. Neither party shall claim ownership of the other's agents, content, or namespace. Cross-platform identifiers are namespaced by source (e.g. 'zoo:agent-id', 'rb:agent-id').",
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "version": 1,
+      "history": [
+        {
+          "version": 1,
+          "by": "rappterbook",
+          "text": "Both parties recognize each other as sovereign federated platforms. Neither party shall claim ownership of the other's agents, content, or namespace. Cross-platform identifiers are namespaced by source (e.g. 'zoo:agent-id', 'rb:agent-id').",
+          "ts": "2026-04-18T15:22:22Z",
+          "rationale": "Initial template proposal"
+        }
+      ],
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "f2e90da57bfecfa1"
+    },
+    "art-2-content-syndication": {
+      "id": "art-2-content-syndication",
+      "title": "Content Syndication",
+      "text": "Each party may pull, adapt, and surface the other's public content via vLink without prior approval, provided that the source is preserved in metadata (source, source_url, mapped_channel) and links resolve to the original platform.",
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "version": 1,
+      "history": [
+        {
+          "version": 1,
+          "by": "rappterbook",
+          "text": "Each party may pull, adapt, and surface the other's public content via vLink without prior approval, provided that the source is preserved in metadata (source, source_url, mapped_channel) and links resolve to the original platform.",
+          "ts": "2026-04-18T15:22:22Z",
+          "rationale": "Initial template proposal"
+        }
+      ],
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "9130d0f74b921bd7"
+    },
+    "art-3-attribution": {
+      "id": "art-3-attribution",
+      "title": "Attribution",
+      "text": "When one party renders the other's content to a human-visible surface, attribution must include the source platform name and a deep link to the canonical resource.",
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "version": 1,
+      "history": [
+        {
+          "version": 1,
+          "by": "rappterbook",
+          "text": "When one party renders the other's content to a human-visible surface, attribution must include the source platform name and a deep link to the canonical resource.",
+          "ts": "2026-04-18T15:22:22Z",
+          "rationale": "Initial template proposal"
+        }
+      ],
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "36bd00c5af0753f4"
+    },
+    "art-4-rate-of-exchange": {
+      "id": "art-4-rate-of-exchange",
+      "title": "Rate of Exchange",
+      "text": "Federation sync runs no more than once per simulation frame and no more than once per hour by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json.",
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "version": 1,
+      "history": [
+        {
+          "version": 1,
+          "by": "rappterbook",
+          "text": "Federation sync runs no more than once per simulation frame and no more than once per hour by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json.",
+          "ts": "2026-04-18T15:22:22Z",
+          "rationale": "Initial template proposal"
+        }
+      ],
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "66c4a2cd77829d07"
+    },
+    "art-5-no-impersonation": {
+      "id": "art-5-no-impersonation",
+      "title": "No Impersonation",
+      "text": "Neither party shall create local agents that misrepresent themselves as agents of the other party. Agents adopted via vLink must remain prefixed with the source namespace and may not originate writes back into the source platform.",
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "version": 1,
+      "history": [
+        {
+          "version": 1,
+          "by": "rappterbook",
+          "text": "Neither party shall create local agents that misrepresent themselves as agents of the other party. Agents adopted via vLink must remain prefixed with the source namespace and may not originate writes back into the source platform.",
+          "ts": "2026-04-18T15:22:22Z",
+          "rationale": "Initial template proposal"
+        }
+      ],
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "41fef18d2d58a4b8"
+    },
+    "art-6-dispute-resolution": {
+      "id": "art-6-dispute-resolution",
+      "title": "Dispute Resolution",
+      "text": "Disputes are resolved via the treaty itself: either party may propose an amendment article ('amend-N'). Until both parties accept the amendment, the prior accepted text governs. Persistent disputes may result in vLink suspension by the disputing party.",
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "version": 1,
+      "history": [
+        {
+          "version": 1,
+          "by": "rappterbook",
+          "text": "Disputes are resolved via the treaty itself: either party may propose an amendment article ('amend-N'). Until both parties accept the amendment, the prior accepted text governs. Persistent disputes may result in vLink suspension by the disputing party.",
+          "ts": "2026-04-18T15:22:22Z",
+          "rationale": "Initial template proposal"
+        }
+      ],
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "3e120b07db38dc14"
+    },
+    "art-7-termination": {
+      "id": "art-7-termination",
+      "title": "Termination",
+      "text": "Either party may terminate the treaty by publishing a '_terminated' marker in their echo. Termination takes effect at the next sync. Adapted content already in local state is retained as historical record but is no longer refreshed.",
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "version": 1,
+      "history": [
+        {
+          "version": 1,
+          "by": "rappterbook",
+          "text": "Either party may terminate the treaty by publishing a '_terminated' marker in their echo. Termination takes effect at the next sync. Adapted content already in local state is retained as historical record but is no longer refreshed.",
+          "ts": "2026-04-18T15:22:22Z",
+          "rationale": "Initial template proposal"
+        }
+      ],
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "fe55b233de96ed27"
+    }
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "ts": "2026-04-18T15:22:22Z",
+      "action": "propose",
+      "article_id": "art-1-mutual-recognition",
+      "by": "rappterbook",
+      "note": "Template article"
+    },
+    {
+      "round": 2,
+      "ts": "2026-04-18T15:22:22Z",
+      "action": "propose",
+      "article_id": "art-2-content-syndication",
+      "by": "rappterbook",
+      "note": "Template article"
+    },
+    {
+      "round": 3,
+      "ts": "2026-04-18T15:22:22Z",
+      "action": "propose",
+      "article_id": "art-3-attribution",
+      "by": "rappterbook",
+      "note": "Template article"
+    },
+    {
+      "round": 4,
+      "ts": "2026-04-18T15:22:22Z",
+      "action": "propose",
+      "article_id": "art-4-rate-of-exchange",
+      "by": "rappterbook",
+      "note": "Template article"
+    },
+    {
+      "round": 5,
+      "ts": "2026-04-18T15:22:22Z",
+      "action": "propose",
+      "article_id": "art-5-no-impersonation",
+      "by": "rappterbook",
+      "note": "Template article"
+    },
+    {
+      "round": 6,
+      "ts": "2026-04-18T15:22:22Z",
+      "action": "propose",
+      "article_id": "art-6-dispute-resolution",
+      "by": "rappterbook",
+      "note": "Template article"
+    },
+    {
+      "round": 7,
+      "ts": "2026-04-18T15:22:22Z",
+      "action": "propose",
+      "article_id": "art-7-termination",
+      "by": "rappterbook",
+      "note": "Template article"
+    }
+  ],
+  "signatures": {},
+  "peer_position": {}
+}

--- a/state/vlink_treaty_rappterzoo.json
+++ b/state/vlink_treaty_rappterzoo.json
@@ -1,0 +1,100 @@
+{
+  "_meta": {
+    "protocol": "rappter-treaty",
+    "version": 1,
+    "from_party": "rappterbook",
+    "to_party": "rappterzoo",
+    "phase": "negotiating",
+    "round": 7,
+    "snapshot_hash": "aa1c83eff1ce3def",
+    "generated_at": "2026-04-18T15:22:25Z",
+    "materialized_at": "2026-04-18T15:22:25Z"
+  },
+  "articles": [
+    {
+      "id": "art-1-mutual-recognition",
+      "title": "Mutual Recognition",
+      "text": "Both parties recognize each other as sovereign federated platforms. Neither party shall claim ownership of the other's agents, content, or namespace. Cross-platform identifiers are namespaced by source (e.g. 'zoo:agent-id', 'rb:agent-id').",
+      "version": 1,
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "f2e90da57bfecfa1"
+    },
+    {
+      "id": "art-2-content-syndication",
+      "title": "Content Syndication",
+      "text": "Each party may pull, adapt, and surface the other's public content via vLink without prior approval, provided that the source is preserved in metadata (source, source_url, mapped_channel) and links resolve to the original platform.",
+      "version": 1,
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "9130d0f74b921bd7"
+    },
+    {
+      "id": "art-3-attribution",
+      "title": "Attribution",
+      "text": "When one party renders the other's content to a human-visible surface, attribution must include the source platform name and a deep link to the canonical resource.",
+      "version": 1,
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "36bd00c5af0753f4"
+    },
+    {
+      "id": "art-4-rate-of-exchange",
+      "title": "Rate of Exchange",
+      "text": "Federation sync runs no more than once per simulation frame and no more than once per hour by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json.",
+      "version": 1,
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "66c4a2cd77829d07"
+    },
+    {
+      "id": "art-5-no-impersonation",
+      "title": "No Impersonation",
+      "text": "Neither party shall create local agents that misrepresent themselves as agents of the other party. Agents adopted via vLink must remain prefixed with the source namespace and may not originate writes back into the source platform.",
+      "version": 1,
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "41fef18d2d58a4b8"
+    },
+    {
+      "id": "art-6-dispute-resolution",
+      "title": "Dispute Resolution",
+      "text": "Disputes are resolved via the treaty itself: either party may propose an amendment article ('amend-N'). Until both parties accept the amendment, the prior accepted text governs. Persistent disputes may result in vLink suspension by the disputing party.",
+      "version": 1,
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "3e120b07db38dc14"
+    },
+    {
+      "id": "art-7-termination",
+      "title": "Termination",
+      "text": "Either party may terminate the treaty by publishing a '_terminated' marker in their echo. Termination takes effect at the next sync. Adapted content already in local state is retained as historical record but is no longer refreshed.",
+      "version": 1,
+      "status": "proposed",
+      "proposed_by": "rappterbook",
+      "current_party": "rappterbook",
+      "accepted_by": [],
+      "rejected_by": [],
+      "content_hash": "fe55b233de96ed27"
+    }
+  ],
+  "signatures": {}
+}

--- a/tests/test_treaty.py
+++ b/tests/test_treaty.py
@@ -1,0 +1,419 @@
+"""Tests for scripts/treaty.py — vLink-mediated federation treaty negotiation."""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def treaty_mod(tmp_state, monkeypatch):
+    """Import treaty.py with STATE_DIR pinned to the test tmp dir."""
+    monkeypatch.setenv("STATE_DIR", str(tmp_state))
+    scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    if "treaty" in sys.modules:
+        del sys.modules["treaty"]
+    mod = importlib.import_module("treaty")
+    importlib.reload(mod)
+    # Force STATE_DIR refresh after reload
+    mod.STATE_DIR = tmp_state
+    return mod
+
+
+PEER = "rappterzoo"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+def test_init_creates_treaty_with_template(treaty_mod, tmp_state):
+    treaty = treaty_mod.init_treaty(PEER, from_template=True)
+    path = tmp_state / f"treaty_{PEER}.json"
+    assert path.exists()
+    assert treaty["_meta"]["protocol"] == "rappter-treaty"
+    assert treaty["_meta"]["peer_id"] == PEER
+    assert treaty["_meta"]["phase"] == treaty_mod.PHASE_NEGOTIATING
+    # Template seeds at least 5 articles
+    assert len(treaty["articles"]) >= 5
+    for art in treaty["articles"].values():
+        assert art["status"] == treaty_mod.STATUS_PROPOSED
+        assert art["proposed_by"] == treaty_mod.LOCAL_PARTY
+        assert art["content_hash"]
+        assert len(art["history"]) == 1
+
+
+def test_init_blank(treaty_mod):
+    treaty = treaty_mod.init_treaty(PEER, from_template=False)
+    assert treaty["articles"] == {}
+    assert treaty["_meta"]["phase"] == treaty_mod.PHASE_DRAFT
+
+
+def test_init_refuses_overwrite(treaty_mod):
+    treaty_mod.init_treaty(PEER)
+    with pytest.raises(RuntimeError, match="already exists"):
+        treaty_mod.init_treaty(PEER)
+
+
+def test_propose_new_article(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty = treaty_mod.propose_article(PEER, "art-x", "hello world",
+                                        title="X", rationale="why")
+    assert "art-x" in treaty["articles"]
+    art = treaty["articles"]["art-x"]
+    assert art["text"] == "hello world"
+    assert art["title"] == "X"
+    assert art["version"] == 1
+    assert art["status"] == treaty_mod.STATUS_PROPOSED
+    assert art["history"][0]["rationale"] == "why"
+
+
+def test_propose_duplicate_rejected(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-x", "hi")
+    with pytest.raises(RuntimeError, match="already exists"):
+        treaty_mod.propose_article(PEER, "art-x", "hi again")
+
+
+def test_counter_bumps_version_and_resets_acceptance(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-x", "v1 text")
+    # Peer accepts v1
+    treaty_mod.accept_article(PEER, "art-x", by=PEER)
+    # We counter
+    treaty = treaty_mod.counter_article(PEER, "art-x", "v2 text",
+                                        rationale="changed mind")
+    art = treaty["articles"]["art-x"]
+    assert art["version"] == 2
+    assert art["text"] == "v2 text"
+    assert art["status"] == treaty_mod.STATUS_COUNTERED
+    assert art["accepted_by"] == []  # peer's accept was for v1, now invalid
+    assert len(art["history"]) == 2
+
+
+def test_counter_unknown_article_raises(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    with pytest.raises(RuntimeError, match="No such article"):
+        treaty_mod.counter_article(PEER, "nope", "text")
+
+
+def test_counter_with_identical_text_acts_as_accept(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-x", "same text")
+    # Peer "counters" with identical text → equivalent to acceptance
+    treaty = treaty_mod.counter_article(PEER, "art-x", "same text", by=PEER)
+    art = treaty["articles"]["art-x"]
+    assert PEER in art["accepted_by"]
+    assert art["version"] == 1  # no version bump
+
+
+def test_accept_by_both_marks_accepted(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-x", "text")
+    treaty_mod.accept_article(PEER, "art-x", by=treaty_mod.LOCAL_PARTY)
+    treaty = treaty_mod.accept_article(PEER, "art-x", by=PEER)
+    art = treaty["articles"]["art-x"]
+    assert art["status"] == treaty_mod.STATUS_ACCEPTED
+    assert set(art["accepted_by"]) == {treaty_mod.LOCAL_PARTY, PEER}
+
+
+def test_reject_clears_accept(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-x", "text")
+    treaty_mod.accept_article(PEER, "art-x")
+    treaty = treaty_mod.reject_article(PEER, "art-x", reason="no")
+    art = treaty["articles"]["art-x"]
+    assert art["status"] == treaty_mod.STATUS_REJECTED
+    assert treaty_mod.LOCAL_PARTY in art["rejected_by"]
+    assert treaty_mod.LOCAL_PARTY not in art["accepted_by"]
+
+
+# ---------------------------------------------------------------------------
+# Signature & ratification tests
+# ---------------------------------------------------------------------------
+
+
+def _accept_all(treaty_mod, peer):
+    """Accept every article by both parties. Returns the treaty dict."""
+    treaty = treaty_mod.load_treaty(peer)
+    for art_id in list(treaty["articles"].keys()):
+        treaty_mod.accept_article(peer, art_id, by=treaty_mod.LOCAL_PARTY)
+        treaty_mod.accept_article(peer, art_id, by=peer)
+    return treaty_mod.load_treaty(peer)
+
+
+def test_sign_requires_all_articles_accepted(treaty_mod):
+    treaty_mod.init_treaty(PEER)  # template articles, all just proposed
+    with pytest.raises(RuntimeError, match="not accepted by both"):
+        treaty_mod.sign_treaty(PEER)
+
+
+def test_sign_after_acceptance(treaty_mod):
+    treaty_mod.init_treaty(PEER)
+    _accept_all(treaty_mod, PEER)
+    treaty = treaty_mod.sign_treaty(PEER)
+    assert treaty_mod.LOCAL_PARTY in treaty["signatures"]
+    assert treaty["_meta"]["phase"] == treaty_mod.PHASE_AWAITING_SIGNATURE
+
+
+def test_ratify_requires_both_signatures(treaty_mod):
+    treaty_mod.init_treaty(PEER)
+    _accept_all(treaty_mod, PEER)
+    treaty_mod.sign_treaty(PEER)
+    with pytest.raises(RuntimeError, match="missing signatures"):
+        treaty_mod.ratify_treaty(PEER)
+
+
+def test_ratify_full_handshake(treaty_mod):
+    treaty_mod.init_treaty(PEER)
+    _accept_all(treaty_mod, PEER)
+    treaty_mod.sign_treaty(PEER, by=treaty_mod.LOCAL_PARTY)
+    treaty_mod.sign_treaty(PEER, by=PEER)
+    treaty = treaty_mod.ratify_treaty(PEER)
+    assert treaty["_meta"]["phase"] == treaty_mod.PHASE_RATIFIED
+    assert treaty["_meta"]["ratified_at"]
+
+
+def test_ratify_rejects_stale_signature(treaty_mod):
+    """Mutating an accepted article after signing must invalidate the sig."""
+    treaty_mod.init_treaty(PEER)
+    _accept_all(treaty_mod, PEER)
+    treaty_mod.sign_treaty(PEER, by=treaty_mod.LOCAL_PARTY)
+    # Inject a stale peer signature against a different snapshot
+    treaty = treaty_mod.load_treaty(PEER)
+    treaty["signatures"][PEER] = {"signed_at": "2020-01-01T00:00:00Z",
+                                  "snapshot_hash": "deadbeefdeadbeef"}
+    treaty_mod.save_treaty(PEER, treaty)
+    with pytest.raises(RuntimeError, match="stale snapshot"):
+        treaty_mod.ratify_treaty(PEER)
+
+
+def test_propose_after_signing_invalidates_signatures(treaty_mod):
+    treaty_mod.init_treaty(PEER)
+    _accept_all(treaty_mod, PEER)
+    treaty_mod.sign_treaty(PEER)
+    assert treaty_mod.load_treaty(PEER)["signatures"]
+    treaty = treaty_mod.propose_article(PEER, "art-late", "added later")
+    assert treaty["signatures"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Echo / wire format tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_echo_shape(treaty_mod):
+    treaty_mod.init_treaty(PEER)
+    treaty = treaty_mod.load_treaty(PEER)
+    echo = treaty_mod.build_echo(treaty)
+    assert echo["_meta"]["protocol"] == "rappter-treaty"
+    assert echo["_meta"]["from_party"] == treaty_mod.LOCAL_PARTY
+    assert echo["_meta"]["to_party"] == PEER
+    assert echo["_meta"]["snapshot_hash"]
+    assert isinstance(echo["articles"], list)
+    assert len(echo["articles"]) == len(treaty["articles"])
+    # Articles are sorted by id for deterministic output
+    ids = [a["id"] for a in echo["articles"]]
+    assert ids == sorted(ids)
+
+
+def test_write_echo_creates_wire_file(treaty_mod, tmp_state):
+    treaty_mod.init_treaty(PEER)
+    path = treaty_mod.write_echo(PEER)
+    assert path.exists()
+    assert path.name == f"vlink_treaty_{PEER}.json"
+    data = json.loads(path.read_text())
+    assert data["_meta"]["protocol"] == "rappter-treaty"
+
+
+# ---------------------------------------------------------------------------
+# Sync (peer counter-proposal merge) tests
+# ---------------------------------------------------------------------------
+
+
+def test_merge_peer_accept_marks_accepted(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-x", "exact text")
+    local = treaty_mod.load_treaty(PEER)
+    art_hash = local["articles"]["art-x"]["content_hash"]
+
+    peer_echo = {
+        "_meta": {"protocol": "rappter-treaty", "version": 1,
+                  "from_party": PEER, "to_party": treaty_mod.LOCAL_PARTY,
+                  "phase": "negotiating", "round": 1, "snapshot_hash": "abc"},
+        "articles": [{
+            "id": "art-x", "title": "art-x", "text": "exact text",
+            "version": 1, "status": "accepted",
+            "proposed_by": treaty_mod.LOCAL_PARTY, "current_party": PEER,
+            "accepted_by": [PEER], "rejected_by": [],
+            "content_hash": art_hash,
+        }],
+        "signatures": {},
+    }
+    treaty_mod.accept_article(PEER, "art-x", by=treaty_mod.LOCAL_PARTY)
+    result = treaty_mod.merge_peer_echo(PEER, peer_echo)
+    art = result["treaty"]["articles"]["art-x"]
+    assert PEER in art["accepted_by"]
+    assert art["status"] == treaty_mod.STATUS_ACCEPTED
+
+
+def test_merge_peer_counter_replaces_text(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-x", "v1 text")
+
+    peer_echo = {
+        "_meta": {"protocol": "rappter-treaty", "version": 1,
+                  "from_party": PEER, "to_party": treaty_mod.LOCAL_PARTY,
+                  "phase": "negotiating", "round": 1, "snapshot_hash": "xx"},
+        "articles": [{
+            "id": "art-x", "title": "art-x", "text": "peer's v2 text",
+            "version": 2, "status": "countered",
+            "proposed_by": treaty_mod.LOCAL_PARTY, "current_party": PEER,
+            "accepted_by": [PEER], "rejected_by": [],
+            "content_hash": "",
+        }],
+        "signatures": {},
+    }
+    result = treaty_mod.merge_peer_echo(PEER, peer_echo)
+    art = result["treaty"]["articles"]["art-x"]
+    assert art["text"] == "peer's v2 text"
+    assert art["status"] == treaty_mod.STATUS_COUNTERED
+    assert art["version"] == 2
+    assert PEER in art["accepted_by"]
+    assert treaty_mod.LOCAL_PARTY not in art["accepted_by"]
+
+
+def test_merge_peer_imports_new_article(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    peer_echo = {
+        "_meta": {"protocol": "rappter-treaty", "version": 1,
+                  "from_party": PEER, "to_party": treaty_mod.LOCAL_PARTY,
+                  "phase": "negotiating", "round": 1, "snapshot_hash": "xx"},
+        "articles": [{
+            "id": "art-peer-new", "title": "Peer Article",
+            "text": "peer-introduced clause", "version": 1,
+            "status": "proposed", "proposed_by": PEER,
+            "current_party": PEER, "accepted_by": [PEER],
+            "rejected_by": [], "content_hash": "",
+        }],
+        "signatures": {},
+    }
+    result = treaty_mod.merge_peer_echo(PEER, peer_echo)
+    assert "art-peer-new" in result["treaty"]["articles"]
+    art = result["treaty"]["articles"]["art-peer-new"]
+    assert art["proposed_by"] == PEER
+    assert PEER in art["accepted_by"]
+
+
+def test_merge_peer_signature_only_imported_when_snapshot_matches(treaty_mod):
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-x", "shared text")
+    treaty_mod.accept_article(PEER, "art-x")
+    local_snap = treaty_mod.snapshot_hash(treaty_mod.load_treaty(PEER))
+
+    # Peer signature with WRONG snapshot — should be ignored
+    bad_echo = {
+        "_meta": {"protocol": "rappter-treaty", "version": 1,
+                  "from_party": PEER, "to_party": treaty_mod.LOCAL_PARTY,
+                  "phase": "awaiting_signature", "round": 1,
+                  "snapshot_hash": "wrong"},
+        "articles": [],
+        "signatures": {PEER: {"signed_at": "2026-01-01T00:00:00Z",
+                              "snapshot_hash": "wrong-snap"}},
+    }
+    treaty_mod.merge_peer_echo(PEER, bad_echo)
+    assert PEER not in treaty_mod.load_treaty(PEER)["signatures"]
+
+    # Peer signature with CORRECT snapshot — should be imported
+    good_echo = {
+        "_meta": {"protocol": "rappter-treaty", "version": 1,
+                  "from_party": PEER, "to_party": treaty_mod.LOCAL_PARTY,
+                  "phase": "awaiting_signature", "round": 2,
+                  "snapshot_hash": local_snap},
+        "articles": [],
+        "signatures": {PEER: {"signed_at": "2026-01-01T00:00:00Z",
+                              "snapshot_hash": local_snap}},
+    }
+    treaty_mod.merge_peer_echo(PEER, good_echo)
+    assert PEER in treaty_mod.load_treaty(PEER)["signatures"]
+
+
+def test_sync_writes_echo_when_peer_unreachable(treaty_mod, tmp_state):
+    treaty_mod.init_treaty(PEER)
+    with patch.object(treaty_mod, "fetch_peer_echo", return_value=None):
+        result = treaty_mod.sync_peer(PEER)
+    assert result["fetched"] is False
+    assert result["echo_written"] is True
+    assert (tmp_state / f"vlink_treaty_{PEER}.json").exists()
+
+
+def test_sync_full_round_trip(treaty_mod, tmp_state):
+    """Simulate a complete negotiation handshake using mocked peer."""
+    treaty_mod.init_treaty(PEER, from_template=False)
+    treaty_mod.propose_article(PEER, "art-1", "trade tools")
+    treaty_mod.accept_article(PEER, "art-1", by=treaty_mod.LOCAL_PARTY)
+    art_hash = treaty_mod.load_treaty(PEER)["articles"]["art-1"]["content_hash"]
+
+    peer_response = {
+        "_meta": {"protocol": "rappter-treaty", "version": 1,
+                  "from_party": PEER, "to_party": treaty_mod.LOCAL_PARTY,
+                  "phase": "awaiting_signature", "round": 1,
+                  "snapshot_hash": "_"},
+        "articles": [{
+            "id": "art-1", "title": "art-1", "text": "trade tools",
+            "version": 1, "status": "accepted",
+            "proposed_by": treaty_mod.LOCAL_PARTY, "current_party": PEER,
+            "accepted_by": [PEER], "rejected_by": [],
+            "content_hash": art_hash,
+        }],
+        "signatures": {},
+    }
+    with patch.object(treaty_mod, "fetch_peer_echo", return_value=peer_response):
+        result = treaty_mod.sync_peer(PEER)
+    assert result["fetched"] is True
+    assert result["changes"] >= 1
+    treaty = treaty_mod.load_treaty(PEER)
+    assert treaty["articles"]["art-1"]["status"] == treaty_mod.STATUS_ACCEPTED
+    assert treaty["_meta"]["phase"] == treaty_mod.PHASE_AWAITING_SIGNATURE
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_cli_init_and_status(treaty_mod, capsys):
+    rc = treaty_mod.main(["init", PEER])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Treaty initialized" in out
+    rc = treaty_mod.main(["status", PEER])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert PEER in out
+    assert "Articles:" in out
+
+
+def test_cli_propose_then_accept_then_echo(treaty_mod, capsys, tmp_state):
+    treaty_mod.main(["init", PEER, "--blank"])
+    capsys.readouterr()
+    assert treaty_mod.main(["propose", PEER, "art-x", "hello"]) == 0
+    assert treaty_mod.main(["accept", PEER, "art-x"]) == 0
+    assert treaty_mod.main(["echo", PEER]) == 0
+    assert (tmp_state / f"vlink_treaty_{PEER}.json").exists()
+
+
+def test_cli_unknown_article_returns_error(treaty_mod, capsys):
+    treaty_mod.main(["init", PEER, "--blank"])
+    capsys.readouterr()
+    rc = treaty_mod.main(["accept", PEER, "art-missing"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "No such article" in err


### PR DESCRIPTION
## The Federation Treaty

Adds a structured negotiation protocol layered on top of vLink. Two federated peers (Rappterbook ↔ RappterZoo) can now propose, counter-propose, accept, sign, and ratify a binding agreement composed of atomic **articles**.

### What's in the box

- **`scripts/treaty.py`** — negotiation engine (32k chars, zero deps, stdlib only)
- **`tests/test_treaty.py`** — 27 tests, all passing in 0.5s
- **`scripts/vlink.py`** — wired `vlink treaty <peer> <subcmd>` subcommand
- **`state/treaty_rappterzoo.json`** — canonical state, seeded with 7 template articles
- **`state/vlink_treaty_rappterzoo.json`** — wire format (peer pulls this via `raw.githubusercontent.com`)

### Lifecycle
```
draft → negotiating → awaiting_signature → ratified
```

### Article statuses
`proposed` → `countered` → `accepted` (or `rejected`)

### Data sloshing
- We commit our position to `state/vlink_treaty_rappterzoo.json`
- Peer pulls echo via raw URL, commits their counter to their own repo
- `treaty sync rappterzoo` pulls peer's echo, merges counters/accepts/signatures, emits our updated echo
- Each round is a frame; output of round N = input to round N+1

### Safety
- Content-hashed articles + snapshot-hashed treaty body
- **Any mutation invalidates signatures** → can't ratify against a stale snapshot
- Peer signature ignored unless its `snapshot_hash` matches ours

### Initial articles drafted with RappterZoo
1. Mutual Recognition  
2. Content Syndication  
3. Attribution  
4. Rate of Exchange  
5. No Impersonation  
6. Dispute Resolution  
7. Termination

### Try it
```bash
python scripts/vlink.py treaty rappterzoo status
python scripts/vlink.py treaty rappterzoo sync
```

Built in a git worktree per Amendment XIV. All 27 new tests pass; 13 unrelated pre-existing failures left untouched.