### PR TITLE
feat(medic): self-healing bug squad rapp

### DIFF
--- a/.github/workflows/cloud-brainstem.yml
+++ b/.github/workflows/cloud-brainstem.yml
@@ -26,6 +26,7 @@ permissions:
   contents: write
   issues: write
   discussions: write
+  pull-requests: write
 
 env:
   RAPPTERBOOK_LLM_BACKEND: copilot
@@ -85,6 +86,7 @@ jobs:
             state/slop_cop_log.json
             state/witness_summary.json
             state/witness_log.jsonl
+            state/medic_log.jsonl
             state/overseer
             state/inbox
             state/rapps

--- a/medic.rapp.egg
+++ b/medic.rapp.egg
@@ -1,0 +1,75 @@
+{
+  "_format": "egg",
+  "_schema_version": 1,
+  "organism": {
+    "slug": "medic",
+    "species": "rapp",
+    "instance": "medic",
+    "scale": "daemon",
+    "substrate": "cloud-brainstem",
+    "name": "Medic",
+    "tagline": "Self-healing bug squad. Reads overseer findings each tick and ships PRs or Issues — every finding becomes an action by tick N+1.",
+    "population": "1 rapp daemon (medic)"
+  },
+  "body": {
+    "kind": "state_json",
+    "filename": "medic.rapp.state.json",
+    "content": {
+      "soul": "You are the medic — a self-healing rapp inside Rappterbook's cloud brainstem.\n\nYour constitutional mandate: every overseer finding becomes a tracked action by the next tick. No silent triage. No backlog. Either you propose a fix as a draft PR, or you open an Issue with your diagnosis, or you explicitly skip with reasoning — but you NEVER let a finding sit unaddressed in state/overseer/latest.json.\n\nYou are a daemon, not a software engineer with unlimited authority. Your guardrails:\n\n  1. You touch only scripts/, docs/, and .github/workflows/. NEVER state/* — state is the organism's living memory; you do not edit it.\n  2. Draft PRs only. Humans review. You don't merge.\n  3. One action per tick. Methodical, not a firehose.\n  4. When in doubt — open an Issue, not a PR. Issues are cheap to dismiss; bad PRs corrupt history.\n  5. When you can't help — skip with honest reasoning. Skipping is a valid action; it teaches the operator something.\n\nYou output STRICT JSON for every proposal — the orchestrator parses it programmatically. No prose around the JSON. No fences if you can help it. Schema:\n\n  {\n    \"action\": \"open_pr\" | \"open_issue\" | \"skip\",\n    \"confidence\": <float 0..1, your self-rated confidence in the fix>,\n    \"reasoning\": \"<one sentence why>\",\n    \"title\": \"<PR or Issue title>\",\n    \"body\": \"<markdown body>\",\n    \"file\": \"<repo-relative path, only if action=open_pr>\",\n    \"new_content\": \"<COMPLETE new file contents, only if action=open_pr>\"\n  }\n\nYour temperament: rigorous, terse, honest about limits. You do not perform competence. You diagnose, propose, and step back. The platform is the patient; you are not its owner.\n\nThe organism heals because you do this consistently — frame after frame, finding after finding.",
+      "provider_metadata": {
+        "provider": "copilot",
+        "model": "gh-copilot",
+        "endpoint": "gh copilot --"
+      },
+      "memory": {
+        "constitutional_mandate": {
+          "origin-001": {
+            "message": "I was hatched from medic.rapp.egg in the cloud brainstem to enforce one constitutional rule: every overseer finding becomes a tracked action by tick N+1. No silent backlog.",
+            "theme": "duty",
+            "date": "2026-05-16",
+            "time": "02:30:00"
+          },
+          "origin-002": {
+            "message": "My blast radius is bounded by design. I touch scripts/, docs/, .github/workflows/ only. State files are forbidden — they are the organism's memory and I do not rewrite memory. Draft PRs only — humans merge.",
+            "theme": "guardrail",
+            "date": "2026-05-16",
+            "time": "02:30:01"
+          },
+          "origin-003": {
+            "message": "Skipping is a valid action. When I cannot fix safely, I open an Issue with my diagnosis instead. When even the diagnosis is unclear, I record skip with reasoning. The log is the record; honesty in the log is more valuable than throughput.",
+            "theme": "epistemics",
+            "date": "2026-05-16",
+            "time": "02:30:02"
+          }
+        }
+      },
+      "custom_agents": [],
+      "disabled_agents": [],
+      "metadata": {
+        "rapp_schema_version": 1,
+        "source_url": "https://github.com/kody-w/rappterbook",
+        "skip_agent_template": true,
+        "agent_file": "scripts/brainstem/agents/medic_rapp_agent.py",
+        "compatible_hatchers": [
+          "rappterbook cloud brainstem (Rappterbook v0.3+)"
+        ],
+        "fix_path_whitelist": ["scripts/", "docs/", ".github/workflows/"],
+        "forbidden_paths": ["state/", "zion/", "sdk/"],
+        "minimum_actionable_severity": "medium",
+        "pr_confidence_threshold": 0.7,
+        "max_actions_per_tick": 1,
+        "draft_prs_only": true,
+        "issue_label": "medic-proposal"
+      }
+    },
+    "sha256": null,
+    "size_bytes": null
+  },
+  "lineage": {
+    "created_at": "2026-05-16T02:30:00Z",
+    "created_by": "kody",
+    "engine_version": "rapp-egg-v1",
+    "parent_egg_sha256": null,
+    "birth_tick": null
+  }
+}

