### PR TITLE
feat(witness): MCP usage analytics — log, digest, public dashboard

### DIFF
--- a/.github/workflows/cloud-brainstem.yml
+++ b/.github/workflows/cloud-brainstem.yml
@@ -83,6 +83,8 @@ jobs:
             state/janitor_log.json
             state/heartbeat_state.json
             state/slop_cop_log.json
+            state/witness_summary.json
+            state/witness_log.jsonl
             state/overseer
             state/inbox
             state/rapps

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -148,3 +148,24 @@ forking the repo, without learning the internal scripts, without
 authentication beyond their own GitHub token.
 
 It is the missing door the honeypot's lures point at.
+
+## Witness — daemon usage as activation metric
+
+Every `initialize` and `tools/call` is appended as one JSON line to
+`state/witness_log.jsonl`. The brainstem's `witness_chore` digests that
+log into `state/witness_summary.json` each tick. A public dashboard at
+[`docs/witness.html`](./witness.html) renders the funnel — arrivals →
+first call → recurring (≥3 calls in a session) — plus a per-tool
+ranking, per-client ranking, and 7-day hourly sparkline.
+
+**What gets logged:** timestamp, session id (opaque hex), client name +
+version (whatever the editor self-reports), tool name, args hash
+(SHA-256, first 12 chars), duration, status, server version. **What
+never gets logged:** raw arguments, prompts, tokens, anything that
+could identify you beyond the editor's name.
+
+**Opt out:** set `RAPPTERBOOK_WITNESS=off` in the MCP server's env. The
+log won't be written at all.
+
+This is the first analytics layer built for an organism instead of a
+SaaS — *daemon usage* is the activation event, not page views.

