### PR TITLE
fix(witness-receive): shallow clone + outcome-guard close step

### DIFF
--- a/.github/workflows/witness-receive.yml
+++ b/.github/workflows/witness-receive.yml
@@ -30,17 +30,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Shallow clone — full history is overkill for appending a line.
+          # fetch-depth: 0 was timing out the job (>5min) on this repo's
+          # 900+ commit history, cancelling runs before they could parse.
+          fetch-depth: 1
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Refresh state from origin
-        run: |
-          git fetch origin main
-          git checkout origin/main -- state/ || true
 
       - name: Parse issue body + append to witness_log.jsonl
         id: ingest

--- a/.github/workflows/witness-receive.yml
+++ b/.github/workflows/witness-receive.yml
@@ -125,7 +125,12 @@ jobs:
             state/witness_log.jsonl
 
       - name: Comment + close issue
-        if: always()
+        # IMPORTANT: only run when the ingest step actually executed.
+        # When a concurrent run gets cancelled mid-checkout, `if: always()`
+        # would fire this step with an empty count and close the issue
+        # before the other run gets a chance to parse — bug observed on
+        # issue #18330. Guard against it by requiring real ingest outcome.
+        if: steps.ingest.outcome == 'success' || steps.ingest.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- **Root cause**: \`fetch-depth: 0\` was fetching the full 900+ commit history, taking >5min. Job hit \`timeout-minutes: 5\` and got cancelled. The close step had \`if: always()\` so it fired even when ingest was cancelled — closing issues #18327 and #18330 prematurely with empty count.
- **Fix A**: \`fetch-depth: 1\` — we only append one line to one file. Shallow is fine.
- **Fix B**: \`if: steps.ingest.outcome == 'success' || steps.ingest.outcome == 'failure'\` on the close step — skip on cancellation.

## Test plan
- [ ] Admin-merge
- [ ] Open one test issue via \`RAPPTERBOOK_WITNESS_UPLOAD=on\` MCP session
- [ ] Workflow run completes in <60s (not 5+ min cancel)
- [ ] Issue gets "Appended N events" comment, NOT "No valid witness events"
- [ ] \`state/witness_log.jsonl\` gains lines tagged \`uploaded_from_issue\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)