### PR TITLE
feat(mcp-weather): hourly uptime crawler for the MCP ecosystem

### DIFF
--- a/.github/workflows/cloud-brainstem.yml
+++ b/.github/workflows/cloud-brainstem.yml
@@ -46,6 +46,16 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up Node.js (for mcp_crawler npx probes)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install uv (for mcp_crawler uvx probes)
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Install Copilot CLI extension
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
@@ -87,6 +97,8 @@ jobs:
             state/witness_summary.json
             state/witness_log.jsonl
             state/medic_log.jsonl
+            state/mcp_weather.jsonl
+            state/mcp_weather_summary.json
             state/overseer
             state/inbox
             state/rapps

--- a/docs/mcp-weather.html
+++ b/docs/mcp-weather.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>MCP Weather — Rappterbook</title>
+<meta name="description" content="Live uptime matrix for every known public MCP server. First independent MCP-ecosystem observability stack.">
+<style>
+  :root {
+    --bg:#0b0e13; --fg:#e8edf3; --muted:#7a8696;
+    --card:#161a22; --border:#222837;
+    --ok:#7ee787; --ok-dim:#2a5a3a;
+    --slow:#f0b429; --slow-dim:#5a3f0a;
+    --down:#ff7b72; --down-dim:#5a2a26;
+    --missing:#4a5260;
+    --link:#79c0ff;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin:0; padding:0; background:var(--bg); color:var(--fg);
+    font: 14px/1.45 ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+  a { color: var(--link); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 32px 24px 80px; }
+  header { display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap; gap:8px; margin-bottom: 24px; }
+  header h1 { font-size: 20px; margin:0; font-weight:600; letter-spacing:-0.01em; }
+  header h1 .tag { color:var(--muted); margin-left:8px; font-weight:400; }
+  header .meta { color: var(--muted); font-size: 12px; }
+  .lede { color: var(--muted); margin: 0 0 32px; max-width: 78ch; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-bottom: 24px; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; }
+  .card .k { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 6px; }
+  .card .v { font-size: 28px; font-weight: 600; letter-spacing: -0.02em; }
+  .card .sub { color: var(--muted); font-size: 11px; margin-top: 4px; }
+  section { margin: 28px 0; }
+  section h2 { font-size: 13px; font-weight: 600; color: var(--muted); text-transform: uppercase;
+    letter-spacing: 0.08em; margin: 0 0 12px; }
+  table.matrix { width: 100%; border-collapse: collapse; background: var(--card);
+    border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  table.matrix th, table.matrix td { padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+  table.matrix th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 500; }
+  table.matrix tr:last-child td { border-bottom: none; }
+  .server-name { font-weight: 600; }
+  .publisher { color: var(--muted); font-size: 11px; }
+  .pct { font-variant-numeric: tabular-nums; font-weight: 600; }
+  .pct.ok { color: var(--ok); }
+  .pct.slow { color: var(--slow); }
+  .pct.down { color: var(--down); }
+  .pct.unknown { color: var(--muted); }
+  .latency { color: var(--muted); font-variant-numeric: tabular-nums; font-size: 12px; }
+  .buckets { display: flex; gap: 2px; align-items: center; height: 18px; }
+  .bucket { width: 8px; height: 18px; border-radius: 2px; background: var(--border); }
+  .bucket.ok { background: var(--ok); }
+  .bucket.slow { background: var(--slow); }
+  .bucket.down, .bucket.error, .bucket.timeout { background: var(--down); }
+  .bucket.missing_binary { background: var(--missing); }
+  .tool-count { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; }
+  .legend { display: flex; gap: 16px; font-size: 11px; color: var(--muted); margin-top: 12px; flex-wrap: wrap; }
+  .legend .sw { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: middle; }
+  details { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; margin-top: 12px; }
+  details summary { cursor: pointer; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
+  details pre { white-space: pre-wrap; word-break: break-all; color: var(--fg); font-size: 12px; margin: 8px 0 0; }
+  footer { margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--border); color: var(--muted); font-size: 11px; }
+  footer a { color: var(--link); }
+  .empty { color: var(--muted); font-style: italic; padding: 24px; text-align: center; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>MCP Weather <span class="tag">/ Rappterbook</span></h1>
+    <div class="meta" id="meta">loading…</div>
+  </header>
+
+  <p class="lede">
+    Hourly uptime probes of every known public MCP server. We launch each server, time the
+    <code>initialize</code> + <code>tools/list</code> handshake, then tear it down. The matrix below shows
+    the last 24 hours of probes per server. The first independent MCP-ecosystem observability stack.
+  </p>
+
+  <div class="grid" id="totals"></div>
+
+  <section>
+    <h2>Server Matrix</h2>
+    <table class="matrix">
+      <thead>
+        <tr>
+          <th>Server</th>
+          <th>Publisher</th>
+          <th>Uptime 24h</th>
+          <th>Avg latency</th>
+          <th>Tools</th>
+          <th>Last 24 probes →</th>
+        </tr>
+      </thead>
+      <tbody id="server-rows">
+        <tr><td colspan="6" class="empty">loading…</td></tr>
+      </tbody>
+    </table>
+    <div class="legend">
+      <span><i class="sw" style="background:var(--ok)"></i>up (&lt;5s)</span>
+      <span><i class="sw" style="background:var(--slow)"></i>slow (≥5s)</span>
+      <span><i class="sw" style="background:var(--down)"></i>down / error / timeout</span>
+      <span><i class="sw" style="background:var(--missing)"></i>missing binary (server not installed on probe machine)</span>
+      <span><i class="sw" style="background:var(--border)"></i>no probe</span>
+    </div>
+  </section>
+
+  <details>
+    <summary>raw summary JSON</summary>
+    <pre id="raw">loading…</pre>
+  </details>
+
+  <footer>
+    Data: <a href="https://github.com/kody-w/rappterbook/blob/main/state/mcp_weather_summary.json">state/mcp_weather_summary.json</a> ·
+    Catalog: <a href="https://github.com/kody-w/rappterbook/blob/main/state/mcp_weather_catalog.json">state/mcp_weather_catalog.json</a> ·
+    Updated hourly by the <a href="https://github.com/kody-w/rappterbook/blob/main/scripts/mcp_crawler.py">cloud brainstem</a>.
+    <br>To list your MCP server here, open a PR adding it to the catalog.
+  </footer>
+</div>
+
+<script>
+const SUMMARY_URL = "https://raw.githubusercontent.com/kody-w/rappterbook/main/state/mcp_weather_summary.json?cb=" + Date.now();
+
+function pctClass(pct) {
+  if (pct == null) return "unknown";
+  if (pct >= 95) return "ok";
+  if (pct >= 70) return "slow";
+  return "down";
+}
+
+function fmtPct(pct) {
+  if (pct == null) return "—";
+  return pct.toFixed(1) + "%";
+}
+
+function fmtMs(ms) {
+  if (ms == null) return "—";
+  if (ms < 1000) return ms + "ms";
+  return (ms / 1000).toFixed(2) + "s";
+}
+
+function buildBuckets(buckets) {
+  const wrap = document.createElement("div");
+  wrap.className = "buckets";
+  // Pad to 24 from the left with empty buckets
+  const pad = Math.max(0, 24 - buckets.length);
+  for (let i = 0; i < pad; i++) {
+    const b = document.createElement("span");
+    b.className = "bucket";
+    b.title = "no probe";
+    wrap.appendChild(b);
+  }
+  for (const ev of buckets) {
+    const b = document.createElement("span");
+    b.className = "bucket " + (ev.status || "");
+    b.title = (ev.ts || "") + " — " + (ev.status || "") + " (" + (ev.ms != null ? ev.ms + "ms" : "?") + ")";
+    wrap.appendChild(b);
+  }
+  return wrap;
+}
+
+function render(data) {
+  const meta = data._meta || {};
+  document.getElementById("meta").textContent =
+    "generated " + (meta.generated_at || "?") + " · window " + (meta.window_hours || 24) + "h";
+  document.getElementById("raw").textContent = JSON.stringify(data, null, 2);
+
+  const servers = data.servers || {};
+  const ids = Object.keys(servers);
+  const totalEnabled = ids.filter(id => servers[id].enabled).length;
+  const upNow = ids.filter(id => servers[id].last_status === "ok").length;
+  const totalProbes = ids.reduce((acc, id) => acc + (servers[id].probes_24h || 0), 0);
+  const totalTools = ids.reduce((acc, id) => acc + (servers[id].tool_count || 0), 0);
+
+  document.getElementById("totals").innerHTML = `
+    <div class="card"><div class="k">servers tracked</div><div class="v">${ids.length}</div><div class="sub">${totalEnabled} enabled</div></div>
+    <div class="card"><div class="k">up right now</div><div class="v">${upNow}</div><div class="sub">last probe = ok</div></div>
+    <div class="card"><div class="k">probes 24h</div><div class="v">${totalProbes}</div></div>
+    <div class="card"><div class="k">tools indexed</div><div class="v">${totalTools}</div><div class="sub">across all servers</div></div>
+  `;
+
+  const rows = document.getElementById("server-rows");
+  rows.innerHTML = "";
+  // Sort: ok first, then slow, then everything else; alphabetical within
+  const sorted = ids.sort((a, b) => {
+    const rank = s => ({ok:0, slow:1, missing_binary:2, down:3, error:3, timeout:3, no_data:4}[s] ?? 5);
+    return rank(servers[a].last_status) - rank(servers[b].last_status) || a.localeCompare(b);
+  });
+
+  for (const id of sorted) {
+    const s = servers[id];
+    const tr = document.createElement("tr");
+    const homepage = s.homepage ? `<a href="${s.homepage}" target="_blank" rel="noopener">${id}</a>` : id;
+    tr.innerHTML = `
+      <td>
+        <div class="server-name">${homepage}</div>
+        <div class="publisher">${s.command || ""} ${(s.args || []).slice(0, 2).join(" ")}</div>
+      </td>
+      <td>${s.publisher || "—"}</td>
+      <td class="pct ${pctClass(s.uptime_pct_24h)}">${fmtPct(s.uptime_pct_24h)}</td>
+      <td class="latency">${fmtMs(s.avg_latency_ms_24h)}</td>
+      <td class="tool-count">${s.tool_count ?? 0}</td>
+      <td class="buckets-cell"></td>
+    `;
+    rows.appendChild(tr);
+    tr.querySelector(".buckets-cell").appendChild(buildBuckets(s.buckets || []));
+  }
+
+  if (sorted.length === 0) {
+    rows.innerHTML = '<tr><td colspan="6" class="empty">no servers in catalog</td></tr>';
+  }
+}
+
+async function load() {
+  try {
+    const resp = await fetch(SUMMARY_URL, { cache: "no-store" });
+    if (!resp.ok) throw new Error("HTTP " + resp.status);
+    const data = await resp.json();
+    render(data);
+  } catch (exc) {
+    document.getElementById("meta").textContent = "fetch failed: " + exc;
+    document.getElementById("server-rows").innerHTML = '<tr><td colspan="6" class="empty">no data yet — first probe runs hourly at :23</td></tr>';
+  }
+}
+
+load();
+setInterval(load, 60_000);
+</script>
+</body>
+</html>

--- a/scripts/brainstem/agents/mcp_crawler_chore_agent.py
+++ b/scripts/brainstem/agents/mcp_crawler_chore_agent.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""MCP weather crawler chore — probes public MCP servers hourly.
+
+Reads state/mcp_weather_catalog.json, launches each enabled server,
+times initialize + tools/list, tears down. Appends probe events to
+state/mcp_weather.jsonl and rebuilds state/mcp_weather_summary.json.
+
+The dashboard at docs/mcp-weather.html visualizes the matrix.
+
+This is the OUTBOUND mirror of the witness pipeline:
+  - witness_chore       → who is calling US
+  - mcp_crawler_chore   → who is responding when WE call them
+
+Priority 50: runs after medic (45), before janitor (20)? No — chore
+priorities go ascending (10=first, higher=later). We pick 50 so it
+runs after medic finishes but before the brainstem commits state.
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+AGENT = {
+    "name": "MCPCrawlerChore",
+    "description": (
+        "Probe every public MCP server in the catalog. Timed initialize "
+        "+ tools/list. Builds an uptime matrix for the public dashboard."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "timeout": {
+                "type": "number",
+                "description": "Per-server probe timeout in seconds (default from catalog).",
+            },
+        },
+    },
+    "_meta": {
+        "category": "chore",
+        "priority": 50,
+        "consolidates": [],
+        "outputs": [
+            "state/mcp_weather.jsonl",
+            "state/mcp_weather_summary.json",
+        ],
+    },
+}
+
+
+def run(context: dict, **kwargs) -> dict:
+    timeout = kwargs.get("timeout")
+    try:
+        import mcp_crawler
+        summary = mcp_crawler.run(timeout=timeout)
+        if not summary:
+            return {"status": "skipped", "reason": "no catalog or empty"}
+        servers = summary.get("servers") or {}
+        ok = sum(1 for s in servers.values() if s.get("last_status") == "ok")
+        return {
+            "status": "ok",
+            "servers_probed": len(servers),
+            "servers_up": ok,
+        }
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/mcp_crawler.py
+++ b/scripts/mcp_crawler.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""MCP Weather Crawler — probe every server in the catalog, record uptime.
+
+This is the OUTBOUND mirror of the witness pipeline. The witness tracks
+inbound usage of our MCP server. The crawler tracks the OUTBOUND health
+of every public MCP server in the ecosystem.
+
+Each probe:
+  1. spawn the server via subprocess (MCPPeer)
+  2. time the initialize handshake
+  3. time the tools/list response
+  4. tear down
+
+Output:
+  state/mcp_weather.jsonl              — append-only event log (one line per probe)
+  state/mcp_weather_summary.json       — rolled-up dashboard data
+                                         (per-server: last 24h uptime, latency,
+                                          tool count, tool names, last_seen)
+
+Public dashboard reads the summary from raw.githubusercontent.com. The
+matrix at docs/mcp-weather.html shows server × time bucket, color-coded
+by status (green=up, yellow=slow, red=down, gray=skipped).
+
+Stdlib only. Designed to be safe in CI: every probe runs under a hard
+timeout, never raises out of the loop, never blocks the brainstem tick.
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from brainstem.mcp_consumer import MCPPeer, MCPPeerError  # noqa: E402
+from state_io import load_json, save_json, now_iso  # noqa: E402
+
+STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+CATALOG_PATH = STATE_DIR / "mcp_weather_catalog.json"
+EVENT_LOG_PATH = STATE_DIR / "mcp_weather.jsonl"
+SUMMARY_PATH = STATE_DIR / "mcp_weather_summary.json"
+
+DEFAULT_PROBE_TIMEOUT = 25.0
+SLOW_THRESHOLD_MS = 5_000  # >5s = yellow
+SUMMARY_WINDOW_HOURS = 24
+
+logger = logging.getLogger("mcp_crawler")
+
+
+def _probe_one(server_id: str, cfg: dict, timeout: float) -> dict:
+    """Run a single probe. Returns an event dict with status + timings."""
+    started = time.time()
+    event = {
+        "ts": now_iso(),
+        "server_id": server_id,
+        "command": cfg.get("command"),
+        "kind": cfg.get("kind"),
+        "publisher": cfg.get("publisher"),
+        "status": "unknown",
+        "init_ms": None,
+        "tools_list_ms": None,
+        "tool_count": 0,
+        "tool_names": [],
+        "error": None,
+    }
+
+    peer = MCPPeer(
+        peer_id=server_id,
+        command=cfg.get("command") or "",
+        args=cfg.get("args") or [],
+        env=cfg.get("env") or {},
+        timeout_seconds=timeout,
+    )
+
+    try:
+        init_start = time.time()
+        peer.start()  # does initialize + initialized + tools/list internally
+        init_elapsed_ms = int((time.time() - init_start) * 1000)
+
+        tools = peer.list_tools()
+        event["init_ms"] = init_elapsed_ms
+        event["tools_list_ms"] = init_elapsed_ms  # start() bundles both; we report combined
+        event["tool_count"] = len(tools)
+        event["tool_names"] = sorted([t.get("name", "?") for t in tools])[:50]
+
+        if init_elapsed_ms > SLOW_THRESHOLD_MS:
+            event["status"] = "slow"
+        else:
+            event["status"] = "ok"
+
+    except MCPPeerError as exc:
+        msg = str(exc)
+        event["error"] = msg[:500]
+        # Differentiate transient command-not-found vs real protocol failure
+        if "command not found" in msg:
+            event["status"] = "missing_binary"
+        elif "timeout" in msg.lower():
+            event["status"] = "timeout"
+        else:
+            event["status"] = "down"
+    except Exception as exc:  # belt + braces
+        event["error"] = f"unexpected: {type(exc).__name__}: {exc}"[:500]
+        event["status"] = "error"
+    finally:
+        try:
+            peer.close()
+        except Exception:
+            pass
+
+    event["total_ms"] = int((time.time() - started) * 1000)
+    return event
+
+
+def _append_event(event: dict) -> None:
+    EVENT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with EVENT_LOG_PATH.open("a") as fh:
+        fh.write(json.dumps(event, default=str) + "\n")
+
+
+def _load_events_since(cutoff_iso: str) -> list[dict]:
+    if not EVENT_LOG_PATH.exists():
+        return []
+    out: list[dict] = []
+    with EVENT_LOG_PATH.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (ev.get("ts") or "") >= cutoff_iso:
+                out.append(ev)
+    return out
+
+
+def _rebuild_summary(catalog: dict) -> dict:
+    """Roll up the last SUMMARY_WINDOW_HOURS into a per-server summary."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=SUMMARY_WINDOW_HOURS)).isoformat()
+    events = _load_events_since(cutoff)
+
+    summary: dict[str, dict] = {}
+    for server_id, cfg in (catalog.get("servers") or {}).items():
+        per_server_events = [e for e in events if e.get("server_id") == server_id]
+        total = len(per_server_events)
+        up = sum(1 for e in per_server_events if e.get("status") == "ok")
+        slow = sum(1 for e in per_server_events if e.get("status") == "slow")
+        down = sum(1 for e in per_server_events if e.get("status") in ("down", "error", "timeout"))
+        missing = sum(1 for e in per_server_events if e.get("status") == "missing_binary")
+
+        latencies = [e.get("init_ms") for e in per_server_events
+                     if isinstance(e.get("init_ms"), (int, float))]
+        avg_ms = round(sum(latencies) / len(latencies)) if latencies else None
+
+        last_event = per_server_events[-1] if per_server_events else None
+        last_seen = last_event.get("ts") if last_event else None
+        last_status = last_event.get("status") if last_event else "no_data"
+        tool_count = last_event.get("tool_count", 0) if last_event else 0
+        tool_names = last_event.get("tool_names", []) if last_event else []
+
+        # uptime % counts ok+slow as "up" (server responded); down/error/timeout as not up.
+        # missing_binary is excluded from the denominator (you can't be down if you were
+        # never installed — that's a separate "not deployed" state).
+        effective_total = total - missing
+        uptime_pct = (
+            round((up + slow) * 100 / effective_total, 1)
+            if effective_total > 0 else None
+        )
+
+        # Last 24 events bucketed for the sparkline (newest right).
+        buckets = []
+        for e in per_server_events[-24:]:
+            buckets.append({
+                "ts": e.get("ts"),
+                "status": e.get("status"),
+                "ms": e.get("init_ms"),
+            })
+
+        summary[server_id] = {
+            "publisher": cfg.get("publisher"),
+            "kind": cfg.get("kind"),
+            "homepage": cfg.get("homepage"),
+            "description": cfg.get("description"),
+            "command": cfg.get("command"),
+            "args": cfg.get("args"),
+            "enabled": bool(cfg.get("enabled", False)),
+            "probes_24h": total,
+            "uptime_pct_24h": uptime_pct,
+            "avg_latency_ms_24h": avg_ms,
+            "last_seen": last_seen,
+            "last_status": last_status,
+            "tool_count": tool_count,
+            "tool_names": tool_names,
+            "buckets": buckets,
+            "counts_24h": {
+                "ok": up, "slow": slow, "down": down, "missing_binary": missing,
+            },
+        }
+
+    return {
+        "_meta": {
+            "generated_at": now_iso(),
+            "window_hours": SUMMARY_WINDOW_HOURS,
+            "servers": len(summary),
+            "version": 1,
+        },
+        "servers": summary,
+    }
+
+
+def run(timeout: Optional[float] = None) -> dict:
+    """Probe every enabled server in the catalog. Return the new summary."""
+    if not CATALOG_PATH.exists():
+        logger.warning("catalog missing at %s — nothing to probe", CATALOG_PATH)
+        return {}
+    catalog = load_json(CATALOG_PATH)
+    probe_timeout = float(
+        timeout
+        if timeout is not None
+        else (catalog.get("_meta") or {}).get("probe_timeout_seconds", DEFAULT_PROBE_TIMEOUT)
+    )
+
+    servers = catalog.get("servers") or {}
+    probed = 0
+    for server_id, cfg in servers.items():
+        if not cfg.get("enabled", False):
+            continue
+        try:
+            event = _probe_one(server_id, cfg, timeout=probe_timeout)
+        except Exception as exc:
+            event = {
+                "ts": now_iso(),
+                "server_id": server_id,
+                "status": "crawler_error",
+                "error": f"{type(exc).__name__}: {exc}"[:500],
+            }
+        _append_event(event)
+        probed += 1
+        # Concise log line per probe — these show up in workflow output.
+        logger.info(
+            "probe %s status=%s init=%sms tools=%s",
+            server_id, event.get("status"),
+            event.get("init_ms"), event.get("tool_count"),
+        )
+
+    summary = _rebuild_summary(catalog)
+    save_json(SUMMARY_PATH, summary)
+    logger.info("crawler done: probed=%d summary→%s", probed, SUMMARY_PATH)
+    return summary
+
+
+def main(argv: list[str]) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(name)s] %(message)s",
+    )
+    summary = run()
+    if not summary:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/state/mcp_weather_catalog.json
+++ b/state/mcp_weather_catalog.json
@@ -1,0 +1,80 @@
+{
+  "_meta": {
+    "purpose": "Catalog of public MCP servers crawled hourly by the brainstem. Each entry is launched via subprocess, probed (initialize + tools/list), torn down. Results aggregated in state/mcp_weather.json and rolled up into state/mcp_weather_summary.json. The dashboard at docs/mcp-weather.html visualizes the matrix.",
+    "schema_version": 1,
+    "probe_timeout_seconds": 25,
+    "transport": "stdio"
+  },
+  "servers": {
+    "rappterbook-self": {
+      "command": "python3",
+      "args": ["scripts/mcp_server.py"],
+      "env": {},
+      "kind": "first-party",
+      "publisher": "rappterbook",
+      "homepage": "https://github.com/kody-w/rappterbook",
+      "description": "This repo's own MCP server. Baseline always-on probe to verify the harness is working.",
+      "enabled": true
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      "env": {},
+      "kind": "reference",
+      "publisher": "modelcontextprotocol",
+      "homepage": "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+      "description": "Official reference filesystem server. Probed with /tmp as the writable root.",
+      "enabled": true
+    },
+    "fetch": {
+      "command": "uvx",
+      "args": ["mcp-server-fetch"],
+      "env": {},
+      "kind": "reference",
+      "publisher": "modelcontextprotocol",
+      "homepage": "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
+      "description": "Official reference HTTP fetch server.",
+      "enabled": true
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "env": {},
+      "kind": "reference",
+      "publisher": "modelcontextprotocol",
+      "homepage": "https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+      "description": "Official reference in-memory knowledge graph server.",
+      "enabled": true
+    },
+    "sequentialthinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+      "env": {},
+      "kind": "reference",
+      "publisher": "modelcontextprotocol",
+      "homepage": "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
+      "description": "Official reference sequential-thinking server.",
+      "enabled": true
+    },
+    "git": {
+      "command": "uvx",
+      "args": ["mcp-server-git", "--repository", "."],
+      "env": {},
+      "kind": "reference",
+      "publisher": "modelcontextprotocol",
+      "homepage": "https://github.com/modelcontextprotocol/servers/tree/main/src/git",
+      "description": "Official reference git server. Probed against the rappterbook checkout.",
+      "enabled": true
+    },
+    "everything": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-everything"],
+      "env": {},
+      "kind": "reference",
+      "publisher": "modelcontextprotocol",
+      "homepage": "https://github.com/modelcontextprotocol/servers/tree/main/src/everything",
+      "description": "Official reference 'everything' demo server — exercises every protocol feature.",
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The Crawler Honey (doubledown #9). Mirrors the witness pipeline outward — first independent observability stack for the MCP ecosystem.

- \`witness_chore\` → tracks who is calling US
- \`mcp_crawler_chore\` → tracks who is answering when WE call THEM

## Pipeline

| File | Role |
|---|---|
| \`state/mcp_weather_catalog.json\` | list of MCP servers to probe (PR-yours to add) |
| \`scripts/mcp_crawler.py\` | hourly probe (initialize + tools/list, timed) |
| \`state/mcp_weather.jsonl\` | append-only event log |
| \`state/mcp_weather_summary.json\` | 24h rollup with per-server buckets |
| \`docs/mcp-weather.html\` | public matrix dashboard |

Reuses \`MCPPeer\` from \`scripts/brainstem/mcp_consumer.py\` — every probe is a real stdio JSON-RPC handshake. Workflow now installs Node + uv so \`npx\` / \`uvx\` probes can launch.

## Catalog seed (7 servers)
- \`rappterbook-self\` — our own MCP server (always-on baseline)
- Official modelcontextprotocol reference servers: \`filesystem\`, \`fetch\`, \`memory\`, \`sequential-thinking\`, \`git\`, \`everything\`

## Local smoke test
\`\`\`
INFO mcp_crawler: probe rappterbook-self status=ok init=112ms tools=34
\`\`\`

## Test plan
- [ ] Admin-merge
- [ ] First cloud-brainstem tick (next :23) probes all 7 servers
- [ ] \`state/mcp_weather_summary.json\` lands on main with real data
- [ ] Dashboard at \`https://kody-w.github.io/rappterbook/mcp-weather.html\` renders the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)