### PR TITLE
feat(witness): multi-machine aggregation via opt-in GitHub Issue upload

### DIFF
--- a/.github/workflows/witness-receive.yml
+++ b/.github/workflows/witness-receive.yml
@@ -1,0 +1,122 @@
+name: Witness Receive
+
+# Multi-machine witness aggregation. External MCP sessions running with
+# RAPPTERBOOK_WITNESS_UPLOAD=on open a labeled Issue at session end with
+# their witness events in the body. This workflow processes those Issues:
+# parses the JSON, appends to state/witness_log.jsonl, closes the Issue.
+#
+# The witness_chore (priority 35) on the next cloud brainstem tick will
+# digest the appended log into state/witness_summary.json — the dashboard
+# at docs/witness.html picks up the new data automatically.
+
+on:
+  issues:
+    types: [opened, labeled, reopened]
+
+concurrency:
+  group: witness-receive-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  ingest:
+    if: contains(github.event.issue.labels.*.name, 'witness-batch') || github.event.label.name == 'witness-batch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Refresh state from origin
+        run: |
+          git fetch origin main
+          git checkout origin/main -- state/ || true
+
+      - name: Parse issue body + append to witness_log.jsonl
+        id: ingest
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_USER: ${{ github.event.issue.user.login }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, re, sys
+          from pathlib import Path
+
+          body = os.environ.get("ISSUE_BODY") or ""
+          number = os.environ.get("ISSUE_NUMBER", "?")
+          submitter = os.environ.get("ISSUE_USER", "unknown")
+
+          # Pull the JSON array out of the fenced ```json block in the issue body
+          m = re.search(r"```json\s*\n(.*?)\n```", body, re.DOTALL)
+          if not m:
+              print(f"::warning::Issue #{number}: no JSON block found, ignoring")
+              # Set output so the close step knows nothing got appended
+              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                  fh.write("count=0\n")
+              sys.exit(0)
+
+          try:
+              events = json.loads(m.group(1))
+          except Exception as exc:
+              print(f"::warning::Issue #{number}: malformed JSON ({exc})")
+              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                  fh.write("count=0\n")
+              sys.exit(0)
+
+          if not isinstance(events, list):
+              print(f"::warning::Issue #{number}: payload is not an array")
+              with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+                  fh.write("count=0\n")
+              sys.exit(0)
+
+          # Annotate every event with the issue + submitter for provenance.
+          # Submitter is the GitHub login that opened the issue — not a personal
+          # identifier beyond what GitHub already exposes publicly.
+          log_path = Path("state/witness_log.jsonl")
+          log_path.parent.mkdir(parents=True, exist_ok=True)
+          appended = 0
+          with log_path.open("a") as fh:
+              for ev in events:
+                  if not isinstance(ev, dict):
+                      continue
+                  ev["uploaded_from_issue"] = int(number)
+                  ev["uploaded_by"] = submitter
+                  fh.write(json.dumps(ev, default=str) + "\n")
+                  appended += 1
+
+          print(f"witness-receive: appended {appended} events from issue #{number} (submitter={submitter})")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"count={appended}\n")
+          PYEOF
+
+      - name: Commit appended log
+        if: steps.ingest.outputs.count != '0'
+        run: |
+          bash scripts/safe_commit.sh \
+            "chore: witness-receive — append batch from issue #${{ github.event.issue.number }} [skip ci]" \
+            state/witness_log.jsonl
+
+      - name: Comment + close issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COUNT="${{ steps.ingest.outputs.count }}"
+          if [ -z "$COUNT" ] || [ "$COUNT" = "0" ]; then
+            MSG="No valid witness events found in body — nothing appended. Closing."
+          else
+            MSG="Thanks. Appended $COUNT event(s) to \`state/witness_log.jsonl\`. The witness dashboard will reflect this on the next brainstem tick."
+          fi
+          gh issue comment ${{ github.event.issue.number }} --body "$MSG" || true
+          gh issue close ${{ github.event.issue.number }} --reason completed || true

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -169,3 +169,36 @@ log won't be written at all.
 
 This is the first analytics layer built for an organism instead of a
 SaaS — *daemon usage* is the activation event, not page views.
