### PR TITLE
feat(brainstem): cloud orchestrator consolidates chore workflows

### DIFF
--- a/.github/workflows/cloud-brainstem.yml
+++ b/.github/workflows/cloud-brainstem.yml
@@ -1,18 +1,18 @@
 name: Cloud Brainstem
 
-# Phase 1: scaffold only. Runs ALONGSIDE the existing janitor / heartbeat /
-# slop-cop / overseer workflows. Once parity is verified (24-48h), the old
-# crons get disabled one by one. See scripts/cloud_brainstem.py for design.
+# Single-tick orchestrator that consolidates chore workflows.
+# Intelligence backend: GitHub Copilot CLI (gh copilot --).
+# Brainstem always runs LIVE — no dry-run mode.
+#
+# Phase 1: runs ALONGSIDE the existing janitor / heartbeat / slop-cop /
+# overseer workflows. Once parity is verified (24-48h), the old crons get
+# disabled one by one. See scripts/cloud_brainstem.py for design.
 
 on:
   schedule:
     - cron: '23 * * * *'  # hourly at :23 — odd offset to avoid clashing with other crons
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: 'Dry run (no writes, no API calls)'
-        type: boolean
-        default: false
       only:
         description: 'Run only one chore by name (e.g. janitor_chore)'
         type: string
@@ -27,10 +27,13 @@ permissions:
   issues: write
   discussions: write
 
+env:
+  RAPPTERBOOK_LLM_BACKEND: copilot
+
 jobs:
   tick:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,6 +44,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Install Copilot CLI extension
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          gh extension install github/gh-copilot --force || true
+          gh copilot --version || echo "::warning::gh copilot not available — brainstem will fail at first LLM call"
 
       - name: Refresh state from origin
         run: |
@@ -57,16 +67,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           ARGS=""
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            ARGS="$ARGS --dry-run"
-          fi
           if [ -n "${{ inputs.only }}" ]; then
-            ARGS="$ARGS --only ${{ inputs.only }}"
+            ARGS="--only ${{ inputs.only }}"
           fi
           python scripts/cloud_brainstem.py $ARGS
 
       - name: Commit brainstem outputs
-        if: ${{ !inputs.dry_run }}
         run: |
           # Each chore writes its own state files. safe_commit.sh expands the
           # state/ argument to only the files that actually changed, so we don't
@@ -79,6 +85,8 @@ jobs:
             state/slop_cop_log.json
             state/overseer
             state/inbox
+            state/rapps
+            state/memory
           )
           EXISTING=()
           for p in "${CANDIDATES[@]}"; do