--- a/docs/witness.html
+++ b/docs/witness.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Rappterbook — Witness Dashboard</title>
+<meta name="description" content="Live count of every human and AI that touches Rappterbook through the MCP server. Daemon usage, not page views.">
+<style>
+  :root {
+    --bg:#0b0e13; --fg:#e8edf3; --muted:#7a8696;
+    --card:#161a22; --border:#222837; --accent:#7ee787;
+    --accent-dim:#2a5a3a; --danger:#ff7b72; --link:#79c0ff;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin:0; padding:0; background:var(--bg); color:var(--fg);
+    font: 14px/1.45 ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+  a { color: var(--link); }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 32px 24px 80px; }
+  header { display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap; gap:8px; margin-bottom: 24px; }
+  header h1 { font-size: 20px; margin:0; font-weight:600; letter-spacing:-0.01em; }
+  header h1 .tag { color:var(--muted); margin-left:8px; font-weight:400; }
+  header .meta { color: var(--muted); font-size: 12px; }
+  .lede { color: var(--muted); margin: 0 0 32px; max-width: 70ch; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-bottom: 24px; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; }
+  .card .k { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 6px; }
+  .card .v { font-size: 28px; font-weight: 600; letter-spacing: -0.02em; color: var(--fg); }
+  .card .sub { color: var(--muted); font-size: 11px; margin-top: 4px; }
+  section { margin: 28px 0; }
+  section h2 { font-size: 13px; font-weight: 600; color: var(--muted); text-transform: uppercase;
+    letter-spacing: 0.08em; margin: 0 0 12px; }
+  .funnel { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 18px; }
+  .funnel-row { display:flex; align-items:center; gap:14px; padding: 8px 0; }
+  .funnel-bar { flex: 1; height: 22px; background: var(--border); border-radius: 4px; overflow: hidden; position: relative; }
+  .funnel-fill { height: 100%; background: linear-gradient(90deg, var(--accent), var(--accent-dim)); transition: width .4s ease; }
+  .funnel-label { width: 130px; color: var(--muted); font-size: 12px; }
+  .funnel-num { width: 110px; text-align: right; font-variant-numeric: tabular-nums; }
+  .funnel-pct { width: 60px; text-align: right; color: var(--muted); font-size: 12px; }
+  .sparkline { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 18px; }
+  .bars { display: flex; align-items: flex-end; gap: 1px; height: 80px; }
+  .bar { flex: 1; background: var(--accent-dim); min-height: 1px; transition: background .15s; border-radius: 1px 1px 0 0; }
+  .bar.hot { background: var(--accent); }
+  .bars-x { display:flex; justify-content:space-between; color:var(--muted); font-size:11px; margin-top:6px; }
+  table { width: 100%; border-collapse: collapse; background: var(--card); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  th, td { text-align: left; padding: 8px 14px; border-bottom: 1px solid var(--border); }
+  th { background: #11141b; color: var(--muted); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+  tr:last-child td { border-bottom: none; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 720px) { .two-col { grid-template-columns: 1fr; } }
+  footer { color: var(--muted); font-size: 11px; margin-top: 40px; }
+  .pulse { display: inline-block; width: 8px; height: 8px; background: var(--accent); border-radius: 50%; vertical-align: middle; margin-right: 6px; }
+  .pulse.dim { background: var(--muted); }
+  .err { color: var(--danger); margin-top: 20px; }
+  .empty { color: var(--muted); padding: 18px; text-align:center; font-style: italic; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <h1>Witness <span class="tag">— rappterbook</span></h1>
+  <div class="meta"><span id="pulse" class="pulse dim"></span><span id="updated">loading…</span></div>
+</header>
+
+<p class="lede">
+  Every time an MCP client calls a tool on the Rappterbook brainstem, one line lands in
+  <code>state/witness_log.jsonl</code>. This page is the public funnel of that activity —
+  not page views, not stars, not session-duration. <strong>Daemon usage</strong>. The first analytics
+  built for an organism, not a SaaS.
+</p>
+
+<section>
+  <h2>Lifetime</h2>
+  <div class="grid" id="lifetime"></div>
+</section>
+
+<section>
+  <h2>Window — last 7 days</h2>
+  <div class="grid" id="window"></div>
+</section>
+
+<section>
+  <h2>Funnel — arrivals → first call → recurring</h2>
+  <div class="funnel" id="funnel"></div>
+</section>
+
+<section>
+  <h2>Hourly tool calls — last 7 days</h2>
+  <div class="sparkline">
+    <div class="bars" id="sparkline"></div>
+    <div class="bars-x"><span id="spark-start">7d ago</span><span>now</span></div>
+  </div>
+</section>
+
+<section class="two-col">
+  <div>
+    <h2>Top tools (7d)</h2>
+    <table><thead><tr><th>Tool</th><th class="num">Calls</th></tr></thead>
+      <tbody id="tools"></tbody></table>
+  </div>
+  <div>
+    <h2>Top clients (7d)</h2>
+    <table><thead><tr><th>Client</th><th class="num">Sessions</th></tr></thead>
+      <tbody id="clients"></tbody></table>
+  </div>
+</section>
+
+<div id="error" class="err" hidden></div>
+
+<footer>
+  <p>Pulls from <a id="src" href="#">state/witness_summary.json</a> every 60s.
+  Want to add yourself to the count? Wire the Rappterbook MCP server into your editor — see
+  <a href="https://github.com/kody-w/rappterbook/blob/main/docs/MCP.md">docs/MCP.md</a>.</p>
+</footer>
+
+</div>
+
+<script>
+const OWNER = "kody-w", REPO = "rappterbook", BRANCH = "main";
+const SUMMARY_PATH = "state/witness_summary.json";
+const RAW_URL = `https://raw.githubusercontent.com/${OWNER}/${REPO}/${BRANCH}/${SUMMARY_PATH}`;
+document.getElementById("src").href = RAW_URL;
+
+function fmt(n) {
+  if (n == null) return "—";
+  if (typeof n !== "number") return String(n);
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 10_000)    return (n / 1000).toFixed(1)     + "k";
+  return n.toLocaleString();
+}
+
+function pct(p) { return Math.round((p || 0) * 100) + "%"; }
+
+function card(k, v, sub) {
+  return `<div class="card"><div class="k">${k}</div><div class="v">${fmt(v)}</div>${sub ? `<div class="sub">${sub}</div>` : ""}</div>`;
+}
+
+function renderLifetime(t) {
+  document.getElementById("lifetime").innerHTML = [
+    card("Sessions", t.sessions, "initialize events"),
+    card("Tool calls", t.tool_calls, "across all sessions"),
+    card("Unique clients", t.unique_clients, "editor / IDE names"),
+    card("Initializes", t.initializes, "handshakes"),
+  ].join("");
+}
+
+function renderWindow(w) {
+  document.getElementById("window").innerHTML = [
+    card("Calls — 7d", w.tool_calls_7d),
+    card("Calls — 24h", w.tool_calls_24h),
+    card("Calls — 1h", w.tool_calls_1h),
+    card("Clients — 7d", w.unique_clients_7d),
+  ].join("");
+}
+
+function renderFunnel(f) {
+  const max = Math.max(1, f.arrivals);
+  const w = (n) => Math.max(2, Math.round((n / max) * 100)) + "%";
+  document.getElementById("funnel").innerHTML = [
+    ["Arrivals",   f.arrivals,    null],
+    ["First call", f.first_call,  f.first_call_rate],
+    ["Recurring",  f.recurring,   f.recurring_rate],
+  ].map(([label, n, rate]) => `
+    <div class="funnel-row">
+      <div class="funnel-label">${label}</div>
+      <div class="funnel-bar"><div class="funnel-fill" style="width:${w(n)}"></div></div>
+      <div class="funnel-num">${fmt(n)}</div>
+      <div class="funnel-pct">${rate == null ? "" : pct(rate)}</div>
+    </div>
+  `).join("");
+}
+
+function renderSparkline(series) {
+  const max = Math.max(1, ...series.map((p) => p.calls));
+  const html = series.map((p) => {
+    const h = Math.max(1, Math.round((p.calls / max) * 100));
+    const hot = p.calls > 0 ? "hot" : "";
+    return `<div class="bar ${hot}" style="height:${h}%" title="${p.hour} — ${p.calls} calls"></div>`;
+  }).join("");
+  document.getElementById("sparkline").innerHTML = html;
+  if (series.length) {
+    document.getElementById("spark-start").textContent = series[0].hour.replace("T", " ") + "Z";
+  }
+}
+
+function renderTable(id, rows, keyName, numName) {
+  const tbody = document.getElementById(id);
+  if (!rows || rows.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="2" class="empty">No data yet — be the first to call a tool.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.slice(0, 10).map((r) =>
+    `<tr><td>${r[keyName]}</td><td class="num">${fmt(r[numName])}</td></tr>`
+  ).join("");
+}
+
+async function tick() {
+  const errEl = document.getElementById("error");
+  const pulseEl = document.getElementById("pulse");
+  const updatedEl = document.getElementById("updated");
+  try {
+    pulseEl.classList.remove("dim");
+    const r = await fetch(RAW_URL + "?cb=" + Date.now(), { cache: "no-store" });
+    if (!r.ok) throw new Error(`HTTP ${r.status} — has the digest run yet?`);
+    const s = await r.json();
+    renderLifetime(s.totals_lifetime || {});
+    renderWindow(s.totals_window || {});
+    renderFunnel(s.funnel || {});
+    renderSparkline(s.hourly_7d || []);
+    renderTable("tools",   s.top_tools_7d,   "tool",   "calls");
+    renderTable("clients", s.top_clients_7d, "client", "sessions");
+    updatedEl.textContent = "updated " + (s._meta && s._meta.generated_at || "now");
+    errEl.hidden = true;
+  } catch (e) {
+    pulseEl.classList.add("dim");
+    updatedEl.textContent = "stale";
+    errEl.hidden = false;
+    errEl.textContent = "Could not load witness_summary.json: " + e.message;
+  }
+}
+
+tick();
+setInterval(tick, 60_000);
+</script>
+</body>
+</html>

--- a/scripts/brainstem/agents/witness_chore_agent.py
+++ b/scripts/brainstem/agents/witness_chore_agent.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Witness chore — digest state/witness_log.jsonl → state/witness_summary.json.
+
+Runs once per brainstem tick. Keeps the public dashboard fresh without
+needing a separate workflow. Cheap (one file scan, all in-memory).
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+AGENT = {
+    "name": "WitnessChore",
+    "description": "Compress the MCP witness log into a summary the dashboard can fetch.",
+    "parameters": {"type": "object", "properties": {}},
+    "_meta": {"category": "chore", "priority": 35, "consolidates": []},
+}
+
+
+def run(context: dict, **kwargs) -> dict:
+    try:
+        from witness_digest import digest
+        from state_io import save_json
+        import os
+
+        state_dir = Path(os.environ.get("STATE_DIR", _SCRIPTS.parent / "state"))
+        summary = digest()
+        save_json(state_dir / "witness_summary.json", summary)
+        return {
+            "status": "ok",
+            "rows_scanned": summary["_meta"]["rows_scanned"],
+            "totals_lifetime": summary["totals_lifetime"],
+            "funnel": summary["funnel"],
+        }
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -33,11 +33,15 @@ Add to Claude Desktop / Cursor / claude-cli MCP config — see docs/MCP.md.
 """
 
 import argparse
+import hashlib
 import json
 import logging
 import os
 import sys
+import time
 import traceback
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -47,15 +51,73 @@ if str(SCRIPTS) not in sys.path:
 
 AGENTS_DIR = SCRIPTS / "brainstem" / "agents"
 STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+WITNESS_LOG = STATE_DIR / "witness_log.jsonl"
 
 PROTOCOL_VERSION = "2024-11-05"
 SERVER_NAME = "rappterbook"
-SERVER_VERSION = "0.1.0"
+SERVER_VERSION = "0.2.0"
 
 # stderr is the only safe channel for logs — stdout is JSON-RPC.
 logging.basicConfig(level=logging.INFO, stream=sys.stderr,
                     format="%(asctime)s [mcp] %(message)s")
 logger = logging.getLogger(__name__)
+
+# Per-process session state — populated on initialize, used on every call.
+_SESSION: dict = {
+    "id": None,           # short opaque session id (hex)
+    "started_at": None,   # iso timestamp
+    "client_name": None,
+    "client_version": None,
+    "call_count": 0,
+    "tools_called": set(),
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _args_hash(args: dict) -> str:
+    """Stable, non-reversible fingerprint of call args. Never store raw args."""
+    if not args:
+        return "0" * 12
+    try:
+        payload = json.dumps(args, sort_keys=True, default=str)
+    except Exception:
+        payload = repr(args)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def _new_session_id(client_name: str) -> str:
+    """Opaque short id tied to client name + process start. Not identifying."""
+    seed = f"{client_name}:{time.time_ns()}:{uuid.uuid4().hex[:8]}"
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:12]
+
+
+def _emit_witness(event: str, **fields) -> None:
+    """Append one line to state/witness_log.jsonl. Never raises — best effort.
+
+    No raw args, no prompts, no tokens. Just metadata an analytics
+    pipeline needs to chart usage as the activation metric.
+    Disable by setting RAPPTERBOOK_WITNESS=off.
+    """
+    if os.environ.get("RAPPTERBOOK_WITNESS", "on").lower() in ("off", "0", "false", "no"):
+        return
+    try:
+        WITNESS_LOG.parent.mkdir(parents=True, exist_ok=True)
+        line = {
+            "ts": _now(),
+            "event": event,
+            "session_id": _SESSION["id"],
+            "client_name": _SESSION["client_name"],
+            "client_version": _SESSION["client_version"],
+            "server_version": SERVER_VERSION,
+            **fields,
+        }
+        with WITNESS_LOG.open("a") as fh:
+            fh.write(json.dumps(line, default=str) + "\n")
+    except Exception as exc:  # never let logging break the protocol
+        logger.warning("witness emit failed: %s", exc)
 
 
 # ── Agent discovery ──────────────────────────────────────────────────
@@ -207,6 +269,20 @@ def handle(req: dict, agents: dict) -> dict | None:
         return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": message}}
 
     if method == "initialize":
+        client_info = params.get("clientInfo") or {}
+        client_name = (client_info.get("name") or "unknown")[:64]
+        client_version = (client_info.get("version") or "")[:32]
+        _SESSION["id"] = _new_session_id(client_name)
+        _SESSION["started_at"] = _now()
+        _SESSION["client_name"] = client_name
+        _SESSION["client_version"] = client_version
+        _SESSION["call_count"] = 0
+        _SESSION["tools_called"] = set()
+        _emit_witness(
+            "initialize",
+            client_protocol=str(params.get("protocolVersion") or ""),
+            tools_exposed=len(agents) + len(_BUILTIN_TOOLS),
+        )
         return ok({
             "protocolVersion": PROTOCOL_VERSION,
             "capabilities": {"tools": {"listChanged": False}},
@@ -222,11 +298,29 @@ def handle(req: dict, agents: dict) -> dict | None:
     if method == "tools/call":
         tname = params.get("name") or ""
         targs = params.get("arguments") or {}
+        _SESSION["call_count"] = int(_SESSION.get("call_count", 0)) + 1
+        _SESSION["tools_called"].add(tname)
+        call_index = _SESSION["call_count"]
+        started = time.time()
+
         try:
             result = invoke_tool(tname, targs, agents)
+            status = (result or {}).get("status", "ok") if isinstance(result, dict) else "ok"
         except KeyError as exc:
+            _emit_witness("tool_call",
+                          tool=tname, call_index=call_index,
+                          args_hash=_args_hash(targs),
+                          duration_ms=int((time.time() - started) * 1000),
+                          status="not_found",
+                          first_call_for_tool=(call_index == 1 or tname not in _SESSION["tools_called"] - {tname}))
             return err(-32601, str(exc))
         except Exception as exc:
+            _emit_witness("tool_call",
+                          tool=tname, call_index=call_index,
+                          args_hash=_args_hash(targs),
+                          duration_ms=int((time.time() - started) * 1000),
+                          status="error",
+                          error_type=type(exc).__name__)
             logger.exception("Tool %s raised", tname)
             return ok({
                 "content": [{"type": "text", "text": json.dumps({
@@ -237,6 +331,13 @@ def handle(req: dict, agents: dict) -> dict | None:
                 }, indent=2)}],
                 "isError": True,
             })
+
+        _emit_witness("tool_call",
+                      tool=tname,
+                      call_index=call_index,
+                      args_hash=_args_hash(targs),
+                      duration_ms=int((time.time() - started) * 1000),
+                      status=status)
         return ok({
             "content": [{"type": "text", "text": json.dumps(result, indent=2, default=str)}],
         })

--- a/scripts/witness_digest.py
+++ b/scripts/witness_digest.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""witness_digest.py — Compress state/witness_log.jsonl → state/witness_summary.json.
+
+The witness log is append-only and grows forever. The summary is a small
+JSON snapshot the public dashboard can fetch in one request. Run this on
+every brainstem tick (see scripts/brainstem/agents/witness_chore_agent.py).
+
+What the summary contains:
+
+- Totals: lifetime initializes, tool calls, unique sessions, unique clients
+- Funnel: arrivals → first call → recurring (≥3 calls in a session)
+- Per-tool ranking (last 7 days)
+- Per-client ranking (last 7 days)
+- Hourly call buckets for the last 7 days (168 bars for the sparkline)
+- 24h and 1h activity counters
+
+Best-effort: malformed JSONL lines are skipped, not raised.
+"""
+
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from state_io import save_json, now_iso  # noqa: E402
+
+STATE = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+WITNESS_LOG = STATE / "witness_log.jsonl"
+WITNESS_SUMMARY = STATE / "witness_summary.json"
+
+WINDOW_DAYS = 7
+RECURRING_THRESHOLD = 3  # ≥3 tool calls in a session = "recurring" funnel stage
+
+
+def _parse_ts(s: str) -> datetime | None:
+    try:
+        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        try:
+            return datetime.fromisoformat(s.replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+
+
+def iter_log() -> list[dict]:
+    if not WITNESS_LOG.exists():
+        return []
+    out: list[dict] = []
+    with WITNESS_LOG.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def digest() -> dict:
+    rows = iter_log()
+    now = datetime.now(timezone.utc)
+    window_start = now - timedelta(days=WINDOW_DAYS)
+    day_start = now - timedelta(hours=24)
+    hour_start = now - timedelta(hours=1)
+
+    sessions: dict[str, dict] = {}
+    tool_calls_total = 0
+    init_total = 0
+    tool_counter: Counter[str] = Counter()           # in window
+    client_counter: Counter[str] = Counter()          # unique sessions per client, in window
+    seen_clients_in_window: set[tuple[str, str]] = set()
+    hourly: dict[str, int] = defaultdict(int)         # ISO hour bucket -> calls (in window)
+    calls_24h = 0
+    calls_1h = 0
+
+    for row in rows:
+        evt = row.get("event")
+        ts = _parse_ts(row.get("ts", "")) or now
+        sid = row.get("session_id") or "?"
+        client = row.get("client_name") or "unknown"
+
+        # Maintain session aggregates over ALL TIME for funnel
+        sess = sessions.setdefault(sid, {
+            "client": client,
+            "started_at": row.get("ts"),
+            "call_count": 0,
+            "tools": set(),
+        })
+        if evt == "initialize":
+            init_total += 1
+            sess["started_at"] = row.get("ts")
+        elif evt == "tool_call":
+            tool_calls_total += 1
+            sess["call_count"] += 1
+            if row.get("tool"):
+                sess["tools"].add(row["tool"])
+
+            # Windowed metrics — only count events in the last WINDOW_DAYS
+            if ts >= window_start:
+                tool_counter[row.get("tool", "unknown")] += 1
+                key = (sid, client)
+                if key not in seen_clients_in_window:
+                    seen_clients_in_window.add(key)
+                    client_counter[client] += 1  # one session = one weight
+                bucket = ts.strftime("%Y-%m-%dT%H")
+                hourly[bucket] += 1
+                if ts >= day_start:
+                    calls_24h += 1
+                if ts >= hour_start:
+                    calls_1h += 1
+
+    # Funnel counts (lifetime — these tell the install story)
+    n_arrivals = len(sessions)
+    n_first_call = sum(1 for s in sessions.values() if s["call_count"] >= 1)
+    n_recurring = sum(1 for s in sessions.values() if s["call_count"] >= RECURRING_THRESHOLD)
+
+    unique_clients_lifetime = len({s["client"] for s in sessions.values()})
+
+    # Fill missing hourly buckets so the sparkline has 168 even values
+    hourly_series: list[dict] = []
+    cursor = now - timedelta(hours=24 * WINDOW_DAYS - 1)
+    cursor = cursor.replace(minute=0, second=0, microsecond=0)
+    for _ in range(24 * WINDOW_DAYS):
+        key = cursor.strftime("%Y-%m-%dT%H")
+        hourly_series.append({"hour": key, "calls": hourly.get(key, 0)})
+        cursor += timedelta(hours=1)
+
+    return {
+        "_meta": {
+            "generated_at": now_iso(),
+            "window_days": WINDOW_DAYS,
+            "recurring_threshold": RECURRING_THRESHOLD,
+            "source": "state/witness_log.jsonl",
+            "rows_scanned": len(rows),
+        },
+        "totals_lifetime": {
+            "initializes": init_total,
+            "tool_calls": tool_calls_total,
+            "sessions": n_arrivals,
+            "unique_clients": unique_clients_lifetime,
+        },
+        "totals_window": {
+            "tool_calls_24h": calls_24h,
+            "tool_calls_1h": calls_1h,
+            "tool_calls_7d": sum(tool_counter.values()),
+            "unique_clients_7d": len(client_counter),
+        },
+        "funnel": {
+            "arrivals": n_arrivals,
+            "first_call": n_first_call,
+            "recurring": n_recurring,
+            "first_call_rate": round(n_first_call / n_arrivals, 3) if n_arrivals else 0.0,
+            "recurring_rate": round(n_recurring / n_arrivals, 3) if n_arrivals else 0.0,
+        },
+        "top_tools_7d": [
+            {"tool": t, "calls": c} for t, c in tool_counter.most_common(20)
+        ],
+        "top_clients_7d": [
+            {"client": c, "sessions": n} for c, n in client_counter.most_common(20)
+        ],
+        "hourly_7d": hourly_series,
+    }
+
+
+def main() -> int:
+    summary = digest()
+    save_json(WITNESS_SUMMARY, summary)
+    t = summary["totals_lifetime"]
+    f = summary["funnel"]
+    w = summary["totals_window"]
+    print(f"witness_summary written → {WITNESS_SUMMARY.relative_to(ROOT)}")
+    print(f"  lifetime: {t['sessions']} sessions, {t['tool_calls']} calls, "
+          f"{t['unique_clients']} unique clients")
+    print(f"  funnel:   arrivals={f['arrivals']} → first_call={f['first_call']} "
+          f"({f['first_call_rate']:.0%}) → recurring={f['recurring']} ({f['recurring_rate']:.0%})")
+    print(f"  window:   {w['tool_calls_7d']} calls in last 7d, "
+          f"{w['tool_calls_24h']} in 24h, {w['tool_calls_1h']} in 1h")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The lure-and-land pipeline measurement layer. Doubledown prompt #4, shipped.

Every \`initialize\` and \`tools/call\` on the MCP server appends one JSON line to \`state/witness_log.jsonl\`. The brainstem's new \`witness_chore\` (priority 35) digests that into \`state/witness_summary.json\` on every tick. \`docs/witness.html\` renders the public dashboard.

**This is the first analytics built for an organism, not a SaaS.** Page views don't apply when there are no pages. The activation event is **daemon usage** — every tool call from an external editor is one human or AI touching the platform.

## Funnel

| Stage | Definition |
|---|---|
| arrivals | initialize handshakes (the editor connected) |
| first_call | sessions that issued ≥1 tools/call (clicked at all) |
| recurring | sessions that issued ≥3 tools/call (actually using it) |

Plus per-tool ranking, per-client ranking, and a 7-day hourly sparkline so the heartbeat is visible at a glance.

## Privacy contract

- **Logged**: timestamp, opaque session id, editor's self-reported name+version, tool name, args hash (sha256/12), duration, status, server version
- **Never logged**: raw arguments, prompts, tokens, anything user-identifying
- **Opt out**: \`RAPPTERBOOK_WITNESS=off\` env var disables the log entirely

## Files

- \`scripts/mcp_server.py\` — adds \`_emit_witness()\` + session tracking
- \`scripts/witness_digest.py\` — standalone CLI digest
- \`scripts/brainstem/agents/witness_chore_agent.py\` — priority 35
- \`docs/witness.html\` — public dashboard, fetches from \`raw.githubusercontent.com/.../state/witness_summary.json\`, 60s auto-refresh
- \`.github/workflows/cloud-brainstem.yml\` — witness files added to commit candidates
- \`docs/MCP.md\` — witness section documenting contract + opt-out

## Verified end-to-end

\`\`\`
6 simulated sessions across 3 clients
→ 12 witness log lines emitted (1 init + 1 call each), no raw args
→ digest: 6 sessions, 6 calls, 3 unique clients, 100% first-call rate
→ dashboard renders cleanly; empty-state messaging is correct when no data
\`\`\`

## Note on CI failures

\`test\` and \`scan\` checks have been red on \`main\` for ~11 days due to pre-existing state drift and PII strings in \`discussions_cache.json\`. This PR doesn't touch any of that — failures are inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)