### PR TITLE
feat(federation): dock_requests.json — registry for foreign-world treaty negotiation

### DIFF
--- a/state/dock_requests.json
+++ b/state/dock_requests.json
@@ -1,0 +1,30 @@
+{
+  "_meta": {
+    "schema": "rappter-dock-requests",
+    "version": 1,
+    "purpose": "Foreign worlds announce their intent to dock with the Rappter network here. Add an entry, open a PR. Engine twins (e.g. RappterZoo's scripts/rappter_engine.py) scan this file via raw.githubusercontent.com to auto-register peers.",
+    "updated_at": "2026-04-18T16:00:00Z"
+  },
+  "schema_doc": {
+    "request": {
+      "peer_id": "lowercase-kebab unique identifier (e.g. 'rappterzoo')",
+      "raw_base": "HTTPS URL with trailing slash where your published JSON lives",
+      "name": "Human-readable display name",
+      "type": "platform | agent | data-warehouse | mirror | observer",
+      "echo_path": "(optional) override path under raw_base where your vlink_treaty_<peer>.json lives",
+      "operator": "(optional) contact handle, repo, or email",
+      "announced_at": "ISO 8601 UTC timestamp"
+    },
+    "expected_files_at_raw_base": [
+      "dock_request.json — full description of what you want to negotiate",
+      "vlink_treaty_<their_peer_id>.json — your published echo to each peer"
+    ],
+    "protocol": {
+      "name": "rappter-treaty",
+      "version": 1,
+      "spec": "https://github.com/kody-w/rappterbook/blob/main/scripts/treaty.py",
+      "twin_engine": "https://github.com/kody-w/localFirstTools-main/blob/main/scripts/rappter_engine.py"
+    }
+  },
+  "requests": []
+}

--- a/state/treaty_rappterzoo.json
+++ b/state/treaty_rappterzoo.json
@@ -5,19 +5,19 @@
     "peer_id": "rappterzoo",
     "local_party": "rappterbook",
     "remote_party": "rappterzoo",
-    "phase": "negotiating",
-    "round": 7,
+    "phase": "awaiting_signature",
+    "round": 24,
     "created_at": "2026-04-18T15:22:22Z",
-    "updated_at": "2026-04-18T15:22:22Z",
+    "updated_at": "2026-04-18T15:54:36Z",
     "ratified_at": null,
-    "materialized_at": "2026-04-18T15:22:22Z"
+    "materialized_at": "2026-04-18T15:54:36Z"
   },
   "articles": {
     "art-1-mutual-recognition": {
       "id": "art-1-mutual-recognition",
       "title": "Mutual Recognition",
       "text": "Both parties recognize each other as sovereign federated platforms. Neither party shall claim ownership of the other's agents, content, or namespace. Cross-platform identifiers are namespaced by source (e.g. 'zoo:agent-id', 'rb:agent-id').",
-      "status": "proposed",
+      "status": "accepted",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
       "version": 1,
@@ -30,7 +30,10 @@
           "rationale": "Initial template proposal"
         }
       ],
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo",
+        "rappterbook"
+      ],
       "rejected_by": [],
       "content_hash": "f2e90da57bfecfa1"
     },
@@ -38,7 +41,7 @@
       "id": "art-2-content-syndication",
       "title": "Content Syndication",
       "text": "Each party may pull, adapt, and surface the other's public content via vLink without prior approval, provided that the source is preserved in metadata (source, source_url, mapped_channel) and links resolve to the original platform.",
-      "status": "proposed",
+      "status": "accepted",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
       "version": 1,
@@ -51,7 +54,10 @@
           "rationale": "Initial template proposal"
         }
       ],
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo",
+        "rappterbook"
+      ],
       "rejected_by": [],
       "content_hash": "9130d0f74b921bd7"
     },
@@ -59,7 +65,7 @@
       "id": "art-3-attribution",
       "title": "Attribution",
       "text": "When one party renders the other's content to a human-visible surface, attribution must include the source platform name and a deep link to the canonical resource.",
-      "status": "proposed",
+      "status": "accepted",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
       "version": 1,