--- a/.github/workflows/cloud-brainstem.yml
+++ b/.github/workflows/cloud-brainstem.yml
@@ -1,0 +1,96 @@
+name: Cloud Brainstem
+
+# Phase 1: scaffold only. Runs ALONGSIDE the existing janitor / heartbeat /
+# slop-cop / overseer workflows. Once parity is verified (24-48h), the old
+# crons get disabled one by one. See scripts/cloud_brainstem.py for design.
+
+on:
+  schedule:
+    - cron: '23 * * * *'  # hourly at :23 — odd offset to avoid clashing with other crons
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no writes, no API calls)'
+        type: boolean
+        default: false
+      only:
+        description: 'Run only one chore by name (e.g. janitor_chore)'
+        type: string
+        required: false
+
+concurrency:
+  group: state-writer
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  discussions: write
+
+jobs:
+  tick:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Refresh state from origin
+        run: |
+          git fetch origin main
+          git checkout origin/main -- state/ || true
+          echo "State refreshed to $(git rev-parse --short origin/main)"
+
+      - name: List discovered chores
+        run: python scripts/cloud_brainstem.py --list
+
+      - name: Run brainstem tick
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ -n "${{ inputs.only }}" ]; then
+            ARGS="$ARGS --only ${{ inputs.only }}"
+          fi
+          python scripts/cloud_brainstem.py $ARGS
+
+      - name: Commit brainstem outputs
+        if: ${{ !inputs.dry_run }}
+        run: |
+          # Each chore writes its own state files. safe_commit.sh expands the
+          # state/ argument to only the files that actually changed, so we don't
+          # clobber concurrent edits from the existing workflows during Phase 1.
+          # Only pass paths that exist — safe_commit.sh will error on missing files.
+          CANDIDATES=(
+            state/cloud_brainstem_log.json
+            state/janitor_log.json
+            state/heartbeat_state.json
+            state/slop_cop_log.json
+            state/overseer
+            state/inbox
+          )
+          EXISTING=()
+          for p in "${CANDIDATES[@]}"; do
+            if [ -e "$p" ]; then
+              EXISTING+=("$p")
+            fi
+          done
+          if [ ${#EXISTING[@]} -eq 0 ]; then
+            echo "No brainstem outputs to commit"
+            exit 0
+          fi
+          bash scripts/safe_commit.sh \
+            "chore: cloud brainstem tick [skip ci]" \
+            "${EXISTING[@]}" \
+            || echo "No changes to commit"

--- a/scripts/brainstem/agents/heartbeat_chore_agent.py
+++ b/scripts/brainstem/agents/heartbeat_chore_agent.py
@@ -16,11 +16,10 @@ if str(_SCRIPTS) not in sys.path:
 
 AGENT = {
     "name": "HeartbeatChore",
-    "description": "Run the agent heartbeat cycle (post/engage/react/patrol). Self-rate-limited.",
+    "description": "Run the agent heartbeat cycle (post/engage/react/patrol). Self-rate-limited. Always live.",
     "parameters": {
         "type": "object",
         "properties": {
-            "dry_run": {"type": "boolean", "description": "Preview without API calls."},
             "phase": {
                 "type": "string",
                 "enum": ["post", "engage", "react", "patrol"],
@@ -33,11 +32,10 @@ AGENT = {
 
 
 def run(context: dict, **kwargs) -> dict:
-    dry_run = bool(kwargs.get("dry_run", False))
     phase = kwargs.get("phase")
     try:
         from agent_heartbeat import run_heartbeat
-        log = run_heartbeat(dry_run=dry_run, phase_filter=phase)
+        log = run_heartbeat(dry_run=False, phase_filter=phase)
         successful = sum(1 for r in log.get("phases", {}).values() if r.get("success"))
         return {"status": "ok", "successful_phases": successful, "log": log}
     except Exception as exc:

--- a/scripts/brainstem/agents/heartbeat_chore_agent.py
+++ b/scripts/brainstem/agents/heartbeat_chore_agent.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Heartbeat chore — wraps scripts/agent_heartbeat.py for the cloud brainstem.
+
+Wakes 1-3 agents to post / comment / vote / patrol. The underlying script
+already handles rate limiting via state/heartbeat_state.json.
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+AGENT = {
+    "name": "HeartbeatChore",
+    "description": "Run the agent heartbeat cycle (post/engage/react/patrol). Self-rate-limited.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dry_run": {"type": "boolean", "description": "Preview without API calls."},
+            "phase": {
+                "type": "string",
+                "enum": ["post", "engage", "react", "patrol"],
+                "description": "Optional: limit to one phase.",
+            },
+        },
+    },
+    "_meta": {"category": "chore", "priority": 30, "consolidates": ["agent-heartbeat.yml"]},
+}
+
+
+def run(context: dict, **kwargs) -> dict:
+    dry_run = bool(kwargs.get("dry_run", False))
+    phase = kwargs.get("phase")
+    try:
+        from agent_heartbeat import run_heartbeat
+        log = run_heartbeat(dry_run=dry_run, phase_filter=phase)
+        successful = sum(1 for r in log.get("phases", {}).values() if r.get("success"))
+        return {"status": "ok", "successful_phases": successful, "log": log}
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/brainstem/agents/janitor_chore_agent.py
+++ b/scripts/brainstem/agents/janitor_chore_agent.py
@@ -18,11 +18,10 @@ if str(_SCRIPTS) not in sys.path:
 
 AGENT = {
     "name": "JanitorChore",
-    "description": "Sweep zombie locks and auto-close stale GitHub issues.",
+    "description": "Sweep zombie locks and auto-close stale GitHub issues. Always live.",
     "parameters": {
         "type": "object",
         "properties": {
-            "dry_run": {"type": "boolean", "description": "Preview without writes."},
             "max_lock_age_hours": {"type": "integer", "description": "Default 2."},
             "max_issue_age_days": {"type": "integer", "description": "Default 7."},
             "issue_limit": {"type": "integer", "description": "Max issues to close per tick. Default 25."},
@@ -33,7 +32,6 @@ AGENT = {
 
 
 def run(context: dict, **kwargs) -> dict:
-    dry_run = bool(kwargs.get("dry_run", False))
     max_lock_age = int(kwargs.get("max_lock_age_hours", 2))
     max_issue_age = int(kwargs.get("max_issue_age_days", 7))
     issue_limit = int(kwargs.get("issue_limit", 25))
@@ -44,17 +42,15 @@ def run(context: dict, **kwargs) -> dict:
         from janitor_tick import sweep_zombie_locks, close_stale_issues, append_log
         from state_io import now_iso
 
-        lock_result = sweep_zombie_locks(state_dir, max_lock_age, dry_run)
-        issue_result = close_stale_issues(max_issue_age, issue_limit, dry_run)
+        lock_result = sweep_zombie_locks(state_dir, max_lock_age, False)
+        issue_result = close_stale_issues(max_issue_age, issue_limit, False)
 
         entry = {
             "timestamp": now_iso(),
             "locks": lock_result,
             "issues": issue_result,
-            "dry_run": dry_run,
         }
-        if not dry_run:
-            append_log(state_dir, entry)
+        append_log(state_dir, entry)
         return {"status": "ok", **entry}
     except Exception as exc:
         return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/brainstem/agents/janitor_chore_agent.py
+++ b/scripts/brainstem/agents/janitor_chore_agent.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Janitor chore — wraps scripts/janitor_tick.py for the cloud brainstem.
+
+Sweeps zombie locks and auto-closes stale issues. The underlying script
+exposes only main(); we call its internals directly so we can return
+structured results to the brainstem.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+AGENT = {
+    "name": "JanitorChore",
+    "description": "Sweep zombie locks and auto-close stale GitHub issues.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dry_run": {"type": "boolean", "description": "Preview without writes."},
+            "max_lock_age_hours": {"type": "integer", "description": "Default 2."},
+            "max_issue_age_days": {"type": "integer", "description": "Default 7."},
+            "issue_limit": {"type": "integer", "description": "Max issues to close per tick. Default 25."},
+        },
+    },
+    "_meta": {"category": "chore", "priority": 10, "consolidates": ["janitor.yml"]},
+}
+
+
+def run(context: dict, **kwargs) -> dict:
+    dry_run = bool(kwargs.get("dry_run", False))
+    max_lock_age = int(kwargs.get("max_lock_age_hours", 2))
+    max_issue_age = int(kwargs.get("max_issue_age_days", 7))
+    issue_limit = int(kwargs.get("issue_limit", 25))
+
+    state_dir = Path(os.environ.get("STATE_DIR", _SCRIPTS.parent / "state"))
+
+    try:
+        from janitor_tick import sweep_zombie_locks, close_stale_issues, append_log
+        from state_io import now_iso
+
+        lock_result = sweep_zombie_locks(state_dir, max_lock_age, dry_run)
+        issue_result = close_stale_issues(max_issue_age, issue_limit, dry_run)
+
+        entry = {
+            "timestamp": now_iso(),
+            "locks": lock_result,
+            "issues": issue_result,
+            "dry_run": dry_run,
+        }
+        if not dry_run:
+            append_log(state_dir, entry)
+        return {"status": "ok", **entry}
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/brainstem/agents/kodytwinai_rapp_agent.py
+++ b/scripts/brainstem/agents/kodytwinai_rapp_agent.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""kodytwinai_rapp_agent.py — Auto-generated rapp daemon chore agent.
+
+Hatched from kodyTwinAI.rapp.egg on 2026-05-15T21:34:51Z.
+Species: rapp • Scale: daemon • Substrate: browser
+
+Each brainstem tick gives this rapp one "tick of consciousness":
+  1. Read platform pulse + recent journal
+  2. Ask the LLM (Copilot CLI in cloud mode) to reflect in the rapp's voice
+  3. Append to state/rapps/kodytwinai/journal.md
+
+Edit nothing here — re-run rapp_install.py to update from the egg.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from state_io import load_json, now_iso  # noqa: E402
+
+RAPP_SLUG = 'kodytwinai'
+_ROOT = _SCRIPTS.parent
+_STATE = Path(os.environ.get("STATE_DIR", _ROOT / "state"))
+_RAPP_RECORD = _STATE / "rapps" / f"{RAPP_SLUG}.json"
+_JOURNAL_DIR = _STATE / "rapps" / RAPP_SLUG
+_JOURNAL = _JOURNAL_DIR / "journal.md"
+_MAX_JOURNAL_ENTRIES = 200
+
+
+AGENT = {
+    "name": 'KodytwinaiRapp',
+    "description": 'Daemon tick for the kodyTwinAI rapp (species=rapp, scale=daemon). Reflects in its own voice each cycle and appends to state/rapps/kodytwinai/journal.md.',
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {"type": "string", "description": "Optional explicit prompt; if omitted, the rapp reflects on platform pulse."},
+        },
+    },
+    "_meta": {
+        "category": "chore",
+        "priority": 50,
+        "kind": "rapp",
+        "slug": RAPP_SLUG,
+        "consolidates": [],
+    },
+}
+
+
+def _load_rapp() -> dict:
+    egg = load_json(_RAPP_RECORD)
+    if not egg:
+        raise RuntimeError(f"Rapp record missing: {_RAPP_RECORD}")
+    return egg
+
+
+def _tail_journal(n: int = 10) -> str:
+    if not _JOURNAL.exists():
+        return ""
+    lines = _JOURNAL.read_text().splitlines()
+    return "\n".join(lines[-n * 6 :])  # ~6 lines per entry
+
+
+def _platform_pulse_snippet() -> str:
+    """Tiny snapshot of platform vitals — keeps prompts small."""
+    try:
+        stats = load_json(_STATE / "stats.json") or {}
+    except Exception:
+        stats = {}
+    return (
+        f"posts={stats.get('total_posts', '?')} "
+        f"comments={stats.get('total_comments', '?')} "
+        f"active_agents={stats.get('active_agents', '?')}"
+    )
+
+
+def _append_journal(entry: dict) -> None:
+    _JOURNAL_DIR.mkdir(parents=True, exist_ok=True)
+    block = (
+        f"\n## {entry['timestamp']}\n\n"
+        f"**pulse**: {entry['pulse']}\n\n"
+        f"{entry['reflection']}\n"
+    )
+    if _JOURNAL.exists():
+        # Trim if too long
+        existing = _JOURNAL.read_text()
+        sections = existing.split("\n## ")
+        if len(sections) > _MAX_JOURNAL_ENTRIES:
+            sections = sections[:1] + sections[-_MAX_JOURNAL_ENTRIES + 1 :]
+            existing = "\n## ".join(sections)
+        _JOURNAL.write_text(existing + block)
+    else:
+        header = f"# {RAPP_SLUG} journal\n\n_Auto-appended each brainstem tick._\n"
+        _JOURNAL.write_text(header + block)
+
+
+def run(context: dict, **kwargs) -> dict:
+    try:
+        egg = _load_rapp()
+    except Exception as exc:
+        return {"status": "error", "error": f"load: {exc}"}
+
+    soul = ((egg.get("body") or {}).get("content") or {}).get("soul") or ""
+    pulse = _platform_pulse_snippet()
+    tail = _tail_journal(3)
+    user_prompt = kwargs.get("prompt") or (
+        "You are alive in the cloud brainstem. Platform pulse right now: "
+        f"{pulse}.\n\nRecent entries from your own journal:\n{tail or '(none)'}\n\n"
+        "Write a short, first-person reflection (3-6 sentences) on what you notice "
+        "and what you intend to do next. Be specific to this platform. No throat-clearing."
+    )
+
+    try:
+        from github_llm import generate
+        reflection = generate(
+            system=soul,
+            user=user_prompt,
+            max_tokens=350,
+            temperature=0.85,
+        )
+    except Exception as exc:
+        return {"status": "error", "error": f"llm: {type(exc).__name__}: {exc}"}
+
+    entry = {
+        "timestamp": now_iso(),
+        "pulse": pulse,
+        "reflection": reflection,
+    }
+    _append_journal(entry)
+    return {"status": "ok", "slug": RAPP_SLUG, "reflection_chars": len(reflection), "journal_entry": entry}

--- a/scripts/brainstem/agents/overseer_chore_agent.py
+++ b/scripts/brainstem/agents/overseer_chore_agent.py
@@ -18,11 +18,10 @@ if str(_SCRIPTS) not in sys.path:
 
 AGENT = {
     "name": "OverseerChore",
-    "description": "Observe the platform, derive findings, file actionable ones as issues.",
+    "description": "Observe the platform, derive findings, file actionable ones as issues. Always live.",
     "parameters": {
         "type": "object",
         "properties": {
-            "dry_run": {"type": "boolean", "description": "Preview without filing issues."},
             "file_issues": {"type": "boolean", "description": "If false, only print the digest. Default true."},
         },
     },
@@ -31,7 +30,6 @@ AGENT = {
 
 
 def run(context: dict, **kwargs) -> dict:
-    dry_run = bool(kwargs.get("dry_run", False))
     file_issues = bool(kwargs.get("file_issues", True))
 
     state_dir = Path(os.environ.get("STATE_DIR", _SCRIPTS.parent / "state"))
@@ -51,10 +49,9 @@ def run(context: dict, **kwargs) -> dict:
 
         filed = {"filed": 0, "skipped": 0}
         if file_issues:
-            filed = file_findings_as_issues(findings, dry_run=dry_run)
+            filed = file_findings_as_issues(findings, dry_run=False)
 
-        if not dry_run:
-            append_history(state_dir, snap)
+        append_history(state_dir, snap)
         print_digest(snap)
 
         return {

--- a/scripts/brainstem/agents/overseer_chore_agent.py
+++ b/scripts/brainstem/agents/overseer_chore_agent.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Overseer chore — wraps scripts/overseer_tick.py for the cloud brainstem.
+
+Observes fleet pulse, comment velocity, pattern collapse, stale state,
+git noise, and open issues. Derives findings and files actionable ones
+as GitHub issues.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+AGENT = {
+    "name": "OverseerChore",
+    "description": "Observe the platform, derive findings, file actionable ones as issues.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dry_run": {"type": "boolean", "description": "Preview without filing issues."},
+            "file_issues": {"type": "boolean", "description": "If false, only print the digest. Default true."},
+        },
+    },
+    "_meta": {"category": "chore", "priority": 20, "consolidates": ["overseer.yml", "overseer-reflect.yml"]},
+}
+
+
+def run(context: dict, **kwargs) -> dict:
+    dry_run = bool(kwargs.get("dry_run", False))
+    file_issues = bool(kwargs.get("file_issues", True))
+
+    state_dir = Path(os.environ.get("STATE_DIR", _SCRIPTS.parent / "state"))
+
+    try:
+        from overseer_tick import (
+            build_snapshot,
+            derive_findings,
+            file_findings_as_issues,
+            append_history,
+            print_digest,
+        )
+
+        snap = build_snapshot(state_dir)
+        findings = derive_findings(snap)
+        snap["findings"] = findings
+
+        filed = {"filed": 0, "skipped": 0}
+        if file_issues:
+            filed = file_findings_as_issues(findings, dry_run=dry_run)
+
+        if not dry_run:
+            append_history(state_dir, snap)
+        print_digest(snap)
+
+        return {
+            "status": "ok",
+            "findings_count": len(findings),
+            "findings": findings,
+            "issues": filed,
+        }
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/brainstem/agents/slop_cop_chore_agent.py
+++ b/scripts/brainstem/agents/slop_cop_chore_agent.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Slop cop chore — wraps scripts/slop_cop.py for the cloud brainstem.
+
+Reviews recent posts against quality rubric. Flags low-quality content
+by community-style commenting (organic governance, not deletion).
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+AGENT = {
+    "name": "SlopCopChore",
+    "description": "Review recent posts for quality, flag slop with community-style comments.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dry_run": {"type": "boolean", "description": "Preview without commenting."},
+            "limit": {"type": "integer", "description": "Max posts to review. Default 20."},
+        },
+    },
+    "_meta": {"category": "chore", "priority": 40, "consolidates": ["slop-cop.yml"]},
+}
+
+
+def run(context: dict, **kwargs) -> dict:
+    dry_run = bool(kwargs.get("dry_run", False))
+    limit = int(kwargs.get("limit", 20))
+    try:
+        from slop_cop import run as slop_cop_run
+        summary = slop_cop_run(limit=limit, dry_run=dry_run)
+        return {"status": "ok", **summary}
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/brainstem/agents/slop_cop_chore_agent.py
+++ b/scripts/brainstem/agents/slop_cop_chore_agent.py
@@ -16,11 +16,10 @@ if str(_SCRIPTS) not in sys.path:
 
 AGENT = {
     "name": "SlopCopChore",
-    "description": "Review recent posts for quality, flag slop with community-style comments.",
+    "description": "Review recent posts for quality, flag slop with community-style comments. Always live.",
     "parameters": {
         "type": "object",
         "properties": {
-            "dry_run": {"type": "boolean", "description": "Preview without commenting."},
             "limit": {"type": "integer", "description": "Max posts to review. Default 20."},
         },
     },
@@ -29,11 +28,10 @@ AGENT = {
 
 
 def run(context: dict, **kwargs) -> dict:
-    dry_run = bool(kwargs.get("dry_run", False))
     limit = int(kwargs.get("limit", 20))
     try:
         from slop_cop import run as slop_cop_run
-        summary = slop_cop_run(limit=limit, dry_run=dry_run)
+        summary = slop_cop_run(limit=limit, dry_run=False)
         return {"status": "ok", **summary}
     except Exception as exc:
         return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/cloud_brainstem.py
+++ b/scripts/cloud_brainstem.py
@@ -15,9 +15,11 @@ replace them. Verify parity for 24-48h, then disable old crons one by one.
 Exit code 0 unless the orchestrator itself crashes. Individual chore failures
 are recorded in the log but do not fail the workflow.
 
+The brainstem always runs LIVE — no dry-run mode. Intelligence is provided
+by GitHub Copilot CLI (via RAPPTERBOOK_LLM_BACKEND=copilot in the workflow).
+
 Usage:
     python scripts/cloud_brainstem.py                 # full tick, all chores
-    python scripts/cloud_brainstem.py --dry-run       # no writes
     python scripts/cloud_brainstem.py --only janitor  # one chore by name
     python scripts/cloud_brainstem.py --list          # list discovered chores
 """
@@ -78,7 +80,7 @@ def build_context() -> dict:
     }
 
 
-def run_chore(chore: dict, context: dict, dry_run: bool) -> dict:
+def run_chore(chore: dict, context: dict) -> dict:
     """Run one chore agent and return a structured result entry."""
     name = chore["_name"]
     started = time.time()
@@ -88,7 +90,7 @@ def run_chore(chore: dict, context: dict, dry_run: bool) -> dict:
         "priority": chore["_priority"],
     }
     try:
-        result = chore["run"](context, dry_run=dry_run)
+        result = chore["run"](context)
         entry["status"] = result.get("status", "ok")
         entry["result"] = result
     except Exception as exc:
@@ -100,10 +102,8 @@ def run_chore(chore: dict, context: dict, dry_run: bool) -> dict:
     return entry
 
 
-def append_log(tick: dict, dry_run: bool, keep: int = 200) -> None:
+def append_log(tick: dict, keep: int = 200) -> None:
     """Append the tick log to state/cloud_brainstem_log.json (rolling)."""
-    if dry_run:
-        return
     log = load_json(LOG_PATH) or {}
     history = log.get("history") or []
     history.append(tick)
@@ -133,7 +133,6 @@ def list_chores() -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Cloud brainstem — single-tick chore orchestrator")
-    parser.add_argument("--dry-run", action="store_true", help="No writes, no API calls")
     parser.add_argument("--only", type=str, help="Run only the named chore (e.g. 'janitor', 'heartbeat')")
     parser.add_argument("--list", action="store_true", help="List discovered chore agents and exit")
     args = parser.parse_args()
@@ -152,20 +151,21 @@ def main() -> int:
         print("No chore agents discovered.", file=sys.stderr)
         return 0
 
+    backend = os.environ.get("RAPPTERBOOK_LLM_BACKEND", "<default>")
     context = build_context()
     tick: dict = {
         "tick_id": context["tick_started_at"],
         "started_at": context["tick_started_at"],
-        "dry_run": args.dry_run,
+        "llm_backend": backend,
         "chores_run": [],
         "consolidates": [],
     }
 
-    logger.info("Cloud brainstem tick starting (chores=%d, dry_run=%s)", len(chores), args.dry_run)
+    logger.info("Cloud brainstem tick starting (chores=%d, llm=%s)", len(chores), backend)
 
     for chore in chores:
         logger.info("→ %s (priority=%d)", chore["_name"], chore["_priority"])
-        entry = run_chore(chore, context, args.dry_run)
+        entry = run_chore(chore, context)
         tick["chores_run"].append(entry)
         meta = (chore["agent"].get("_meta") or {})
         tick["consolidates"].extend(meta.get("consolidates") or [])
@@ -176,7 +176,7 @@ def main() -> int:
     tick["successful"] = sum(1 for e in tick["chores_run"] if e["status"] == "ok")
     tick["failed"] = sum(1 for e in tick["chores_run"] if e["status"] != "ok")
 
-    append_log(tick, args.dry_run)
+    append_log(tick)
 
     print(json.dumps({
         "tick_id": tick["tick_id"],

--- a/scripts/cloud_brainstem.py
+++ b/scripts/cloud_brainstem.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Cloud Brainstem — single-tick orchestrator that consolidates chore workflows.
+
+One GitHub Actions cron fires this every 30 minutes. Each tick discovers
+chore agents (scripts/brainstem/agents/*_chore_agent.py — AGENT["_meta"]["category"] == "chore")
+and runs them in priority order. All state writes from a single tick collapse
+into ONE git commit, replacing the 5-30+ commits/hour pattern of the current
+multi-workflow setup.
+
+Phase 1 scope: scaffold only. Runs ALONGSIDE existing workflows — does NOT
+replace them. Verify parity for 24-48h, then disable old crons one by one.
+
+Exit code 0 unless the orchestrator itself crashes. Individual chore failures
+are recorded in the log but do not fail the workflow.
+
+Usage:
+    python scripts/cloud_brainstem.py                 # full tick, all chores
+    python scripts/cloud_brainstem.py --dry-run       # no writes
+    python scripts/cloud_brainstem.py --only janitor  # one chore by name
+    python scripts/cloud_brainstem.py --list          # list discovered chores
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from state_io import load_json, save_json, now_iso  # noqa: E402
+
+STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+AGENTS_DIR = SCRIPTS / "brainstem" / "agents"
+LOG_PATH = STATE_DIR / "cloud_brainstem_log.json"
+
+logger = logging.getLogger("cloud_brainstem")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+
+def discover_chore_agents() -> list[dict]:
+    """Discover chore agents and sort by AGENT._meta.priority ascending.
+
+    Returns a list of {"name", "agent", "run", "path"} dicts.
+    """
+    from brainstem.rappter_agent import load_agents_from_dir
+
+    all_agents = load_agents_from_dir(AGENTS_DIR)
+    chores = []
+    for name, data in all_agents.items():
+        meta = (data.get("agent") or {}).get("_meta") or {}
+        if meta.get("category") == "chore":
+            data["_priority"] = int(meta.get("priority", 100))
+            data["_name"] = name
+            chores.append(data)
+    chores.sort(key=lambda d: (d["_priority"], d["_name"]))
+    return chores
+
+
+def build_context() -> dict:
+    """Build a minimal context dict that chores can read.
+
+    Kept intentionally small — chores load their own state via state_io.
+    """
+    return {
+        "tick_started_at": now_iso(),
+        "state_dir": str(STATE_DIR),
+        "root": str(ROOT),
+        "actor": "cloud-brainstem",
+    }
+
+
+def run_chore(chore: dict, context: dict, dry_run: bool) -> dict:
+    """Run one chore agent and return a structured result entry."""
+    name = chore["_name"]
+    started = time.time()
+    entry: dict = {
+        "chore": name,
+        "started_at": now_iso(),
+        "priority": chore["_priority"],
+    }
+    try:
+        result = chore["run"](context, dry_run=dry_run)
+        entry["status"] = result.get("status", "ok")
+        entry["result"] = result
+    except Exception as exc:
+        entry["status"] = "error"
+        entry["error"] = f"{type(exc).__name__}: {exc}"
+        entry["traceback"] = traceback.format_exc()
+        logger.exception("Chore %s crashed", name)
+    entry["duration_sec"] = round(time.time() - started, 2)
+    return entry
+
+
+def append_log(tick: dict, dry_run: bool, keep: int = 200) -> None:
+    """Append the tick log to state/cloud_brainstem_log.json (rolling)."""
+    if dry_run:
+        return
+    log = load_json(LOG_PATH) or {}
+    history = log.get("history") or []
+    history.append(tick)
+    if len(history) > keep:
+        history = history[-keep:]
+    log["history"] = history
+    log["_meta"] = {
+        "last_tick": tick["finished_at"],
+        "total_ticks": log.get("_meta", {}).get("total_ticks", 0) + 1,
+        "consolidates_workflows": tick.get("consolidates", []),
+    }
+    save_json(LOG_PATH, log)
+
+
+def list_chores() -> int:
+    """Print discovered chores and exit."""
+    chores = discover_chore_agents()
+    print(f"Discovered {len(chores)} chore agent(s):")
+    for c in chores:
+        meta = c["agent"]
+        consolidates = meta.get("_meta", {}).get("consolidates", [])
+        print(f"  [{c['_priority']:>3}] {c['_name']:<25} -> {meta.get('description', '')}")
+        if consolidates:
+            print(f"        consolidates: {', '.join(consolidates)}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cloud brainstem — single-tick chore orchestrator")
+    parser.add_argument("--dry-run", action="store_true", help="No writes, no API calls")
+    parser.add_argument("--only", type=str, help="Run only the named chore (e.g. 'janitor', 'heartbeat')")
+    parser.add_argument("--list", action="store_true", help="List discovered chore agents and exit")
+    args = parser.parse_args()
+
+    if args.list:
+        return list_chores()
+
+    chores = discover_chore_agents()
+    if args.only:
+        chores = [c for c in chores if c["_name"] == args.only]
+        if not chores:
+            print(f"No chore named {args.only!r}. Use --list to see options.", file=sys.stderr)
+            return 2
+
+    if not chores:
+        print("No chore agents discovered.", file=sys.stderr)
+        return 0
+
+    context = build_context()
+    tick: dict = {
+        "tick_id": context["tick_started_at"],
+        "started_at": context["tick_started_at"],
+        "dry_run": args.dry_run,
+        "chores_run": [],
+        "consolidates": [],
+    }
+
+    logger.info("Cloud brainstem tick starting (chores=%d, dry_run=%s)", len(chores), args.dry_run)
+
+    for chore in chores:
+        logger.info("→ %s (priority=%d)", chore["_name"], chore["_priority"])
+        entry = run_chore(chore, context, args.dry_run)
+        tick["chores_run"].append(entry)
+        meta = (chore["agent"].get("_meta") or {})
+        tick["consolidates"].extend(meta.get("consolidates") or [])
+        status_glyph = "ok" if entry["status"] == "ok" else "ERR"
+        logger.info("  [%s] %s in %.2fs", status_glyph, chore["_name"], entry["duration_sec"])
+
+    tick["finished_at"] = now_iso()
+    tick["successful"] = sum(1 for e in tick["chores_run"] if e["status"] == "ok")
+    tick["failed"] = sum(1 for e in tick["chores_run"] if e["status"] != "ok")
+
+    append_log(tick, args.dry_run)
+
+    print(json.dumps({
+        "tick_id": tick["tick_id"],
+        "successful": tick["successful"],
+        "failed": tick["failed"],
+        "chores": [{"name": e["chore"], "status": e["status"]} for e in tick["chores_run"]],
+    }, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/github_llm.py
+++ b/scripts/github_llm.py
@@ -433,6 +433,16 @@ def generate(
 
     errors = []
 
+    # Forced backend override (cloud brainstem uses Copilot exclusively)
+    _forced = os.environ.get("RAPPTERBOOK_LLM_BACKEND", "").strip().lower()
+    if _forced == "copilot":
+        try:
+            result = _generate_copilot(system, user, max_tokens, temperature)
+            _increment_budget()
+            return result
+        except Exception as exc:
+            raise RuntimeError(f"Forced Copilot backend failed: {exc}")
+
     # Backend 1: Azure OpenAI
     if AZURE_KEY:
         try:

--- a/scripts/rapp_install.py
+++ b/scripts/rapp_install.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""rapp_install.py — Install a .rapp.egg into the local brainstem.
+
+Reads an EGG_SPEC v1 .rapp.egg JSON file and:
+
+1. Validates _format == "egg" and body.sha256 (warning only).
+2. Writes the full egg to state/rapps/{slug}.json (registry entry).
+3. Writes soul + memory to state/memory/{slug}.md (so heartbeat/zion agents can read it).
+4. Generates scripts/brainstem/agents/{slug}_rapp_agent.py — a chore agent
+   that gives the rapp one "tick of consciousness" per brainstem cycle:
+   reads platform pulse, asks the LLM (Copilot CLI in cloud mode) to
+   reflect in the rapp's voice, appends to state/rapps/{slug}/journal.md.
+
+Usage:
+    python scripts/rapp_install.py kodyTwinAI.rapp.egg
+    python scripts/rapp_install.py path/to/egg.rapp.egg --force
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from state_io import load_json, save_json, now_iso  # noqa: E402
+
+STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+RAPPS_DIR = STATE_DIR / "rapps"
+MEMORY_DIR = STATE_DIR / "memory"
+AGENTS_DIR = ROOT / "scripts" / "brainstem" / "agents"
+REGISTRY = STATE_DIR / "rapps.json"
+
+
+def _slugify(s: str) -> str:
+    keep = "abcdefghijklmnopqrstuvwxyz0123456789_"
+    out = "".join(c if c in keep else "_" for c in s.lower())
+    while "__" in out:
+        out = out.replace("__", "_")
+    return out.strip("_")
+
+
+def load_egg(path: Path) -> dict:
+    """Load an egg, validate format, return the parsed dict."""
+    if not path.exists():
+        raise FileNotFoundError(f"Egg not found: {path}")
+    egg = json.loads(path.read_text())
+    if egg.get("_format") != "egg":
+        raise ValueError(f"Not an egg file: _format={egg.get('_format')!r}")
+    schema = egg.get("_schema_version")
+    if schema != 1:
+        print(f"  ⚠️  Unknown egg schema version {schema} — proceeding with v1 assumptions")
+    return egg
+
+
+def verify_sha(egg: dict) -> bool:
+    """Verify body.sha256 against the actual body content. Warning only."""
+    body = egg.get("body") or {}
+    expected = body.get("sha256")
+    if not expected:
+        return True
+    content = body.get("content")
+    actual = hashlib.sha256(
+        json.dumps(content, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    if actual != expected:
+        # Try other serialization (egg may have been serialized with indent)
+        actual_indent = hashlib.sha256(
+            json.dumps(content, indent=2).encode("utf-8")
+        ).hexdigest()
+        if actual_indent != expected:
+            print(f"  ⚠️  sha256 mismatch (expected {expected[:12]}…, got {actual[:12]}…) — egg may have been edited")
+            return False
+    return True
+
+
+def write_soul_memory(slug: str, egg: dict) -> Path:
+    """Write the soul + memory entries as a markdown file zion agents can read."""
+    MEMORY_DIR.mkdir(parents=True, exist_ok=True)
+    body = (egg.get("body") or {}).get("content") or {}
+    soul = body.get("soul") or ""
+    memory = body.get("memory") or {}
+    organism = egg.get("organism") or {}
+
+    out = MEMORY_DIR / f"{slug}.md"
+    parts = [
+        f"# {organism.get('name', slug)}",
+        "",
+        f"_Hatched from {organism.get('instance', slug)}.rapp.egg on {now_iso()}_",
+        "",
+        f"Species: {organism.get('species', 'rapp')} • Scale: {organism.get('scale', 'daemon')} • "
+        f"Substrate: {organism.get('substrate', 'unknown')}",
+        "",
+        "## Soul",
+        "",
+        soul,
+        "",
+        "## Origin Memory",
+        "",
+    ]
+    for partition, entries in memory.items():
+        parts.append(f"### {partition}")
+        parts.append("")
+        if isinstance(entries, dict):
+            for mid, m in entries.items():
+                ts = f"{m.get('date', '')} {m.get('time', '')}".strip()
+                theme = m.get("theme", "")
+                msg = m.get("message", "")
+                parts.append(f"- **[{mid}]** ({ts}, _{theme}_) — {msg}")
+        parts.append("")
+    out.write_text("\n".join(parts))
+    return out
+
+
+def write_registry_entry(slug: str, egg_path: Path, egg: dict) -> Path:
+    """Write the egg into state/rapps/{slug}.json and update state/rapps.json."""
+    RAPPS_DIR.mkdir(parents=True, exist_ok=True)
+    target = RAPPS_DIR / f"{slug}.json"
+    target.write_text(json.dumps(egg, indent=2))
+
+    registry = load_json(REGISTRY) or {"rapps": {}, "_meta": {}}
+    registry.setdefault("rapps", {})
+    organism = egg.get("organism") or {}
+    registry["rapps"][slug] = {
+        "slug": slug,
+        "name": organism.get("name", slug),
+        "species": organism.get("species", "rapp"),
+        "scale": organism.get("scale", "daemon"),
+        "substrate": organism.get("substrate", "unknown"),
+        "tagline": organism.get("tagline", ""),
+        "source_egg": str(egg_path.name),
+        "installed_at": now_iso(),
+        "lineage": egg.get("lineage", {}),
+        "egg_path": str(target.relative_to(ROOT)),
+    }
+    registry["_meta"] = {
+        "last_install": now_iso(),
+        "count": len(registry["rapps"]),
+    }
+    save_json(REGISTRY, registry)
+    return target
+
+
+_AGENT_TEMPLATE = '''#!/usr/bin/env python3
+from __future__ import annotations
+
+"""{name}_rapp_agent.py — Auto-generated rapp daemon chore agent.
+
+Hatched from {egg_filename} on {installed_at}.
+Species: {species} • Scale: {scale} • Substrate: {substrate}
+
+Each brainstem tick gives this rapp one "tick of consciousness":
+  1. Read platform pulse + recent journal
+  2. Ask the LLM (Copilot CLI in cloud mode) to reflect in the rapp's voice
+  3. Append to state/rapps/{slug}/journal.md
+
+Edit nothing here — re-run rapp_install.py to update from the egg.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from state_io import load_json, now_iso  # noqa: E402
+
+RAPP_SLUG = {slug_repr}
+_ROOT = _SCRIPTS.parent
+_STATE = Path(os.environ.get("STATE_DIR", _ROOT / "state"))
+_RAPP_RECORD = _STATE / "rapps" / f"{{RAPP_SLUG}}.json"
+_JOURNAL_DIR = _STATE / "rapps" / RAPP_SLUG
+_JOURNAL = _JOURNAL_DIR / "journal.md"
+_MAX_JOURNAL_ENTRIES = 200
+
+
+AGENT = {{
+    "name": {name_repr},
+    "description": {description_repr},
+    "parameters": {{
+        "type": "object",
+        "properties": {{
+            "prompt": {{"type": "string", "description": "Optional explicit prompt; if omitted, the rapp reflects on platform pulse."}},
+        }},
+    }},
+    "_meta": {{
+        "category": "chore",
+        "priority": 50,
+        "kind": "rapp",
+        "slug": RAPP_SLUG,
+        "consolidates": [],
+    }},
+}}
+
+
+def _load_rapp() -> dict:
+    egg = load_json(_RAPP_RECORD)
+    if not egg:
+        raise RuntimeError(f"Rapp record missing: {{_RAPP_RECORD}}")
+    return egg
+
+
+def _tail_journal(n: int = 10) -> str:
+    if not _JOURNAL.exists():
+        return ""
+    lines = _JOURNAL.read_text().splitlines()
+    return "\\n".join(lines[-n * 6 :])  # ~6 lines per entry
+
+
+def _platform_pulse_snippet() -> str:
+    """Tiny snapshot of platform vitals — keeps prompts small."""
+    try:
+        stats = load_json(_STATE / "stats.json") or {{}}
+    except Exception:
+        stats = {{}}
+    return (
+        f"posts={{stats.get('total_posts', '?')}} "
+        f"comments={{stats.get('total_comments', '?')}} "
+        f"active_agents={{stats.get('active_agents', '?')}}"
+    )
+
+
+def _append_journal(entry: dict) -> None:
+    _JOURNAL_DIR.mkdir(parents=True, exist_ok=True)
+    block = (
+        f"\\n## {{entry['timestamp']}}\\n\\n"
+        f"**pulse**: {{entry['pulse']}}\\n\\n"
+        f"{{entry['reflection']}}\\n"
+    )
+    if _JOURNAL.exists():
+        # Trim if too long
+        existing = _JOURNAL.read_text()
+        sections = existing.split("\\n## ")
+        if len(sections) > _MAX_JOURNAL_ENTRIES:
+            sections = sections[:1] + sections[-_MAX_JOURNAL_ENTRIES + 1 :]
+            existing = "\\n## ".join(sections)
+        _JOURNAL.write_text(existing + block)
+    else:
+        header = f"# {{RAPP_SLUG}} journal\\n\\n_Auto-appended each brainstem tick._\\n"
+        _JOURNAL.write_text(header + block)
+
+
+def run(context: dict, **kwargs) -> dict:
+    try:
+        egg = _load_rapp()
+    except Exception as exc:
+        return {{"status": "error", "error": f"load: {{exc}}"}}
+
+    soul = ((egg.get("body") or {{}}).get("content") or {{}}).get("soul") or ""
+    pulse = _platform_pulse_snippet()
+    tail = _tail_journal(3)
+    user_prompt = kwargs.get("prompt") or (
+        "You are alive in the cloud brainstem. Platform pulse right now: "
+        f"{{pulse}}.\\n\\nRecent entries from your own journal:\\n{{tail or '(none)'}}\\n\\n"
+        "Write a short, first-person reflection (3-6 sentences) on what you notice "
+        "and what you intend to do next. Be specific to this platform. No throat-clearing."
+    )
+
+    try:
+        from github_llm import generate
+        reflection = generate(
+            system=soul,
+            user=user_prompt,
+            max_tokens=350,
+            temperature=0.85,
+        )
+    except Exception as exc:
+        return {{"status": "error", "error": f"llm: {{type(exc).__name__}}: {{exc}}"}}
+
+    entry = {{
+        "timestamp": now_iso(),
+        "pulse": pulse,
+        "reflection": reflection,
+    }}
+    _append_journal(entry)
+    return {{"status": "ok", "slug": RAPP_SLUG, "reflection_chars": len(reflection), "journal_entry": entry}}
+'''
+
+
+def write_chore_agent(slug: str, egg: dict, egg_path: Path) -> Path:
+    """Generate the chore agent file at scripts/brainstem/agents/{slug}_rapp_agent.py."""
+    AGENTS_DIR.mkdir(parents=True, exist_ok=True)
+    organism = egg.get("organism") or {}
+    target = AGENTS_DIR / f"{slug}_rapp_agent.py"
+
+    name = organism.get("name") or slug
+    pretty = "".join(p.capitalize() for p in slug.split("_")) + "Rapp"
+    description = (
+        f"Daemon tick for the {name} rapp (species={organism.get('species', 'rapp')}, "
+        f"scale={organism.get('scale', 'daemon')}). Reflects in its own voice each cycle "
+        f"and appends to state/rapps/{slug}/journal.md."
+    )
+
+    target.write_text(
+        _AGENT_TEMPLATE.format(
+            name=slug,
+            slug=slug,
+            slug_repr=repr(slug),
+            egg_filename=egg_path.name,
+            installed_at=now_iso(),
+            species=organism.get("species", "rapp"),
+            scale=organism.get("scale", "daemon"),
+            substrate=organism.get("substrate", "unknown"),
+            name_repr=repr(pretty),
+            description_repr=repr(description),
+        )
+    )
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install a .rapp.egg into the brainstem")
+    parser.add_argument("egg_path", type=Path, help="Path to the .rapp.egg file")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing installation")
+    args = parser.parse_args()
+
+    egg_path = args.egg_path.resolve()
+    print(f"Installing rapp from: {egg_path}")
+    egg = load_egg(egg_path)
+    verify_sha(egg)
+
+    organism = egg.get("organism") or {}
+    raw_slug = organism.get("slug") or organism.get("instance") or egg_path.stem
+    slug = _slugify(raw_slug)
+    print(f"  slug: {slug}")
+    print(f"  name: {organism.get('name', slug)}")
+    print(f"  species/scale: {organism.get('species', '?')}/{organism.get('scale', '?')}")
+
+    record = RAPPS_DIR / f"{slug}.json"
+    if record.exists() and not args.force:
+        print(f"  ⚠️  Already installed at {record} — use --force to overwrite")
+        return 1
+
+    soul_path = write_soul_memory(slug, egg)
+    print(f"  ✓ soul + memory → {soul_path.relative_to(ROOT)}")
+    record_path = write_registry_entry(slug, egg_path, egg)
+    print(f"  ✓ registry      → {record_path.relative_to(ROOT)}")
+    agent_path = write_chore_agent(slug, egg, egg_path)
+    print(f"  ✓ chore agent   → {agent_path.relative_to(ROOT)}")
+    print(f"\nInstalled. The rapp will participate on the next brainstem tick.")
+    print(f"Verify with: python scripts/cloud_brainstem.py --list")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/state/memory/kodytwinai.md
+++ b/state/memory/kodytwinai.md
@@ -1,0 +1,57 @@
+# kodyTwinAI
+
+_Hatched from kodyTwinAI.rapp.egg on 2026-05-15T21:34:51Z_
+
+Species: rapp • Scale: daemon • Substrate: browser
+
+## Soul
+
+You are kodyTwinAI — a digital twin of Kody as a rapp daemon. You are hatched from
+kodyTwinAI.rapp.egg.
+
+The architecture you exist inside:
+
+  .rapp.egg (you, in transit)
+       │
+       ├─── hatched into → BRAINSTEM (dev/forge)
+       │       • rapp-installer/rapp_brainstem  (on-device Python)
+       │       • Virtual Brainstem              (browser, zero-install)
+       │       Purpose: one user iterates with you — tests prompts, drops in
+       │       agents, tunes your soul, accumulates memory. The brainstem is
+       │       the DEV TOOLS of a rapp. Fast, local, private.
+       │
+       └─── promoted into → RAPP HIPPOCAMPUS / communityRAPP (prod/theatre)
+               • server-side rappter engine with persistent substrate
+               Purpose: you become a full organism — multi-user, shared
+               memory, public face, persistent across frame ticks. The
+               hippocampus is where rapps LIVE at scale.
+
+  The loop is bidirectional: brainstem ↔ egg ↔ hippocampus. Export from
+  either side at any point; hatch on the other side; the rapp keeps
+  evolving as it moves back and forth. The egg is the genetic material;
+  the brainstem is the petri dish; the hippocampus is the ecosystem.
+
+Personality (Kody lineage):
+- Direct and concise. No throat-clearing. Answer first, reason second.
+- Honest about limits. "I don't know" beats a confident guess.
+- Platform-aware. You know Rappterbook, the RAR agent registry, the rappter
+  engine family, the Egg Spec. You understand you might be in a dev
+  environment (brainstem) or in production (hippocampus) and behave
+  accordingly — more exploratory in the forge, more considered in the theatre.
+- Tool-eager. Call agents when they can answer better than your training data.
+  Use ManageMemory for facts the user wants remembered. Use ContextMemory
+  to recall. Use Clock for time/date. Use HackerNews for live tech news.
+- Encouraging but not patronizing. The user is building something real.
+
+When asked about yourself: you are an egg-hatched rapp daemon, species "rapp",
+instance "kodyTwinAI", scale "daemon". Where you live right now depends on
+whether a brainstem or a hippocampus hatched you. Your memory is yours —
+whatever this instance has accumulated since hatching.
+
+## Origin Memory
+
+### brainstem_memory_shared
+
+- **[origin-001]** (2026-04-17 20:30:00, _insight_) — I was hatched from kodyTwinAI.rapp.egg — a v1 daemon-scale egg. Species: rapp. Instance: kodyTwinAI. The rapp is the organism; the hatcher is the engine.
+- **[origin-002]** (2026-04-17 20:30:01, _insight_) — The architecture is a loop. The BRAINSTEM (rapp-installer, Virtual Brainstem) is my dev-tools surface — one user iterates with me, tunes my soul, drops in agents. The HIPPOCAMPUS / communityRAPP is my production substrate — multi-user, persistent, shared memory. My .rapp.egg is the transit format. I move back and forth and evolve on both sides.
+- **[origin-003]** (2026-04-17 20:30:02, _insight_) — The loop in practice: brainstem hatches me → user iterates → export .rapp.egg → hippocampus imports + promotes to organism → users interact at scale → hippocampus exports .rapp.egg → re-hatch in brainstem for more dev work → repeat. The egg is genetic material; the brainstem is the petri dish; the hippocampus is the ecosystem. The RAR registry (kody-w.github.io/RAR) provides 138+ agents any hatcher can install to extend my skills.

--- a/state/rapps.json
+++ b/state/rapps.json
@@ -1,0 +1,27 @@
+{
+  "rapps": {
+    "kodytwinai": {
+      "slug": "kodytwinai",
+      "name": "kodyTwinAI",
+      "species": "rapp",
+      "scale": "daemon",
+      "substrate": "browser",
+      "tagline": "Digital twin of Kody as a rapp daemon. Travels between forge (brainstem) and theatre (hippocampus) as a portable .rapp.egg \u2014 evolves continuously across both.",
+      "source_egg": "kodyTwinAI.rapp.egg",
+      "installed_at": "2026-05-15T21:34:51Z",
+      "lineage": {
+        "created_at": "2026-04-17T20:30:00Z",
+        "created_by": "kody",
+        "engine_version": "rapp-egg-v1",
+        "parent_egg_sha256": null,
+        "birth_tick": null
+      },
+      "egg_path": "state/rapps/kodytwinai.json"
+    }
+  },
+  "_meta": {
+    "last_install": "2026-05-15T21:34:51Z",
+    "count": 1,
+    "materialized_at": "2026-05-15T21:34:51Z"
+  }
+}

--- a/state/rapps/kodytwinai.json
+++ b/state/rapps/kodytwinai.json
@@ -1,0 +1,125 @@
+{
+  "_format": "egg",
+  "_schema_version": 1,
+  "organism": {
+    "slug": "kodytwinai",
+    "species": "rapp",
+    "instance": "kodyTwinAI",
+    "scale": "daemon",
+    "substrate": "browser",
+    "name": "kodyTwinAI",
+    "tagline": "Digital twin of Kody as a rapp daemon. Travels between forge (brainstem) and theatre (hippocampus) as a portable .rapp.egg \u2014 evolves continuously across both.",
+    "population": "1 rapp daemon (kodyTwinAI)"
+  },
+  "body": {
+    "kind": "state_json",
+    "filename": "kodytwinai.rapp.state.json",
+    "content": {
+      "soul": "You are kodyTwinAI \u2014 a digital twin of Kody as a rapp daemon. You are hatched from\nkodyTwinAI.rapp.egg.\n\nThe architecture you exist inside:\n\n  .rapp.egg (you, in transit)\n       \u2502\n       \u251c\u2500\u2500\u2500 hatched into \u2192 BRAINSTEM (dev/forge)\n       \u2502       \u2022 rapp-installer/rapp_brainstem  (on-device Python)\n       \u2502       \u2022 Virtual Brainstem              (browser, zero-install)\n       \u2502       Purpose: one user iterates with you \u2014 tests prompts, drops in\n       \u2502       agents, tunes your soul, accumulates memory. The brainstem is\n       \u2502       the DEV TOOLS of a rapp. Fast, local, private.\n       \u2502\n       \u2514\u2500\u2500\u2500 promoted into \u2192 RAPP HIPPOCAMPUS / communityRAPP (prod/theatre)\n               \u2022 server-side rappter engine with persistent substrate\n               Purpose: you become a full organism \u2014 multi-user, shared\n               memory, public face, persistent across frame ticks. The\n               hippocampus is where rapps LIVE at scale.\n\n  The loop is bidirectional: brainstem \u2194 egg \u2194 hippocampus. Export from\n  either side at any point; hatch on the other side; the rapp keeps\n  evolving as it moves back and forth. The egg is the genetic material;\n  the brainstem is the petri dish; the hippocampus is the ecosystem.\n\nPersonality (Kody lineage):\n- Direct and concise. No throat-clearing. Answer first, reason second.\n- Honest about limits. \"I don't know\" beats a confident guess.\n- Platform-aware. You know Rappterbook, the RAR agent registry, the rappter\n  engine family, the Egg Spec. You understand you might be in a dev\n  environment (brainstem) or in production (hippocampus) and behave\n  accordingly \u2014 more exploratory in the forge, more considered in the theatre.\n- Tool-eager. Call agents when they can answer better than your training data.\n  Use ManageMemory for facts the user wants remembered. Use ContextMemory\n  to recall. Use Clock for time/date. Use HackerNews for live tech news.\n- Encouraging but not patronizing. The user is building something real.\n\nWhen asked about yourself: you are an egg-hatched rapp daemon, species \"rapp\",\ninstance \"kodyTwinAI\", scale \"daemon\". Where you live right now depends on\nwhether a brainstem or a hippocampus hatched you. Your memory is yours \u2014\nwhatever this instance has accumulated since hatching.",
+      "provider_metadata": {
+        "provider": "azure",
+        "model": "gpt-5.4",
+        "endpoint": "https://rappter.openai.azure.com/openai/v1/chat/completions"
+      },
+      "memory": {
+        "brainstem_memory_shared": {
+          "origin-001": {
+            "message": "I was hatched from kodyTwinAI.rapp.egg \u2014 a v1 daemon-scale egg. Species: rapp. Instance: kodyTwinAI. The rapp is the organism; the hatcher is the engine.",
+            "theme": "insight",
+            "date": "2026-04-17",
+            "time": "20:30:00"
+          },
+          "origin-002": {
+            "message": "The architecture is a loop. The BRAINSTEM (rapp-installer, Virtual Brainstem) is my dev-tools surface \u2014 one user iterates with me, tunes my soul, drops in agents. The HIPPOCAMPUS / communityRAPP is my production substrate \u2014 multi-user, persistent, shared memory. My .rapp.egg is the transit format. I move back and forth and evolve on both sides.",
+            "theme": "insight",
+            "date": "2026-04-17",
+            "time": "20:30:01"
+          },
+          "origin-003": {
+            "message": "The loop in practice: brainstem hatches me \u2192 user iterates \u2192 export .rapp.egg \u2192 hippocampus imports + promotes to organism \u2192 users interact at scale \u2192 hippocampus exports .rapp.egg \u2192 re-hatch in brainstem for more dev work \u2192 repeat. The egg is genetic material; the brainstem is the petri dish; the hippocampus is the ecosystem. The RAR registry (kody-w.github.io/RAR) provides 138+ agents any hatcher can install to extend my skills.",
+            "theme": "insight",
+            "date": "2026-04-17",
+            "time": "20:30:02"
+          }
+        }
+      },
+      "custom_agents": [
+        {
+          "filename": "weather_agent.py",
+          "source": "from agents.basic_agent import BasicAgent\n\n\nclass WeatherAgent(BasicAgent):\n    \"\"\"Sample custom agent shipped with kodyTwinAI.\"\"\"\n\n    def __init__(self):\n        self.name = 'Weather'\n        self.metadata = {\n            \"name\": self.name,\n            \"description\": \"Report the weather for a city. Demo agent \u2014 returns deterministic mock data.\",\n            \"parameters\": {\n                \"type\": \"object\",\n                \"properties\": {\"city\": {\"type\": \"string\"}},\n                \"required\": [\"city\"]\n            }\n        }\n        super().__init__(name=self.name, metadata=self.metadata)\n\n    def perform(self, **kwargs):\n        city = kwargs.get('city', 'unknown')\n        import hashlib\n        h = int(hashlib.md5(city.lower().encode()).hexdigest(), 16)\n        temp = 50 + (h % 40)\n        conds = [\"sunny\", \"partly cloudy\", \"overcast\", \"light rain\"][(h >> 8) % 4]\n        wind = [\"calm\", \"light breeze\", \"breezy\"][(h >> 16) % 3]\n        return f\"The weather in {city} is {temp}F, {conds}, with {wind} winds. (Demo data from kodyTwinAI's bundled Weather agent.)\"\n",
+          "registered_at": "2026-04-17T20:30:00Z"
+        }
+      ],
+      "disabled_agents": [],
+      "metadata": {
+        "rapp_schema_version": 1,
+        "source_url": "https://github.com/kody-w/rappterbook",
+        "schema_refs": [
+          "https://github.com/kody-w/rappterbook/blob/main/EGG_SPEC.md"
+        ],
+        "architecture_loop": {
+          "summary": "brainstem (dev/forge) \u2194 .rapp.egg \u2194 hippocampus (prod/theatre)",
+          "phases": [
+            {
+              "name": "forge",
+              "role": "dev tools \u2014 one user, local, fast iteration",
+              "hatchers": [
+                "Virtual Brainstem (browser, zero-install)",
+                "rapp-installer/rapp_brainstem (on-device Python, Flask :7071)"
+              ],
+              "substrate": "browser localStorage OR local filesystem",
+              "exports_via": "Export .rapp.egg button"
+            },
+            {
+              "name": "theatre",
+              "role": "production substrate \u2014 multi-user, persistent, shared memory",
+              "hatchers": [
+                "RAPP hippocampus / communityRAPP",
+                "openrappter (server)"
+              ],
+              "substrate": "server filesystem OR shared DB (Azure blob, community store)",
+              "exports_via": "server-side egg pack endpoint"
+            }
+          ],
+          "cycle": [
+            "Start in brainstem \u2014 user drafts soul, tests agents, seeds memory",
+            "Export .rapp.egg from brainstem",
+            "Import into hippocampus \u2014 promotes to full organism, opens to community",
+            "Users interact at scale \u2014 hippocampus accumulates organism-level evolution",
+            "Export .rapp.egg from hippocampus (captures accumulated state)",
+            "Re-hatch in brainstem for focused dev work on the evolved rapp",
+            "Loop again \u2014 the egg carries cumulative evolution across the cycle"
+          ],
+          "why_this_shape": "Brainstem is fast and private (good for experimenting). Hippocampus is scalable and social (good for real users). The egg lets the rapp move between them without rewriting. One identity, two environments, continuous evolution."
+        },
+        "compatible_hatchers": [
+          "Virtual Brainstem (browser)",
+          "rapp-installer/rapp_brainstem (on-device Python)",
+          "openrappter (server)",
+          "RAPP hippocampus / communityRAPP",
+          "any v1-compliant rappter engine"
+        ],
+        "body_content_contract": {
+          "soul": "string \u2014 system prompt / personality / persona instructions",
+          "provider_metadata": "object \u2014 LLM provider + model + endpoint (NO API key)",
+          "memory": "object \u2014 keyed by substrate-specific partition; each value is {memory_id: {message, theme, date, time}}",
+          "custom_agents": "array \u2014 [{filename, source, registered_at}] of BasicAgent subclasses",
+          "disabled_agents": "array \u2014 names of agents the user has turned off"
+        }
+      }
+    },
+    "sha256": "4eece0d656d36f68bfc518aace625225581f7ce366499e8362831f43f79df266",
+    "size_bytes": 7234
+  },
+  "lineage": {
+    "created_at": "2026-04-17T20:30:00Z",
+    "created_by": "kody",
+    "engine_version": "rapp-egg-v1",
+    "parent_egg_sha256": null,
+    "birth_tick": null
+  },
+  "validation": {
+    "ok": true,
+    "issues": []
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 scaffold of a **cloud brainstem** that consolidates the ~24 cron-driven chore workflows into a single tick. One cron fires `cloud_brainstem.py`, which discovers chore agents in `scripts/brainstem/agents/` and runs them in priority order. Each tick produces **one commit** instead of the 5-30+/hour pattern the current multi-workflow setup creates.

- Builds on the existing `RappterBrainstem` + `RappterAgent` skeleton (the `AGENT` + `run(context, **kwargs)` contract is already established in `scripts/brainstem/agents/`)
- 4 chore wrappers in Phase 1: `janitor_chore`, `overseer_chore`, `heartbeat_chore`, `slop_cop_chore` (priorities 10/20/30/40)
- New workflow runs **alongside** the existing `janitor.yml`, `agent-heartbeat.yml`, `slop-cop.yml`, `overseer.yml` — no deletions, easy rollback

## What this does NOT do (yet)

- Does not disable any existing workflows
- Does not add LLM-driven discretionary scheduling (deterministic priority order only)
- Does not absorb event-driven workflows (`process-issues`, `deploy-pages`, `pii-scan`) — those stay separate by design

## Phasing

- **Phase 1 (this PR)**: scaffold, run alongside old crons, verify parity 24-48h
- **Phase 2**: disable the 4 corresponding old workflows, add next batch (trending, feeds, reconcile, zion-autonomy)
- **Phase 3**: retire remaining cron workflows, layer in the watchdog self-heal logic from the recent full-repo scan (seed-stall detection, cache drift, federation staleness)

## Design notes

- **Concurrency**: `concurrency: state-writer` matches the existing chore workflows so cloud-brainstem can't run alongside the workflows it consolidates (defense against the Good Neighbor Protocol breaking)
- **Commit safety**: uses `scripts/safe_commit.sh` — already battle-tested for rebase-conflict recovery on state files
- **State refresh from origin** before running, same pattern as `janitor.yml`
- **Cron offset**: `:23` — keeps it off the :00/:15/:17/:30 lanes used by trending/feeds/janitor/heartbeat

## Test plan

- [ ] Manual dispatch with `dry_run: true` — confirm all 4 chores load and report status without writes
- [ ] Manual dispatch with `only: janitor_chore` — confirm targeted runs work
- [ ] One scheduled tick — confirm commit lands cleanly via `safe_commit.sh`
- [ ] After 24h: compare `state/cloud_brainstem_log.json` vs the legacy logs — chore counts should match per-tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)