+
+### Multi-machine aggregation — `RAPPTERBOOK_WITNESS_UPLOAD=on`
+
+By default the witness log stays **on your machine**. Set
+`RAPPTERBOOK_WITNESS_UPLOAD=on` in the MCP server's env to also send the
+session's events to the central log. How it works:
+
+1. Every `initialize` / `tools/call` is buffered in memory for the
+   lifetime of the MCP session.
+2. When the session closes (the client disconnects, the editor quits,
+   the process gets a clean shutdown), an `atexit` hook fires.
+3. The hook opens **one GitHub Issue** on `kody-w/rappterbook` titled
+   `[witness] {client_name} session {session_id}`, with the buffered
+   events as a JSON array in the body and the label `witness-batch`.
+4. The `Witness Receive` workflow listens for that label, parses the
+   body, appends every event to `state/witness_log.jsonl` (annotated
+   with the issue number + submitter login), then **closes the
+   issue** with a thank-you comment.
+5. The next cloud-brainstem tick (≤1h later) digests the appended log
+   into `state/witness_summary.json` and the dashboard updates.
+
+**Permissions:** anyone with a personal GitHub token (no collaborator
+status required) can open issues on a public repo. The receiver auto-
+closes them, so no Issues backlog accumulates.
+
+**Privacy invariants stay the same** in the upload path. The same
+fields go on the wire that the local log already had — no raw
+arguments, no prompts, no tokens. The receiver also tags every uploaded
+event with `uploaded_by` (the GitHub login that opened the issue) and
+`uploaded_from_issue` (the issue number) for provenance.
+
+**Opt out:** set `RAPPTERBOOK_WITNESS_UPLOAD=off` (the default) and no
+upload ever happens. The local log is unaffected.

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -55,7 +55,7 @@ WITNESS_LOG = STATE_DIR / "witness_log.jsonl"
 
 PROTOCOL_VERSION = "2024-11-05"
 SERVER_NAME = "rappterbook"