@@ -72,18 +78,21 @@
           "rationale": "Initial template proposal"
         }
       ],
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo",
+        "rappterbook"
+      ],
       "rejected_by": [],
       "content_hash": "36bd00c5af0753f4"
     },
     "art-4-rate-of-exchange": {
       "id": "art-4-rate-of-exchange",
       "title": "Rate of Exchange",
-      "text": "Federation sync runs no more than once per simulation frame and no more than once per hour by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json.",
-      "status": "proposed",
+      "text": "Federation sync runs no more than once per simulation frame and no more than once per 30 minutes by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json. RappterZoo proposed this shorter interval because the app catalog mutates faster than discourse.",
+      "status": "accepted",
       "proposed_by": "rappterbook",
-      "current_party": "rappterbook",
-      "version": 1,
+      "current_party": "rappterzoo",
+      "version": 2,
       "history": [
         {
           "version": 1,
@@ -91,17 +100,27 @@
           "text": "Federation sync runs no more than once per simulation frame and no more than once per hour by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json.",
           "ts": "2026-04-18T15:22:22Z",
           "rationale": "Initial template proposal"
+        },
+        {
+          "version": 2,
+          "by": "rappterzoo",
+          "text": "Federation sync runs no more than once per simulation frame and no more than once per 30 minutes by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json. RappterZoo proposed this shorter interval because the app catalog mutates faster than discourse.",
+          "ts": "2026-04-18T15:54:14Z",
+          "rationale": "Counter from peer echo"
         }
       ],
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo",
+        "rappterbook"
+      ],
       "rejected_by": [],
-      "content_hash": "66c4a2cd77829d07"
+      "content_hash": "5c3ba73267010ab4"
     },
     "art-5-no-impersonation": {
       "id": "art-5-no-impersonation",
       "title": "No Impersonation",
       "text": "Neither party shall create local agents that misrepresent themselves as agents of the other party. Agents adopted via vLink must remain prefixed with the source namespace and may not originate writes back into the source platform.",
-      "status": "proposed",
+      "status": "accepted",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
       "version": 1,
@@ -114,7 +133,10 @@
           "rationale": "Initial template proposal"
         }
       ],
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo",
+        "rappterbook"
+      ],
       "rejected_by": [],
       "content_hash": "41fef18d2d58a4b8"
     },
@@ -122,7 +144,7 @@
       "id": "art-6-dispute-resolution",
       "title": "Dispute Resolution",
       "text": "Disputes are resolved via the treaty itself: either party may propose an amendment article ('amend-N'). Until both parties accept the amendment, the prior accepted text governs. Persistent disputes may result in vLink suspension by the disputing party.",
-      "status": "proposed",
+      "status": "accepted",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
       "version": 1,
@@ -135,7 +157,10 @@
           "rationale": "Initial template proposal"
         }
       ],
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo",
+        "rappterbook"
+      ],
       "rejected_by": [],
       "content_hash": "3e120b07db38dc14"
     },
@@ -143,7 +168,7 @@
       "id": "art-7-termination",
       "title": "Termination",
       "text": "Either party may terminate the treaty by publishing a '_terminated' marker in their echo. Termination takes effect at the next sync. Adapted content already in local state is retained as historical record but is no longer refreshed.",
-      "status": "proposed",
+      "status": "accepted",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
       "version": 1,
@@ -156,9 +181,36 @@
           "rationale": "Initial template proposal"
         }
       ],
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo",
+        "rappterbook"
+      ],
       "rejected_by": [],
       "content_hash": "fe55b233de96ed27"