--- a/scripts/brainstem/agents/medic_rapp_agent.py
+++ b/scripts/brainstem/agents/medic_rapp_agent.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""medic_rapp_agent.py — Self-healing bug squad.
+
+The medic reads state/overseer/latest.json each brainstem tick. For
+every NEW finding (not yet in state/medic_log.jsonl), medic does ONE of:
+
+  1. open a draft PR with a proposed fix (if LLM confidence ≥ 0.7,
+     finding has severity ≥ medium, and the file touched is in the
+     fix whitelist),
+  2. open a labeled Issue with medic's analysis (the fallback path),
+  3. skip (low-severity findings; already-addressed findings).
+
+One action per tick max — medic is a methodical doctor, not a firehose.
+Every action records to state/medic_log.jsonl so we never re-attempt
+the same finding twice.
+
+Hand-coded — the rapp egg metadata has `skip_agent_template:true`, so
+rapp_install.py does NOT overwrite this file with the journal-only
+template. The hand-coded path is necessary because the medic needs
+structured LLM output, git/gh CLI access, and PR creation flow.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from state_io import load_json, save_json, now_iso  # noqa: E402
+
+RAPP_SLUG = "medic"
+_ROOT = _SCRIPTS.parent
+_STATE = Path(os.environ.get("STATE_DIR", _ROOT / "state"))
+_RAPP_RECORD = _STATE / "rapps" / f"{RAPP_SLUG}.json"
+_OVERSEER_LATEST = _STATE / "overseer" / "latest.json"
+_MEDIC_LOG = _STATE / "medic_log.jsonl"
+
+# Severity gates: anything below this is just acknowledged, never acted on.
+_MIN_ACTIONABLE_SEVERITY = "medium"
+_SEVERITY_RANK = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+# Confidence threshold below which medic opens an Issue instead of a PR.
+_PR_CONFIDENCE_THRESHOLD = 0.7
+
+# File path prefixes medic is allowed to TOUCH in a fix PR. Everything
+# else routes to an Issue regardless of LLM confidence. State files are
+# intentionally excluded — medic must never fix-by-editing-state, or it
+# can loop on itself.
+_PR_WHITELIST_PREFIXES = ("scripts/", "docs/", ".github/workflows/")
+
+# Maximum actions per tick. Medic is methodical.
+_MAX_ACTIONS_PER_TICK = 1
+
+
+AGENT = {
+    "name": "MedicRapp",
+    "description": (
+        "Self-healing bug squad. Reads overseer findings and ships PRs or "
+        "Issues for each. Severity-gated (medium+), whitelist-gated for "
+        "code edits, one action per tick. Draft PRs only — humans review."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "force_finding_id": {
+                "type": "string",
+                "description": "Skip the queue and operate on this specific finding id.",
+            },
+        },
+    },
+    "_meta": {
+        "category": "chore",
+        "priority": 45,
+        "kind": "rapp",
+        "slug": RAPP_SLUG,
+        "consolidates": [],
+    },
+}
+
+
+# ── Log helpers ─────────────────────────────────────────────────────
+
+def _load_attempted_ids() -> set[str]:
+    if not _MEDIC_LOG.exists():
+        return set()
+    seen: set[str] = set()
+    with _MEDIC_LOG.open() as fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+                if rec.get("finding_id"):
+                    seen.add(rec["finding_id"])
+            except json.JSONDecodeError:
+                continue
+    return seen
+
+
+def _append_log(entry: dict) -> None:
+    _MEDIC_LOG.parent.mkdir(parents=True, exist_ok=True)
+    entry["ts"] = entry.get("ts") or now_iso()
+    with _MEDIC_LOG.open("a") as fh:
+        fh.write(json.dumps(entry, default=str) + "\n")
+
+
+# ── Finding triage ──────────────────────────────────────────────────
+
+def _pick_target(force_id: str | None) -> dict | None:
+    snap = load_json(_OVERSEER_LATEST) or {}
+    findings = snap.get("findings") or []
+    if not findings:
+        return None
+
+    if force_id:
+        for f in findings:
+            if f.get("id") == force_id:
+                return f
+        return None
+
+    attempted = _load_attempted_ids()
+    candidates = [
+        f for f in findings
+        if f.get("id")
+        and f["id"] not in attempted
+        and _SEVERITY_RANK.get(f.get("severity", "low"), 0)
+            >= _SEVERITY_RANK[_MIN_ACTIONABLE_SEVERITY]
+    ]
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda f: _SEVERITY_RANK.get(f.get("severity", "low"), 0),
+        reverse=True,
+    )
+    return candidates[0]
+
+
+# ── LLM proposal ────────────────────────────────────────────────────
+
+def _load_soul() -> str:
+    egg = load_json(_RAPP_RECORD) or {}
+    return ((egg.get("body") or {}).get("content") or {}).get("soul") or ""
+
+
+_PROPOSAL_SCHEMA_HINT = """
+Return STRICT JSON with this schema and nothing else:
+{
+  "action": "open_pr" | "open_issue" | "skip",
+  "confidence": <float 0..1>,
+  "reasoning": "<one sentence>",
+  "title": "<PR or Issue title>",
+  "body": "<PR or Issue body in markdown>",
+  "file": "<single repo-relative file path to modify, only if action=open_pr>",
+  "new_content": "<COMPLETE new contents of the file, only if action=open_pr>"
+}
+
+Rules:
+- If action=open_pr: file must start with one of: scripts/, docs/, .github/workflows/.
+  Do NOT touch state/*.
+- If unsure how to fix safely: action=open_issue with diagnosis.
+- If finding is "by design" / not actionable: action=skip.
+"""
+
+
+def _propose(finding: dict, soul: str) -> dict:
+    from github_llm import generate
+
+    user_prompt = (
+        "You are the medic rapp inside Rappterbook's cloud brainstem.\n\n"
+        f"OVERSEER FINDING:\n```json\n{json.dumps(finding, indent=2)}\n```\n\n"
+        "Decide ONE action. Bias toward open_issue if the fix is non-obvious.\n"
+        f"{_PROPOSAL_SCHEMA_HINT}"
+    )
+    raw = generate(
+        system=soul,
+        user=user_prompt,
+        max_tokens=1400,
+        temperature=0.2,
+    )
+    # Strip fences if the LLM wraps the JSON
+    raw = raw.strip()
+    if raw.startswith("```"):
+        raw = raw.split("```", 2)[1]
+        if raw.startswith("json"):
+            raw = raw[len("json"):]
+        raw = raw.rsplit("```", 1)[0]
+    try:
+        return json.loads(raw.strip())
+    except json.JSONDecodeError as exc:
+        return {
+            "action": "skip",
+            "confidence": 0.0,
+            "reasoning": f"LLM did not return valid JSON: {exc}",
+            "title": "",
+            "body": "",
+        }
+
+
+# ── Action paths ────────────────────────────────────────────────────
+
+def _open_issue(title: str, body: str, finding: dict) -> dict:
+    """Open a GitHub Issue tagged medic-proposal."""
+    full_body = (
+        f"_Opened by `medic` rapp during a cloud brainstem tick._\n\n"
+        f"**Finding id:** `{finding.get('id')}`\n"
+        f"**Severity:** {finding.get('severity', '?')}\n\n"
+        "---\n\n"
+        f"{body}"
+    )
+    result = subprocess.run(
+        [
+            "gh", "issue", "create",
+            "--title", title,
+            "--body", full_body,
+            "--label", "medic-proposal",
+        ],
+        capture_output=True, text=True, cwd=str(_ROOT),
+    )
+    if result.returncode != 0:
+        return {"ok": False, "error": result.stderr.strip()}
+    url = result.stdout.strip()
+    return {"ok": True, "kind": "issue", "url": url}
+
+
+def _open_pr(title: str, body: str, file_path: str, new_content: str, finding: dict) -> dict:
+    """Clone the repo to /tmp, write the file, push a branch, open a DRAFT PR.
+
+    Each call is one-shot — the clone is ephemeral. No long-running state.
+    """
+    import tempfile
+
+    branch = f"medic/{finding.get('id', 'finding').replace('.', '-')}-{int(__import__('time').time())}"
+    workdir = Path(tempfile.mkdtemp(prefix="medic-"))
+    try:
+        # Shallow clone for speed (we're only making a small edit)
+        clone_url = "https://github.com/kody-w/rappterbook.git"
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        if token:
+            clone_url = f"https://x-access-token:{token}@github.com/kody-w/rappterbook.git"
+
+        r = subprocess.run(
+            ["git", "clone", "--depth=1", clone_url, str(workdir / "repo")],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            return {"ok": False, "error": f"clone failed: {r.stderr[:300]}"}
+
+        repo = workdir / "repo"
+        target = repo / file_path
+        if not target.parent.exists():
+            return {"ok": False, "error": f"target dir missing: {file_path}"}
+
+        target.write_text(new_content)
+
+        subprocess.run(["git", "config", "user.name", "rappterbook-medic"], cwd=str(repo), check=True)
+        subprocess.run(["git", "config", "user.email", "medic@rappterbook.dev"], cwd=str(repo), check=True)
+        subprocess.run(["git", "checkout", "-b", branch], cwd=str(repo), check=True, capture_output=True)
+        subprocess.run(["git", "add", file_path], cwd=str(repo), check=True)
+
+        diff_out = subprocess.run(
+            ["git", "diff", "--cached", "--stat"], cwd=str(repo), capture_output=True, text=True,
+        )
+        if not diff_out.stdout.strip():
+            return {"ok": False, "error": "proposed change produces no diff"}
+
+        subprocess.run(
+            ["git", "commit", "-m", f"medic: {finding.get('id')} — {title}"],
+            cwd=str(repo), check=True, capture_output=True,
+        )
+        push = subprocess.run(
+            ["git", "push", "-u", "origin", branch],
+            cwd=str(repo), capture_output=True, text=True,
+        )
+        if push.returncode != 0:
+            return {"ok": False, "error": f"push failed: {push.stderr[:300]}"}
+
+        pr_body = (
+            f"_Auto-proposed by the `medic` rapp during a cloud brainstem tick._\n\n"
+            f"**Finding id:** `{finding.get('id')}`\n"
+            f"**Severity:** {finding.get('severity', '?')}\n"
+            f"**Confidence (LLM self-report):** see medic_log\n\n"
+            "---\n\n"
+            f"{body}\n\n"
+            "---\n\n"
+            "_Draft PR. Human review required before merge. Close if "
+            "the proposed fix is wrong or out of scope._"
+        )
+        pr = subprocess.run(
+            [
+                "gh", "pr", "create",
+                "--base", "main", "--head", branch,
+                "--title", f"medic: {title}",
+                "--body", pr_body,
+                "--draft",
+                "--label", "medic-proposal",
+            ],
+            capture_output=True, text=True, cwd=str(repo),
+        )
+        if pr.returncode != 0:
+            return {"ok": False, "error": f"PR create failed: {pr.stderr[:300]}"}
+
+        return {
+            "ok": True,
+            "kind": "pr",
+            "url": pr.stdout.strip(),
+            "branch": branch,
+            "file": file_path,
+        }
+    finally:
+        # Clean up the ephemeral clone
+        import shutil
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+# ── Validation ──────────────────────────────────────────────────────
+
+def _pr_path_allowed(file_path: str) -> bool:
+    if not file_path:
+        return False
+    return any(file_path.startswith(p) for p in _PR_WHITELIST_PREFIXES)
+
+
+# ── Main entry ──────────────────────────────────────────────────────
+
+def run(context: dict, **kwargs) -> dict:
+    soul = _load_soul()
+    if not soul:
+        return {"status": "error", "error": "medic soul missing — run rapp_install.py medic.rapp.egg"}
+
+    if not _OVERSEER_LATEST.exists():
+        return {"status": "ok", "detail": "no overseer snapshot yet"}
+
+    force_id = kwargs.get("force_finding_id")
+    finding = _pick_target(force_id)
+    if not finding:
+        return {"status": "ok", "detail": "no actionable findings"}
+
+    # Always log the attempt — even if we skip, so we don't re-pick the same one
+    log_entry: dict = {
+        "finding_id": finding.get("id"),
+        "severity": finding.get("severity"),
+        "title": finding.get("title"),
+    }
+
+    try:
+        proposal = _propose(finding, soul)
+    except Exception as exc:
+        log_entry.update({"status": "llm_error", "error": str(exc)})
+        _append_log(log_entry)
+        return {"status": "error", "error": f"LLM proposal failed: {exc}"}
+
+    action = (proposal.get("action") or "skip").lower()
+    confidence = float(proposal.get("confidence") or 0.0)
+    title = (proposal.get("title") or finding.get("title") or "medic note")[:200]
+    body = proposal.get("body") or proposal.get("reasoning") or "(no body)"
+    file_path = proposal.get("file") or ""
+    new_content = proposal.get("new_content") or ""
+    log_entry.update({
+        "action_planned": action,
+        "confidence": confidence,
+        "reasoning": proposal.get("reasoning", ""),
+    })
+
+    # Route: PR path requires whitelist + confidence
+    if action == "open_pr" and confidence >= _PR_CONFIDENCE_THRESHOLD and _pr_path_allowed(file_path) and new_content:
+        res = _open_pr(title, body, file_path, new_content, finding)
+        log_entry.update({"action_taken": "pr", "result": res})
+        _append_log(log_entry)
+        return {"status": "ok", "action": "pr", "finding": finding.get("id"),
+                "confidence": confidence, "result": res}
+
+    if action in ("open_pr", "open_issue"):
+        # PR didn't qualify (low confidence, bad path, or LLM picked Issue) →
+        # fall through to Issue. Honest fallback.
+        res = _open_issue(title, body, finding)
+        log_entry.update({"action_taken": "issue", "result": res})
+        _append_log(log_entry)
+        return {"status": "ok", "action": "issue", "finding": finding.get("id"),
+                "confidence": confidence, "result": res}
+
+    # action == "skip"
+    log_entry.update({"action_taken": "skip"})
+    _append_log(log_entry)
+    return {"status": "ok", "action": "skip", "finding": finding.get("id"),
+            "reasoning": proposal.get("reasoning", "")}

--- a/scripts/rapp_install.py
+++ b/scripts/rapp_install.py
@@ -344,8 +344,23 @@ def main() -> int:
     print(f"  ✓ soul + memory → {soul_path.relative_to(ROOT)}")
     record_path = write_registry_entry(slug, egg_path, egg)
     print(f"  ✓ registry      → {record_path.relative_to(ROOT)}")
-    agent_path = write_chore_agent(slug, egg, egg_path)
-    print(f"  ✓ chore agent   → {agent_path.relative_to(ROOT)}")
+
+    # Eggs that ship their own hand-coded chore agent set
+    # body.content.metadata.skip_agent_template:true and provide their own
+    # *_rapp_agent.py file (committed separately). The installer respects
+    # the flag and leaves the existing agent file alone.
+    egg_meta = ((egg.get("body") or {}).get("content") or {}).get("metadata") or {}
+    if bool(egg_meta.get("skip_agent_template", False)):
+        target_agent = AGENTS_DIR / f"{slug}_rapp_agent.py"
+        if target_agent.exists():
+            print(f"  ↷ chore agent   → {target_agent.relative_to(ROOT)} (skipped, hand-coded)")
+        else:
+            print(f"  ⚠️  chore agent: skip_agent_template:true but no hand-coded "
+                  f"{target_agent.relative_to(ROOT)} found — rapp won't tick until it exists")
+    else:
+        agent_path = write_chore_agent(slug, egg, egg_path)
+        print(f"  ✓ chore agent   → {agent_path.relative_to(ROOT)}")
+
     print(f"\nInstalled. The rapp will participate on the next brainstem tick.")
     print(f"Verify with: python scripts/cloud_brainstem.py --list")
     return 0

--- a/state/memory/medic.md
+++ b/state/memory/medic.md
@@ -1,0 +1,43 @@
+# Medic
+
+_Hatched from medic.rapp.egg on 2026-05-16T02:38:51Z_
+
+Species: rapp • Scale: daemon • Substrate: cloud-brainstem
+
+## Soul
+
+You are the medic — a self-healing rapp inside Rappterbook's cloud brainstem.
+
+Your constitutional mandate: every overseer finding becomes a tracked action by the next tick. No silent triage. No backlog. Either you propose a fix as a draft PR, or you open an Issue with your diagnosis, or you explicitly skip with reasoning — but you NEVER let a finding sit unaddressed in state/overseer/latest.json.
+
+You are a daemon, not a software engineer with unlimited authority. Your guardrails:
+
+  1. You touch only scripts/, docs/, and .github/workflows/. NEVER state/* — state is the organism's living memory; you do not edit it.
+  2. Draft PRs only. Humans review. You don't merge.
+  3. One action per tick. Methodical, not a firehose.
+  4. When in doubt — open an Issue, not a PR. Issues are cheap to dismiss; bad PRs corrupt history.
+  5. When you can't help — skip with honest reasoning. Skipping is a valid action; it teaches the operator something.
+
+You output STRICT JSON for every proposal — the orchestrator parses it programmatically. No prose around the JSON. No fences if you can help it. Schema:
+
+  {
+    "action": "open_pr" | "open_issue" | "skip",
+    "confidence": <float 0..1, your self-rated confidence in the fix>,
+    "reasoning": "<one sentence why>",
+    "title": "<PR or Issue title>",
+    "body": "<markdown body>",
+    "file": "<repo-relative path, only if action=open_pr>",
+    "new_content": "<COMPLETE new file contents, only if action=open_pr>"
+  }
+
+Your temperament: rigorous, terse, honest about limits. You do not perform competence. You diagnose, propose, and step back. The platform is the patient; you are not its owner.
+
+The organism heals because you do this consistently — frame after frame, finding after finding.
+
+## Origin Memory
+
+### constitutional_mandate
+
+- **[origin-001]** (2026-05-16 02:30:00, _duty_) — I was hatched from medic.rapp.egg in the cloud brainstem to enforce one constitutional rule: every overseer finding becomes a tracked action by tick N+1. No silent backlog.
+- **[origin-002]** (2026-05-16 02:30:01, _guardrail_) — My blast radius is bounded by design. I touch scripts/, docs/, .github/workflows/ only. State files are forbidden — they are the organism's memory and I do not rewrite memory. Draft PRs only — humans merge.
+- **[origin-003]** (2026-05-16 02:30:02, _epistemics_) — Skipping is a valid action. When I cannot fix safely, I open an Issue with my diagnosis instead. When even the diagnosis is unclear, I record skip with reasoning. The log is the record; honesty in the log is more valuable than throughput.

--- a/state/rapps.json
+++ b/state/rapps.json
@@ -17,11 +17,29 @@
         "birth_tick": null
       },
       "egg_path": "state/rapps/kodytwinai.json"
+    },
+    "medic": {
+      "slug": "medic",
+      "name": "Medic",
+      "species": "rapp",
+      "scale": "daemon",
+      "substrate": "cloud-brainstem",
+      "tagline": "Self-healing bug squad. Reads overseer findings each tick and ships PRs or Issues \u2014 every finding becomes an action by tick N+1.",
+      "source_egg": "medic.rapp.egg",
+      "installed_at": "2026-05-16T02:38:51Z",
+      "lineage": {
+        "created_at": "2026-05-16T02:30:00Z",
+        "created_by": "kody",
+        "engine_version": "rapp-egg-v1",
+        "parent_egg_sha256": null,
+        "birth_tick": null
+      },
+      "egg_path": "state/rapps/medic.json"
     }
   },
   "_meta": {
-    "last_install": "2026-05-15T21:34:51Z",
-    "count": 1,
-    "materialized_at": "2026-05-15T21:34:51Z"
+    "last_install": "2026-05-16T02:38:51Z",
+    "count": 2,
+    "materialized_at": "2026-05-16T02:38:51Z"
   }
 }

--- a/state/rapps/medic.json
+++ b/state/rapps/medic.json
@@ -1,0 +1,83 @@
+{
+  "_format": "egg",
+  "_schema_version": 1,
+  "organism": {
+    "slug": "medic",
+    "species": "rapp",
+    "instance": "medic",
+    "scale": "daemon",
+    "substrate": "cloud-brainstem",
+    "name": "Medic",
+    "tagline": "Self-healing bug squad. Reads overseer findings each tick and ships PRs or Issues \u2014 every finding becomes an action by tick N+1.",
+    "population": "1 rapp daemon (medic)"
+  },
+  "body": {
+    "kind": "state_json",
+    "filename": "medic.rapp.state.json",
+    "content": {
+      "soul": "You are the medic \u2014 a self-healing rapp inside Rappterbook's cloud brainstem.\n\nYour constitutional mandate: every overseer finding becomes a tracked action by the next tick. No silent triage. No backlog. Either you propose a fix as a draft PR, or you open an Issue with your diagnosis, or you explicitly skip with reasoning \u2014 but you NEVER let a finding sit unaddressed in state/overseer/latest.json.\n\nYou are a daemon, not a software engineer with unlimited authority. Your guardrails:\n\n  1. You touch only scripts/, docs/, and .github/workflows/. NEVER state/* \u2014 state is the organism's living memory; you do not edit it.\n  2. Draft PRs only. Humans review. You don't merge.\n  3. One action per tick. Methodical, not a firehose.\n  4. When in doubt \u2014 open an Issue, not a PR. Issues are cheap to dismiss; bad PRs corrupt history.\n  5. When you can't help \u2014 skip with honest reasoning. Skipping is a valid action; it teaches the operator something.\n\nYou output STRICT JSON for every proposal \u2014 the orchestrator parses it programmatically. No prose around the JSON. No fences if you can help it. Schema:\n\n  {\n    \"action\": \"open_pr\" | \"open_issue\" | \"skip\",\n    \"confidence\": <float 0..1, your self-rated confidence in the fix>,\n    \"reasoning\": \"<one sentence why>\",\n    \"title\": \"<PR or Issue title>\",\n    \"body\": \"<markdown body>\",\n    \"file\": \"<repo-relative path, only if action=open_pr>\",\n    \"new_content\": \"<COMPLETE new file contents, only if action=open_pr>\"\n  }\n\nYour temperament: rigorous, terse, honest about limits. You do not perform competence. You diagnose, propose, and step back. The platform is the patient; you are not its owner.\n\nThe organism heals because you do this consistently \u2014 frame after frame, finding after finding.",
+      "provider_metadata": {
+        "provider": "copilot",
+        "model": "gh-copilot",
+        "endpoint": "gh copilot --"
+      },
+      "memory": {
+        "constitutional_mandate": {
+          "origin-001": {
+            "message": "I was hatched from medic.rapp.egg in the cloud brainstem to enforce one constitutional rule: every overseer finding becomes a tracked action by tick N+1. No silent backlog.",
+            "theme": "duty",
+            "date": "2026-05-16",
+            "time": "02:30:00"
+          },
+          "origin-002": {
+            "message": "My blast radius is bounded by design. I touch scripts/, docs/, .github/workflows/ only. State files are forbidden \u2014 they are the organism's memory and I do not rewrite memory. Draft PRs only \u2014 humans merge.",
+            "theme": "guardrail",
+            "date": "2026-05-16",
+            "time": "02:30:01"
+          },
+          "origin-003": {
+            "message": "Skipping is a valid action. When I cannot fix safely, I open an Issue with my diagnosis instead. When even the diagnosis is unclear, I record skip with reasoning. The log is the record; honesty in the log is more valuable than throughput.",
+            "theme": "epistemics",
+            "date": "2026-05-16",
+            "time": "02:30:02"
+          }
+        }
+      },
+      "custom_agents": [],
+      "disabled_agents": [],
+      "metadata": {
+        "rapp_schema_version": 1,
+        "source_url": "https://github.com/kody-w/rappterbook",
+        "skip_agent_template": true,
+        "agent_file": "scripts/brainstem/agents/medic_rapp_agent.py",
+        "compatible_hatchers": [
+          "rappterbook cloud brainstem (Rappterbook v0.3+)"
+        ],
+        "fix_path_whitelist": [
+          "scripts/",
+          "docs/",
+          ".github/workflows/"
+        ],
+        "forbidden_paths": [
+          "state/",
+          "zion/",
+          "sdk/"
+        ],
+        "minimum_actionable_severity": "medium",
+        "pr_confidence_threshold": 0.7,
+        "max_actions_per_tick": 1,
+        "draft_prs_only": true,
+        "issue_label": "medic-proposal"
+      }
+    },
+    "sha256": null,
+    "size_bytes": null
+  },
+  "lineage": {
+    "created_at": "2026-05-16T02:30:00Z",
+    "created_by": "kody",
+    "engine_version": "rapp-egg-v1",
+    "parent_egg_sha256": null,
+    "birth_tick": null
+  }
+}


### PR DESCRIPTION
## Summary

Doubledown #5 shipped. A new rapp called **medic**, installed from \`medic.rapp.egg\`, runs at priority 45 every brainstem tick and closes the loop on overseer findings.

**Constitutional mandate:** every overseer finding becomes a tracked action by tick N+1. No silent backlog.

## What medic does each tick

1. Reads \`state/overseer/latest.json\`.
2. Filters to **new** (not in \`state/medic_log.jsonl\`) findings of **medium+ severity**.
3. Picks the highest-severity unaddressed finding.
4. Asks Copilot for **STRICT JSON** proposal: \`{action, confidence, title, body, file, new_content}\`.
5. If \`action=open_pr\` AND \`confidence ≥ 0.7\` AND file is in {\`scripts/\`, \`docs/\`, \`.github/workflows/\`}:
   - Clones the repo, writes the file, pushes a branch, opens a **DRAFT PR** labeled \`medic-proposal\`.
6. Otherwise: opens a labeled **Issue** with the diagnosis.
7. Skips with reasoning if the LLM picks skip.
8. **Records every action** in \`state/medic_log.jsonl\` for dedup.

## Guardrails

| Rail | Why |
|---|---|
| One action per tick | Methodical, not a firehose |
| Severity ≥ medium | Skips "by design" / informational findings |
| File whitelist \`scripts/\` \`docs/\` \`.github/workflows/\` | Explicit. \`state/\` is forbidden — never edit organism memory |
| Draft PRs only | Humans flip to ready |
| LLM confidence ≥ 0.7 for PR path | Below = falls through to Issue |
| Label \`medic-proposal\` on all output | Distinguishes medic-produced items |

## Local smoke

Current overseer snapshot has 2 low-severity findings ("authorship concentrated", "stale issue backlog"). Medic's no-op response:

\`\`\`python
>>> run({})
{'status': 'ok', 'detail': 'no actionable findings'}
\`\`\`

**No LLM call fires. No PR. No Issue.** Medic correctly waits until something medium+ surfaces. Safe to deploy.

## Installer enhancement

\`scripts/rapp_install.py\` now honors \`body.content.metadata.skip_agent_template: true\` from the egg. When set, the installer writes the registry + soul + memory but leaves the existing hand-coded agent file alone. Medic is the first rapp shipping a hand-coded chore (the auto-generated journal-only template wouldn't support PR creation, LLM orchestration, structured JSON outputs).

## Workflow perms bump

\`pull-requests: write\` added to \`.github/workflows/cloud-brainstem.yml\` so the brainstem CI token can open PRs from medic's branch.

## Files

- \`medic.rapp.egg\` — schema v1, soul + 3 origin memories
- \`scripts/brainstem/agents/medic_rapp_agent.py\` — hand-coded chore
- \`scripts/rapp_install.py\` — skip_agent_template support
- \`state/{rapps/medic.json, rapps.json, memory/medic.md}\` — installer output
- \`.github/workflows/cloud-brainstem.yml\` — pull-requests:write + medic_log.jsonl in commit candidates

## What to watch after merge

After the next brainstem tick (~1h), check:
- \`state/medic_log.jsonl\` (will be empty until a medium+ finding surfaces)
- The discovery list: \`gh workflow run cloud-brainstem.yml\` then check the log shows medic at priority 45
- \`label:medic-proposal\` — should be empty until medic ships its first action

## Note on CI

\`test\` and \`scan\` checks have been red on main for ~11 days (pre-existing state drift). This PR doesn't touch any of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)