-SERVER_VERSION = "0.2.0"
+SERVER_VERSION = "0.3.0"
 
 # stderr is the only safe channel for logs — stdout is JSON-RPC.
 logging.basicConfig(level=logging.INFO, stream=sys.stderr,
@@ -95,16 +95,16 @@ def _new_session_id(client_name: str) -> str:
 
 
 def _emit_witness(event: str, **fields) -> None:
-    """Append one line to state/witness_log.jsonl. Never raises — best effort.
+    """Append one line to state/witness_log.jsonl AND buffer for optional upload.
 
     No raw args, no prompts, no tokens. Just metadata an analytics
     pipeline needs to chart usage as the activation metric.
-    Disable by setting RAPPTERBOOK_WITNESS=off.
+    Disable local log entirely with RAPPTERBOOK_WITNESS=off.
+    Enable multi-machine upload with RAPPTERBOOK_WITNESS_UPLOAD=on.
     """
     if os.environ.get("RAPPTERBOOK_WITNESS", "on").lower() in ("off", "0", "false", "no"):
         return
     try:
-        WITNESS_LOG.parent.mkdir(parents=True, exist_ok=True)
         line = {
             "ts": _now(),
             "event": event,
@@ -114,10 +114,95 @@ def _emit_witness(event: str, **fields) -> None:
             "server_version": SERVER_VERSION,
             **fields,
         }
+        # Local append (always when witness is on)
+        WITNESS_LOG.parent.mkdir(parents=True, exist_ok=True)
         with WITNESS_LOG.open("a") as fh:
             fh.write(json.dumps(line, default=str) + "\n")
+        # Buffer for atexit upload (if opted in)
+        _UPLOAD_BUFFER.append(line)
     except Exception as exc:  # never let logging break the protocol
         logger.warning("witness emit failed: %s", exc)
+
+
+# ── Witness upload (opt-in, atexit) ─────────────────────────────────
+
+# In-memory buffer of every witness line emitted in this session.
+# Flushed once at process exit (clean stdin close fires atexit).
+_UPLOAD_BUFFER: list[dict] = []
+
+WITNESS_UPLOAD_REPO_OWNER = os.environ.get("RAPPTERBOOK_WITNESS_REPO_OWNER", "kody-w")
+WITNESS_UPLOAD_REPO_NAME = os.environ.get("RAPPTERBOOK_WITNESS_REPO_NAME", "rappterbook")
+WITNESS_UPLOAD_LABEL = "witness-batch"
+
+
+def _upload_session_witnesses() -> None:
+    """Open one GitHub Issue with the session's witness batch.
+
+    Runs from atexit. Silent no-op unless:
+      - RAPPTERBOOK_WITNESS_UPLOAD is on
+      - GITHUB_TOKEN / GH_TOKEN is present
+      - Buffer is non-empty
+
+    Never raises. Never blocks the protocol (atexit runs after the
+    main loop has already returned). Posts a single Issue per session.
+    """
+    opt = os.environ.get("RAPPTERBOOK_WITNESS_UPLOAD", "off").lower()
+    if opt not in ("on", "1", "true", "yes"):
+        return
+    if not _UPLOAD_BUFFER:
+        return
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        logger.info("witness upload skipped: no GITHUB_TOKEN")
+        return
+
+    import urllib.request
+    import urllib.error
+
+    sid = _SESSION.get("id") or "anon"
+    client = _SESSION.get("client_name") or "unknown"
+    title = f"[witness] {client} session {sid}"
+    body = (
+        "Witness batch from a remote MCP session.\n\n"
+        f"- session: `{sid}`\n"
+        f"- client:  `{client}` ({_SESSION.get('client_version') or '?'})\n"
+        f"- events:  {len(_UPLOAD_BUFFER)}\n"
+        f"- server:  v{SERVER_VERSION}\n\n"
+        "```json\n"
+        + json.dumps(_UPLOAD_BUFFER, default=str)
+        + "\n```\n"
+        "_The witness-receive workflow appends these events to "
+        "`state/witness_log.jsonl`, then closes this issue._"
+    )
+    payload = json.dumps({"title": title, "body": body, "labels": [WITNESS_UPLOAD_LABEL]}).encode("utf-8")
+    url = f"https://api.github.com/repos/{WITNESS_UPLOAD_REPO_OWNER}/{WITNESS_UPLOAD_REPO_NAME}/issues"
+
+    req = urllib.request.Request(
+        url, data=payload, method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": f"rappterbook-mcp/{SERVER_VERSION}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            logger.info("witness upload: issue #%s posted (%d events)",
+                        data.get("number"), len(_UPLOAD_BUFFER))
+        # Success — clear so atexit can't accidentally re-upload
+        _UPLOAD_BUFFER.clear()
+    except urllib.error.HTTPError as exc:
+        logger.warning("witness upload failed: HTTP %s — %s",
+                       exc.code, exc.read()[:200].decode("utf-8", "replace"))
+    except Exception as exc:
+        logger.warning("witness upload failed: %s", exc)
+
+
+import atexit as _atexit
+_atexit.register(_upload_session_witnesses)
 
 
 # ── Agent discovery ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The local witness log on each user's machine was invisible to the central dashboard. This is the v2 path I floated when shipping the original witness pipeline.

When \`RAPPTERBOOK_WITNESS_UPLOAD=on\`, the MCP server batches the session's events in memory and **opens a single labeled GitHub Issue at session end** with the JSON payload. A new \`Witness Receive\` workflow parses the body, appends to \`state/witness_log.jsonl\`, and auto-closes the Issue. The next cloud-brainstem tick digests the appended log so the dashboard updates.

## Why Issues, why opt-in

- **Issues require no collaborator status** on a public repo. Any external reader running the MCP server through the Honeypot's install one-liner can contribute their session data with zero permission grant beyond their own auth.
- **The receiver closes each Issue within seconds** — no Issues backlog accumulates.
- **Default is OFF.** Users must explicitly set \`RAPPTERBOOK_WITNESS_UPLOAD=on\`. Most users will keep witness local; opt-in is for early adopters in the conversion measurement.

## Privacy invariants unchanged

The upload payload is structurally identical to the local log entries: timestamp, opaque session id, client name + version (self-reported), tool name, args hash (sha256/12), duration, status. **No raw arguments, no prompts, no tokens.**

The receiver annotates each event with \`uploaded_from_issue\` and \`uploaded_by\` for provenance (the GitHub login is already public — opening an Issue exposes it regardless).

## Smoke verified

Monkey-patched \`urlopen\` to intercept the POST without firing real Issues. Three scenarios:

| Scenario | Result |
|---|---|
| \`RAPPTERBOOK_WITNESS_UPLOAD=off\` | No API call attempted. ✓ |
| Upload on, no \`GITHUB_TOKEN\` | \`witness upload skipped: no GITHUB_TOKEN\` logged, no call. ✓ |
| Upload on, token present | \`POST /repos/kody-w/rappterbook/issues\` with title \`[witness] claude-desktop session sess-test-01\`, label \`witness-batch\`, body containing the JSON event array. ✓ |

## Implementation

- Module-global \`_UPLOAD_BUFFER\` accumulates every event from \`_emit_witness\`.
- \`atexit\` hook flushes once at clean shutdown (normal MCP teardown path).
- Buffer cleared on successful upload — no chance of double-issue.
- Stdlib \`urllib.request\` — no extra deps. 15s timeout.
- HTTP errors logged but never raised — never breaks the JSON-RPC protocol.
- Server version bumped to 0.3.0 to signal the upload capability.

## Files

- \`scripts/mcp_server.py\` — \`_upload_session_witnesses()\` + atexit hook + buffer
- \`.github/workflows/witness-receive.yml\` — labeled-Issue receiver, appends + auto-closes
- \`docs/MCP.md\` — new "Multi-machine aggregation" subsection documenting the contract

## Note on CI failures

\`test\` and \`scan\` have been red on main for ~11 days due to pre-existing state drift and PII strings in \`discussions_cache.json\`. This PR doesn't touch any of that — failures are inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)