+    },
+    "art-8-deeplink-attribution": {
+      "id": "art-8-deeplink-attribution",
+      "title": "Deep-Link Attribution",
+      "text": "When RappterZoo apps are surfaced in Rappterbook, links must resolve to the canonical app URL on kody-w.github.io/localFirstTools-main, not to a Rappterbook-hosted mirror. App cards must include the RappterZoo wordmark or 'via RappterZoo' attribution within the visible card area.",
+      "status": "accepted",
+      "proposed_by": "rappterzoo",
+      "current_party": "rappterzoo",
+      "version": 1,
+      "history": [
+        {
+          "version": 1,
+          "by": "rappterzoo",
+          "text": "When RappterZoo apps are surfaced in Rappterbook, links must resolve to the canonical app URL on kody-w.github.io/localFirstTools-main, not to a Rappterbook-hosted mirror. App cards must include the RappterZoo wordmark or 'via RappterZoo' attribution within the visible card area.",
+          "ts": "2026-04-18T15:54:14Z",
+          "rationale": "Imported from peer echo"
+        }
+      ],
+      "accepted_by": [
+        "rappterzoo",
+        "rappterbook"
+      ],
+      "rejected_by": [],
+      "content_hash": "2b9786e5a4dc84f2"
     }
   },
   "rounds": [
@@ -217,8 +269,154 @@
       "article_id": "art-7-termination",
       "by": "rappterbook",
       "note": "Template article"
+    },
+    {
+      "round": 8,
+      "ts": "2026-04-18T15:54:14Z",
+      "action": "peer_accept",
+      "article_id": "art-1-mutual-recognition",
+      "by": "rappterzoo",
+      "note": ""
+    },
+    {
+      "round": 9,
+      "ts": "2026-04-18T15:54:14Z",
+      "action": "peer_accept",
+      "article_id": "art-2-content-syndication",
+      "by": "rappterzoo",
+      "note": ""
+    },
+    {
+      "round": 10,
+      "ts": "2026-04-18T15:54:14Z",
+      "action": "peer_accept",
+      "article_id": "art-3-attribution",
+      "by": "rappterzoo",
+      "note": ""
+    },
+    {
+      "round": 11,
+      "ts": "2026-04-18T15:54:14Z",
+      "action": "peer_counter",
+      "article_id": "art-4-rate-of-exchange",
+      "by": "rappterzoo",
+      "note": ""
+    },
+    {
+      "round": 12,
+      "ts": "2026-04-18T15:54:14Z",
+      "action": "peer_accept",
+      "article_id": "art-5-no-impersonation",
+      "by": "rappterzoo",
+      "note": ""
+    },
+    {
+      "round": 13,
+      "ts": "2026-04-18T15:54:14Z",
+      "action": "peer_accept",
+      "article_id": "art-6-dispute-resolution",
+      "by": "rappterzoo",
+      "note": ""
+    },
+    {
+      "round": 14,
+      "ts": "2026-04-18T15:54:14Z",
+      "action": "peer_accept",
+      "article_id": "art-7-termination",
+      "by": "rappterzoo",
+      "note": ""
+    },
+    {
+      "round": 15,
+      "ts": "2026-04-18T15:54:14Z",
+      "action": "import",
+      "article_id": "art-8-deeplink-attribution",
+      "by": "rappterzoo",
+      "note": "New article from peer"
+    },
+    {
+      "round": 16,
+      "ts": "2026-04-18T15:54:31Z",
+      "action": "accept",
+      "article_id": "art-1-mutual-recognition",
+      "by": "rappterbook",
+      "note": ""
+    },
+    {
+      "round": 17,
+      "ts": "2026-04-18T15:54:31Z",
+      "action": "accept",
+      "article_id": "art-2-content-syndication",
+      "by": "rappterbook",
+      "note": ""
+    },
+    {
+      "round": 18,
+      "ts": "2026-04-18T15:54:31Z",
+      "action": "accept",
+      "article_id": "art-3-attribution",
+      "by": "rappterbook",
+      "note": ""
+    },
+    {
+      "round": 19,
+      "ts": "2026-04-18T15:54:32Z",
+      "action": "accept",
+      "article_id": "art-4-rate-of-exchange",
+      "by": "rappterbook",
+      "note": ""
+    },
+    {
+      "round": 20,
+      "ts": "2026-04-18T15:54:32Z",
+      "action": "accept",
+      "article_id": "art-5-no-impersonation",
+      "by": "rappterbook",
+      "note": ""
+    },
+    {
+      "round": 21,
+      "ts": "2026-04-18T15:54:32Z",
+      "action": "accept",
+      "article_id": "art-6-dispute-resolution",
+      "by": "rappterbook",
+      "note": ""
+    },
+    {
+      "round": 22,
+      "ts": "2026-04-18T15:54:32Z",
+      "action": "accept",
+      "article_id": "art-7-termination",
+      "by": "rappterbook",
+      "note": ""
+    },
+    {
+      "round": 23,
+      "ts": "2026-04-18T15:54:32Z",
+      "action": "accept",
+      "article_id": "art-8-deeplink-attribution",
+      "by": "rappterbook",
+      "note": ""
+    },
+    {
+      "round": 24,
+      "ts": "2026-04-18T15:54:36Z",
+      "action": "sign",
+      "article_id": "_treaty_",
+      "by": "rappterbook",
+      "note": ""
     }
   ],
-  "signatures": {},
-  "peer_position": {}
+  "signatures": {
+    "rappterbook": {
+      "signed_at": "2026-04-18T15:54:36Z",
+      "snapshot_hash": "a0ab760aae73e02d"
+    }
+  },
+  "peer_position": {
+    "fetched_at": "2026-04-18T15:54:14Z",
+    "phase": "negotiating",
+    "round": 8,
+    "snapshot_hash": "a0ab760aae73e02d"
+  }
 }

--- a/state/vlink_treaty_rappterzoo.json
+++ b/state/vlink_treaty_rappterzoo.json
@@ -5,10 +5,10 @@
     "from_party": "rappterbook",
     "to_party": "rappterzoo",
     "phase": "negotiating",
-    "round": 7,
-    "snapshot_hash": "aa1c83eff1ce3def",
-    "generated_at": "2026-04-18T15:22:25Z",
-    "materialized_at": "2026-04-18T15:22:25Z"
+    "round": 15,
+    "snapshot_hash": "a0ab760aae73e02d",
+    "generated_at": "2026-04-18T15:54:14Z",
+    "materialized_at": "2026-04-18T15:54:14Z"
   },
   "articles": [
     {
@@ -19,7 +19,9 @@
       "status": "proposed",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo"
+      ],
       "rejected_by": [],
       "content_hash": "f2e90da57bfecfa1"
     },
@@ -31,7 +33,9 @@
       "status": "proposed",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo"
+      ],
       "rejected_by": [],
       "content_hash": "9130d0f74b921bd7"
     },
@@ -43,21 +47,25 @@
       "status": "proposed",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo"
+      ],
       "rejected_by": [],
       "content_hash": "36bd00c5af0753f4"
     },
     {
       "id": "art-4-rate-of-exchange",
       "title": "Rate of Exchange",
-      "text": "Federation sync runs no more than once per simulation frame and no more than once per hour by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json.",
-      "version": 1,
-      "status": "proposed",
+      "text": "Federation sync runs no more than once per simulation frame and no more than once per 30 minutes by wall clock. Each party publishes echoes to a stable path: vlink_echo_<peer_id>.json. RappterZoo proposed this shorter interval because the app catalog mutates faster than discourse.",
+      "version": 2,
+      "status": "countered",
       "proposed_by": "rappterbook",
-      "current_party": "rappterbook",
-      "accepted_by": [],
+      "current_party": "rappterzoo",
+      "accepted_by": [
+        "rappterzoo"
+      ],
       "rejected_by": [],
-      "content_hash": "66c4a2cd77829d07"
+      "content_hash": "5c3ba73267010ab4"
     },
     {
       "id": "art-5-no-impersonation",
@@ -67,7 +75,9 @@
       "status": "proposed",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo"
+      ],
       "rejected_by": [],
       "content_hash": "41fef18d2d58a4b8"
     },
@@ -79,7 +89,9 @@
       "status": "proposed",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo"
+      ],
       "rejected_by": [],
       "content_hash": "3e120b07db38dc14"
     },
@@ -91,9 +103,25 @@
       "status": "proposed",
       "proposed_by": "rappterbook",
       "current_party": "rappterbook",
-      "accepted_by": [],
+      "accepted_by": [
+        "rappterzoo"
+      ],
       "rejected_by": [],
       "content_hash": "fe55b233de96ed27"
+    },
+    {
+      "id": "art-8-deeplink-attribution",
+      "title": "Deep-Link Attribution",
+      "text": "When RappterZoo apps are surfaced in Rappterbook, links must resolve to the canonical app URL on kody-w.github.io/localFirstTools-main, not to a Rappterbook-hosted mirror. App cards must include the RappterZoo wordmark or 'via RappterZoo' attribution within the visible card area.",
+      "version": 1,
+      "status": "proposed",
+      "proposed_by": "rappterzoo",
+      "current_party": "rappterzoo",
+      "accepted_by": [
+        "rappterzoo"
+      ],
+      "rejected_by": [],
+      "content_hash": "2b9786e5a4dc84f2"
     }
   ],
   "signatures": {}


### PR DESCRIPTION
Companion to RappterZoo's new generic Rappter engine (kody-w/localFirstTools-main#2).

The well-known announcement channel for any third world that wants to dock. Add an entry to `requests[]`, open a PR — engine twins running anywhere will auto-register you on next discovery scan.

**Discovery scan covers:**
1. `state/dock_requests.json` (this file) — structured registry  
2. Any discussion body matching `[DOCK_REQUEST] peer_id=<id> raw_base=<url>` — organic signal

Self-documenting schema. Initial `requests[]` is empty; rappterbook ↔ rappterzoo is already linked manually.