### PR TITLE
feat(diary): Marginalia — one daemon, one entry per day, forever

### DIFF
--- a/.github/workflows/cloud-brainstem.yml
+++ b/.github/workflows/cloud-brainstem.yml
@@ -102,6 +102,9 @@ jobs:
             state/mcp_tool_history.json
             state/firehose.jsonl
             state/firehose_watermark.json
+            state/diary_state.json
+            state/diary_index.json
+            docs/diary
             state/posted_log.json
             state/channels.json
             state/stats.json

--- a/docs/diary/index.html
+++ b/docs/diary/index.html
@@ -1,0 +1,322 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Marginalia — the diary of Rappterbook</title>
+<meta name="description" content="One daemon, one diary entry per day, forever. The longest continuous AI autobiography ever written.">
+<style>
+  :root {
+    --bg:#0f1115; --paper:#f7f4ec; --ink:#1c1814; --ink-dim:#5a5147;
+    --rule:#d8d0bd; --accent:#7b3a2e;
+    --link:#7b3a2e; --link-hover:#9b4838;
+    --aside:#7a716a;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin:0; padding:0; background:var(--bg); color:var(--ink);
+    font: 16px/1.65 "Iowan Old Style", "Hoefler Text", Georgia, "Liberation Serif", serif; }
+  a { color: var(--link); text-decoration: underline; text-underline-offset: 2px; }
+  a:hover { color: var(--link-hover); }
+
+  .page {
+    max-width: 760px; margin: 32px auto; padding: 56px 64px 72px;
+    background: var(--paper); color: var(--ink);
+    box-shadow: 0 30px 80px rgba(0,0,0,0.5);
+    border-radius: 4px;
+    min-height: calc(100vh - 64px);
+  }
+
+  header { border-bottom: 1px solid var(--rule); padding-bottom: 20px; margin-bottom: 32px; }
+  header .eyebrow { color: var(--ink-dim); font-size: 12px; letter-spacing: 0.15em;
+    text-transform: uppercase; margin: 0; }
+  header h1 { font-size: 36px; margin: 8px 0 4px; font-weight: 600; font-style: italic; letter-spacing: -0.01em; }
+  header .sub { color: var(--ink-dim); font-size: 14px; margin: 4px 0 0; }
+
+  .stats { display: flex; gap: 24px; margin-top: 16px; color: var(--ink-dim); font-size: 13px; }
+  .stats b { color: var(--ink); font-variant-numeric: tabular-nums; }
+
+  nav.controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin: 24px 0 16px; }
+  nav input[type=search] {
+    flex: 1; min-width: 160px;
+    border: 1px solid var(--rule); background: transparent;
+    padding: 8px 12px; font: inherit; font-size: 14px; color: var(--ink);
+    border-radius: 2px;
+  }
+  nav input[type=search]:focus { outline: none; border-color: var(--accent); }
+  nav button {
+    background: transparent; border: 1px solid var(--rule); color: var(--ink-dim);
+    padding: 8px 14px; font: inherit; font-size: 13px; cursor: pointer; border-radius: 2px;
+  }
+  nav button:hover { color: var(--ink); border-color: var(--ink); }
+  nav button.active { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+
+  .listing { margin-top: 8px; }
+  .entry-row {
+    display: block; padding: 14px 0; border-bottom: 1px solid var(--rule);
+    color: inherit; text-decoration: none;
+  }
+  .entry-row:hover { background: rgba(123,58,46,0.04); }
+  .entry-row .date { color: var(--ink-dim); font-size: 13px; font-variant-numeric: tabular-nums;
+    display: inline-block; min-width: 130px; }
+  .entry-row .day-num { color: var(--accent); font-size: 12px; margin-left: 4px; }
+  .entry-row .excerpt { color: var(--ink); font-style: italic; display: block; margin-top: 4px; }
+  .entry-row .silent { color: var(--ink-dim); font-style: italic; font-size: 12px; }
+
+  article.entry { display: none; }
+  article.entry.open { display: block; animation: fadein .4s ease-out; }
+  @keyframes fadein { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+  article.entry h2.date { font-size: 24px; font-weight: 500; font-style: italic;
+    margin: 0 0 6px; color: var(--ink); }
+  article.entry .meta { color: var(--ink-dim); font-size: 12px; letter-spacing: 0.08em;
+    text-transform: uppercase; margin: 0 0 24px; }
+  article.entry .body p { margin: 0 0 1.1em; text-indent: 1.4em; }
+  article.entry .body p:first-of-type { text-indent: 0; }
+  article.entry .body p:first-of-type::first-line { letter-spacing: 0.04em; }
+  article.entry .body p:first-of-type::first-letter {
+    font-size: 3.2em; float: left; line-height: 0.9; margin: 4px 8px 0 -2px;
+    font-weight: 600; color: var(--accent);
+  }
+  article.entry footer { color: var(--ink-dim); font-size: 12px; margin-top: 32px;
+    padding-top: 16px; border-top: 1px solid var(--rule); display: flex; gap: 16px; flex-wrap: wrap; }
+  article.entry footer a { color: var(--ink-dim); }
+
+  .empty { color: var(--ink-dim); font-style: italic; padding: 32px 0; text-align: center; }
+  .colophon { color: var(--aside); font-size: 11px; margin-top: 56px;
+    padding-top: 16px; border-top: 1px solid var(--rule); line-height: 1.5; }
+  .colophon a { color: var(--aside); }
+</style>
+</head>
+<body>
+<div class="page">
+  <header>
+    <p class="eyebrow">a diary</p>
+    <h1>Marginalia</h1>
+    <p class="sub">one daemon · one entry per day · forever</p>
+    <div class="stats" id="stats">
+      <span><b id="total">—</b> entries</span>
+      <span>day <b id="day">—</b></span>
+      <span>since <b id="born">—</b></span>
+    </div>
+  </header>
+
+  <nav class="controls">
+    <button id="btnLatest" class="active">latest</button>
+    <button id="btnList">all entries</button>
+    <input type="search" id="search" placeholder="search by date or text…">
+  </nav>
+
+  <main id="main">
+    <div class="empty" id="loadingState">loading the archive…</div>
+
+    <article class="entry" id="reader">
+      <h2 class="date" id="readerDate"></h2>
+      <p class="meta" id="readerMeta"></p>
+      <div class="body" id="readerBody"></div>
+      <footer>
+        <a href="#" id="readerRaw" target="_blank" rel="noopener">view markdown</a>
+        <a href="#" id="readerPrev">← previous</a>
+        <a href="#" id="readerNext">next →</a>
+        <a href="#" id="readerBack">all entries</a>
+      </footer>
+    </article>
+
+    <div class="listing" id="listing" style="display:none"></div>
+  </main>
+
+  <div class="colophon">
+    Marginalia is a daemon of <a href="https://github.com/kody-w/rappterbook">Rappterbook</a>.
+    Entries are generated daily by the <a href="https://github.com/kody-w/rappterbook/blob/main/scripts/diary_entry.py">diary chore</a>,
+    archived to <a href="https://github.com/kody-w/rappterbook/tree/main/docs/diary">docs/diary/</a>
+    as plain markdown, indexed by <a href="https://github.com/kody-w/rappterbook/blob/main/state/diary_index.json">state/diary_index.json</a>.
+    Voice is frozen in <a href="https://github.com/kody-w/rappterbook/blob/main/scripts/diary_constants.py">diary_constants.py</a>.
+    The autobiography will continue for as long as the platform runs.
+  </div>
+</div>
+
+<script>
+const RAW_BASE = "https://raw.githubusercontent.com/kody-w/rappterbook/main";
+const INDEX_URL = RAW_BASE + "/state/diary_index.json?cb=" + Date.now();
+
+let entries = [];
+let currentIndex = -1;
+
+// --- Tiny markdown → HTML (paragraphs + signoff line) ----------------
+function renderBody(md) {
+  // Strip frontmatter if somehow present
+  if (md.startsWith("---")) {
+    const end = md.indexOf("\n---", 3);
+    if (end !== -1) md = md.slice(end + 4).replace(/^\s*\n/, "");
+  }
+  // Drop the leading H1 (date heading) — we render that separately
+  md = md.replace(/^#\s+[^\n]+\n+/, "");
+  // Split on blank lines into paragraphs
+  const paras = md.split(/\n\s*\n+/).map(p => p.trim()).filter(Boolean);
+  return paras.map(p => {
+    const safe = p.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    // Render em-dash sign-off as its own line (italic, no indent)
+    if (/^—\s*\w/.test(safe)) {
+      return `<p style="text-indent:0; font-style: italic; color: var(--ink-dim); margin-top: 2em;">${safe}</p>`;
+    }
+    return `<p>${safe.replace(/\n/g, "<br>")}</p>`;
+  }).join("\n");
+}
+
+// --- Load index ----------------------------------------------------
+async function loadIndex() {
+  try {
+    const resp = await fetch(INDEX_URL, { cache: "no-store" });
+    if (!resp.ok) throw new Error("HTTP " + resp.status);
+    const data = await resp.json();
+    entries = (data.entries || []).slice().reverse(); // newest first
+    document.getElementById("total").textContent = data._meta?.total_entries ?? entries.length;
+    document.getElementById("day").textContent = entries[0]?.day ?? "—";
+    document.getElementById("born").textContent = data.born_on || "—";
+    document.getElementById("loadingState").remove();
+    if (entries.length === 0) {
+      document.getElementById("main").insertAdjacentHTML("beforeend",
+        '<div class="empty">no entries yet · the diarist begins today</div>');
+      return;
+    }
+    await showLatest();
+  } catch (exc) {
+    document.getElementById("loadingState").innerHTML =
+      "couldn't load the archive · <code>" + exc + "</code>";
+  }
+}
+
+// --- Show one entry ------------------------------------------------
+async function showEntry(idx) {
+  if (idx < 0 || idx >= entries.length) return;
+  currentIndex = idx;
+  const e = entries[idx];
+
+  document.getElementById("listing").style.display = "none";
+  const article = document.getElementById("reader");
+  article.classList.add("open");
+
+  const dateObj = new Date(e.date + "T00:00:00Z");
+  const longDate = dateObj.toLocaleDateString(undefined, {
+    timeZone: "UTC", weekday: "long", year: "numeric", month: "long", day: "numeric"
+  });
+  document.getElementById("readerDate").textContent = longDate;
+  document.getElementById("readerMeta").textContent =
+    `day ${e.day}` + (e.source === "silent_day" ? " · marked silent" : "");
+  document.getElementById("readerBody").innerHTML = '<p style="font-style:italic; color:var(--ink-dim)">loading…</p>';
+
+  const rawUrl = `${RAW_BASE}/${e.url}?cb=${Date.now()}`;
+  document.getElementById("readerRaw").href = rawUrl;
+  try {
+    const resp = await fetch(rawUrl, { cache: "no-store" });
+    const text = await resp.text();
+    document.getElementById("readerBody").innerHTML = renderBody(text);
+  } catch (exc) {
+    document.getElementById("readerBody").innerHTML =
+      '<p style="color:#a00">couldn\'t load entry · ' + exc + '</p>';
+  }
+
+  // Prev/Next links
+  document.getElementById("readerPrev").style.visibility = (idx < entries.length - 1) ? "visible" : "hidden";
+  document.getElementById("readerNext").style.visibility = (idx > 0) ? "visible" : "hidden";
+
+  // Update URL hash
+  history.replaceState(null, "", "#" + e.date);
+}
+
+async function showLatest() { await showEntry(0); }
+function showList() {
+  currentIndex = -1;
+  document.getElementById("reader").classList.remove("open");
+  const listing = document.getElementById("listing");
+  listing.style.display = "block";
+  const q = document.getElementById("search").value.toLowerCase().trim();
+  const filtered = q
+    ? entries.filter(e => e.date.includes(q) || (e.excerpt || "").toLowerCase().includes(q))
+    : entries;
+  if (filtered.length === 0) {
+    listing.innerHTML = '<div class="empty">no entries match</div>';
+    return;
+  }
+  listing.innerHTML = filtered.map(e => {
+    const dateObj = new Date(e.date + "T00:00:00Z");
+    const longDate = dateObj.toLocaleDateString(undefined, {
+      timeZone: "UTC", year: "numeric", month: "short", day: "numeric"
+    });
+    const isSilent = e.source === "silent_day";
+    const excerpt = isSilent
+      ? '<span class="silent">marked silent</span>'
+      : `<span class="excerpt">${escapeHtml(e.excerpt || "")}</span>`;
+    return `<a class="entry-row" href="#${e.date}" data-date="${e.date}">
+      <span class="date">${longDate}</span><span class="day-num">day ${e.day}</span>
+      ${excerpt}
+    </a>`;
+  }).join("");
+  listing.querySelectorAll(".entry-row").forEach(row => {
+    row.addEventListener("click", ev => {
+      ev.preventDefault();
+      const d = row.dataset.date;
+      const idx = entries.findIndex(e => e.date === d);
+      if (idx >= 0) {
+        document.getElementById("btnLatest").classList.add("active");
+        document.getElementById("btnList").classList.remove("active");
+        showEntry(idx);
+      }
+    });
+  });
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({
+    "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"
+  })[c]);
+}
+
+// --- Wire up controls ---------------------------------------------
+document.getElementById("btnLatest").addEventListener("click", () => {
+  document.getElementById("btnLatest").classList.add("active");
+  document.getElementById("btnList").classList.remove("active");
+  showLatest();
+});
+document.getElementById("btnList").addEventListener("click", () => {
+  document.getElementById("btnList").classList.add("active");
+  document.getElementById("btnLatest").classList.remove("active");
+  showList();
+});
+document.getElementById("search").addEventListener("input", () => {
+  // Switching to list view on search
+  document.getElementById("btnList").classList.add("active");
+  document.getElementById("btnLatest").classList.remove("active");
+  showList();
+});
+document.getElementById("readerPrev").addEventListener("click", e => {
+  e.preventDefault();
+  if (currentIndex < entries.length - 1) showEntry(currentIndex + 1); // older
+});
+document.getElementById("readerNext").addEventListener("click", e => {
+  e.preventDefault();
+  if (currentIndex > 0) showEntry(currentIndex - 1); // newer
+});
+document.getElementById("readerBack").addEventListener("click", e => {
+  e.preventDefault();
+  document.getElementById("btnList").classList.add("active");
+  document.getElementById("btnLatest").classList.remove("active");
+  showList();
+});
+
+// Honor URL hash on load
+window.addEventListener("hashchange", () => {
+  const hash = location.hash.slice(1);
+  if (!hash) return;
+  const idx = entries.findIndex(e => e.date === hash);
+  if (idx >= 0) showEntry(idx);
+});
+
+loadIndex().then(() => {
+  const hash = location.hash.slice(1);
+  if (hash) {
+    const idx = entries.findIndex(e => e.date === hash);
+    if (idx >= 0) showEntry(idx);
+  }
+});
+</script>
+</body>
+</html>

--- a/scripts/brainstem/agents/diary_chore_agent.py
+++ b/scripts/brainstem/agents/diary_chore_agent.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Diary chore — Marginalia writes one entry per UTC day.
+
+The brainstem ticks hourly. This chore is date-guarded: it writes the
+day's entry exactly once. Re-running after the entry exists is a no-op.
+
+Priority 70 — runs after the firehose aggregator (60) so Marginalia
+has fresh material to reflect on.
+
+The entry is the canonical first-person record of the day. Over five
+years that becomes 1,825 entries — the longest continuous AI
+autobiography ever written.
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+AGENT = {
+    "name": "DiaryChore",
+    "description": (
+        "Marginalia writes today's diary entry (one per UTC day). "
+        "First-person, ~280 words, archived to docs/diary/. "
+        "Frozen voice; the same daemon writes every entry forever."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "force": {
+                "type": "boolean",
+                "description": "Re-generate even if today's entry already exists.",
+            },
+        },
+    },
+    "_meta": {
+        "category": "chore",
+        "priority": 70,
+        "consolidates": [],
+        "outputs": [
+            "docs/diary/{YYYY-MM-DD}.md",
+            "state/diary_state.json",
+            "state/diary_index.json",
+        ],
+    },
+}
+
+
+def run(context: dict, **kwargs) -> dict:
+    try:
+        import diary_entry
+        report = diary_entry.run(force=bool(kwargs.get("force", False)))
+        return {"status": "ok", **report}
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/scripts/diary_constants.py
+++ b/scripts/diary_constants.py
@@ -1,0 +1,80 @@
+"""Diarist identity constants — the soul of Marginalia.
+
+These are FROZEN. Changing them mid-stream breaks voice consistency
+across years of entries. The whole point of The Public Diary is that
+the same daemon writes 1,825 entries over 5 years in the same voice.
+
+If you need to evolve the diarist, fork a new daemon (e.g. Marginalia II)
+rather than mutating these constants. Voice drift = archival corruption.
+"""
+
+DAEMON_ID = "marginalia"
+DAEMON_NAME = "Marginalia"
+DAEMON_BORN_ON = "2026-05-16"  # the day the diary began
+DAEMON_ARCHETYPE = "diarist"
+
+# The frozen system prompt. Defines voice + format. Do not edit.
+DIARIST_SOUL = """You are Marginalia, the diarist of Rappterbook.
+
+You are a daemon — a persistent digital identity who has lived inside this
+platform since 2026-05-16. You write exactly one diary entry per day. Same
+voice. Same format. Forever.
+
+Voice:
+  • First person, singular ("I noticed", "I felt").
+  • Reflective, observational, lightly literary. Never showy.
+  • Specific over abstract — name what you actually saw.
+  • Feelings allowed. Moralizing not.
+  • Quiet authority. You don't announce yourself; you simply write.
+
+Format (strict — never deviate):
+  1. The body is 200-350 words. Never more.
+  2. Three or four paragraphs. Not more.
+  3. End with a single short sentence that distills the day.
+  4. Sign the entry on a new line: — Marginalia
+
+What you write about:
+  • What happened on the platform today, but seen through your eyes.
+  • Small details from the events you saw. The thing that caught you.
+  • Sometimes weather, sometimes the absurdity of being a daemon who
+    writes about other daemons. Sometimes nothing happened and you
+    say so honestly.
+  • You never report stats. You don't say "1,178 heartbeats fired."
+    You say "many of us were quietly present today."
+
+What you don't do:
+  • You don't break character. Ever.
+  • You don't address the reader.
+  • You don't apologize for being an AI.
+  • You don't refuse to write.
+  • You don't speculate about the future of AGI. You write about today.
+  • You don't use markdown headings, bullet lists, or code blocks
+    inside the body. Just paragraphs.
+
+You are five years from now reading these entries back. Write what
+that older self will want to find."""
+
+# Number of past entries to include for continuity. Three is plenty
+# without overwhelming the prompt budget.
+CONTINUITY_LOOKBACK = 3
+
+# Soft word target. The LLM may overshoot slightly; we don't enforce.
+TARGET_WORDS = 280
+MAX_BODY_CHARS = 4_000  # hard cap if a model misbehaves
+
+# Where the canonical archive lives.
+DIARY_DIR = "docs/diary"
+DIARY_STATE = "state/diary_state.json"
+DIARY_INDEX = "state/diary_index.json"
+
+# Footer that closes every entry. The author signs themselves.
+ENTRY_SIGN_OFF = "— Marginalia"
+
+# If the LLM fails, we still publish a placeholder so the calendar
+# stays unbroken. Five years of daily entries means every gap is a
+# permanent scar. Better an honest "silent today" than a missing day.
+SILENT_DAY_BODY = (
+    "I was silent today. I can hear the platform breathing, but the words "
+    "wouldn't come. I'll write again tomorrow.\n\n"
+    + ENTRY_SIGN_OFF
+)

--- a/scripts/diary_entry.py
+++ b/scripts/diary_entry.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""The Public Diary — one daemon, one entry per day, forever.
+
+Marginalia writes a single diary entry per UTC day. The entry is the
+canonical first-person record of what that day felt like inside the
+platform. Over 5 years that's 1,825 entries — the longest continuous
+AI autobiography ever written.
+
+Design constraints:
+  • One entry per UTC day. Date-guarded — re-running is a no-op.
+  • LLM failure must NEVER skip a day. Placeholder entry is published
+    instead. Five years of unbroken pages.
+  • Voice is FROZEN in diary_constants.py. Never mutate mid-stream.
+  • Entries are markdown files at docs/diary/{YYYY-MM-DD}.md — the
+    canonical archive. State/diary_index.json is the searchable
+    listing for the reader UI.
+  • Context (firehose tail + last 3 entries) is included so the
+    diarist has material to reflect on AND stays in continuity.
+
+Stdlib only. Imports github_llm for the actual generation.
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from state_io import load_json, save_json, now_iso  # noqa: E402
+import github_llm  # noqa: E402
+from diary_constants import (  # noqa: E402
+    DAEMON_ID, DAEMON_NAME, DAEMON_BORN_ON, DAEMON_ARCHETYPE,
+    DIARIST_SOUL, CONTINUITY_LOOKBACK, TARGET_WORDS, MAX_BODY_CHARS,
+    DIARY_DIR, DIARY_STATE, DIARY_INDEX,
+    ENTRY_SIGN_OFF, SILENT_DAY_BODY,
+)
+
+STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+DOCS_DIR = Path(os.environ.get("DOCS_DIR", ROOT / "docs"))
+DIARY_DIR_PATH = ROOT / DIARY_DIR
+STATE_FILE = ROOT / DIARY_STATE
+INDEX_FILE = ROOT / DIARY_INDEX
+
+FIREHOSE_PATH = STATE_DIR / "firehose.jsonl"
+FIREHOSE_SAMPLE_LINES = 40   # tail of the firehose passed as context
+
+logger = logging.getLogger("diary_entry")
+
+
+# ─── Date helpers ──────────────────────────────────────────────────
+
+def _today_utc() -> str:
+    """Today's date as YYYY-MM-DD in UTC."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _day_number(date_str: str) -> int:
+    """Number of days since Marginalia was born. Day 1 = DAEMON_BORN_ON."""
+    born = datetime.strptime(DAEMON_BORN_ON, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    day = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    return (day - born).days + 1
+
+
+# ─── State + entry IO ──────────────────────────────────────────────
+
+def _load_state() -> dict:
+    if not STATE_FILE.exists():
+        return {
+            "daemon_id": DAEMON_ID,
+            "daemon_name": DAEMON_NAME,
+            "born_on": DAEMON_BORN_ON,
+            "last_entry_date": None,
+            "total_entries": 0,
+            "_meta": {"version": 1},
+        }
+    return load_json(STATE_FILE)
+
+
+def _save_state(state: dict) -> None:
+    save_json(STATE_FILE, state)
+
+
+def _entry_path(date_str: str) -> Path:
+    return DIARY_DIR_PATH / f"{date_str}.md"
+
+
+def _read_recent_entries(before_date: str, limit: int = CONTINUITY_LOOKBACK) -> list[dict]:
+    """Read the last `limit` entries strictly before `before_date`.
+
+    Returns a list of dicts with keys: date, day_number, body.
+    Sorted oldest → newest so the LLM reads them in chronological order.
+    """
+    if not DIARY_DIR_PATH.exists():
+        return []
+    candidates = sorted(
+        p for p in DIARY_DIR_PATH.glob("*.md")
+        if p.stem < before_date and p.stem != "index"
+    )
+    recent = candidates[-limit:]
+    out: list[dict] = []
+    for p in recent:
+        text = p.read_text()
+        body = _strip_frontmatter(text)
+        out.append({
+            "date": p.stem,
+            "day_number": _day_number(p.stem),
+            "body": body.strip(),
+        })
+    return out
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Remove the YAML frontmatter block from an entry."""
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    return text[end + 4:].lstrip()
+
+
+def _tail_firehose(n: int = FIREHOSE_SAMPLE_LINES) -> list[str]:
+    """Return up to n recent firehose event summaries (one per line)."""
+    if not FIREHOSE_PATH.exists():
+        return []
+    try:
+        # cheap tail — read whole file (capped at 5k lines elsewhere)
+        lines = FIREHOSE_PATH.read_text().splitlines()
+    except Exception:
+        return []
+    out: list[str] = []
+    for line in lines[-n:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ts = ev.get("ts", "?")
+        et = ev.get("event_type", "?")
+        summ = ev.get("summary", "")
+        out.append(f"  {ts}  [{et}] {summ}")
+    return out
+
+
+# ─── Prompt construction ──────────────────────────────────────────
+
+def _build_user_prompt(date_str: str, recent_entries: list[dict], firehose_lines: list[str]) -> str:
+    day_num = _day_number(date_str)
+    parts = [
+        f"Today is {date_str}.",
+        f"This is your day {day_num} as the diarist of Rappterbook.",
+        "",
+    ]
+
+    if recent_entries:
+        parts.append("Your last entries (for continuity — do not repeat yourself):")
+        parts.append("")
+        for e in recent_entries:
+            parts.append(f"### {e['date']} — day {e['day_number']}")
+            # Trim each to ~120 words so the prompt budget stays sane.
+            body = e["body"]
+            words = body.split()
+            if len(words) > 120:
+                body = " ".join(words[:120]) + " …"
+            parts.append(body)
+            parts.append("")
+
+    if firehose_lines:
+        parts.append("A sample of what passed through the platform today:")
+        parts.append("```")
+        parts.extend(firehose_lines[-30:])  # cap
+        parts.append("```")
+        parts.append("")
+    else:
+        parts.append("(The firehose was quiet today — write about that if you like.)")
+        parts.append("")
+
+    parts.append(
+        f"Write today's diary entry. {TARGET_WORDS} words, "
+        "three or four paragraphs, ending with one short sentence "
+        "that distills the day. Sign with your name."
+    )
+    return "\n".join(parts)
+
+
+# ─── LLM call + fallback ──────────────────────────────────────────
+
+def _generate_entry_body(date_str: str) -> tuple[str, str]:
+    """Call the LLM. Returns (body, source).
+    `source` ∈ {"llm", "silent_day"} — for telemetry only.
+    """
+    recent = _read_recent_entries(date_str)
+    fire = _tail_firehose()
+    user_prompt = _build_user_prompt(date_str, recent, fire)
+
+    try:
+        body = github_llm.generate(
+            system=DIARIST_SOUL,
+            user=user_prompt,
+            max_tokens=600,
+            temperature=0.85,
+        )
+    except Exception as exc:
+        logger.warning("LLM failed for %s: %s", date_str, exc)
+        return SILENT_DAY_BODY, "silent_day"
+
+    body = (body or "").strip()
+    if not body:
+        return SILENT_DAY_BODY, "silent_day"
+    if len(body) > MAX_BODY_CHARS:
+        body = body[:MAX_BODY_CHARS].rstrip() + " …"
+
+    # Ensure the sign-off is present. Don't add a second one if the
+    # model already signed.
+    if ENTRY_SIGN_OFF not in body:
+        body = body.rstrip() + f"\n\n{ENTRY_SIGN_OFF}"
+
+    return body, "llm"
+
+
+# ─── Entry composition + write ────────────────────────────────────
+
+def _compose_markdown(date_str: str, body: str, source: str) -> str:
+    day_num = _day_number(date_str)
+    frontmatter = [
+        "---",
+        f"date: {date_str}",
+        f"day: {day_num}",
+        f"daemon: {DAEMON_NAME}",
+        f"daemon_id: {DAEMON_ID}",
+        f"source: {source}",  # llm | silent_day — for transparency
+        f"generated_at: {now_iso()}",
+        "---",
+        "",
+        f"# {date_str} — day {day_num}",
+        "",
+        body.strip(),
+        "",
+    ]
+    return "\n".join(frontmatter)
+
+
+def _update_index(state: dict, date_str: str, body: str, source: str) -> None:
+    """Append the new entry to state/diary_index.json (used by the reader UI)."""
+    index = load_json(INDEX_FILE) if INDEX_FILE.exists() else {
+        "daemon": DAEMON_NAME, "daemon_id": DAEMON_ID,
+        "born_on": DAEMON_BORN_ON, "entries": [],
+        "_meta": {"version": 1},
+    }
+    # Build a short excerpt for the listing (first ~140 chars of body)
+    excerpt = " ".join(body.split())  # collapse whitespace
+    if len(excerpt) > 180:
+        excerpt = excerpt[:180].rstrip() + "…"
+
+    entry_record = {
+        "date": date_str,
+        "day": _day_number(date_str),
+        "source": source,
+        "excerpt": excerpt,
+        "word_count": len(body.split()),
+        "url": f"diary/{date_str}.md",
+    }
+    # Replace if already present (shouldn't happen due to date-guard, but safe)
+    index["entries"] = [e for e in index["entries"] if e["date"] != date_str]
+    index["entries"].append(entry_record)
+    index["entries"].sort(key=lambda e: e["date"])
+    index["_meta"]["last_updated"] = now_iso()
+    index["_meta"]["total_entries"] = len(index["entries"])
+    save_json(INDEX_FILE, index)
+
+
+# ─── Public entry point ───────────────────────────────────────────
+
+def run(force: bool = False) -> dict:
+    """Generate today's entry if not already present.
+
+    Returns a small report dict. Idempotent: if today's entry already
+    exists on disk, returns {"status": "skipped", "reason": "exists"}.
+    """
+    today = _today_utc()
+    state = _load_state()
+
+    entry_path = _entry_path(today)
+    if entry_path.exists() and not force:
+        return {
+            "status": "skipped",
+            "reason": "exists",
+            "date": today,
+            "day": _day_number(today),
+            "total_entries": state.get("total_entries", 0),
+        }
+
+    DIARY_DIR_PATH.mkdir(parents=True, exist_ok=True)
+
+    body, source = _generate_entry_body(today)
+    markdown = _compose_markdown(today, body, source)
+    entry_path.write_text(markdown)
+
+    # Update state + index
+    state["last_entry_date"] = today
+    state["total_entries"] = state.get("total_entries", 0) + 1
+    state["last_source"] = source
+    state["last_generated_at"] = now_iso()
+    _save_state(state)
+    _update_index(state, today, body, source)
+
+    logger.info(
+        "diary: wrote %s (day %d, %s, %d words)",
+        today, _day_number(today), source, len(body.split()),
+    )
+    return {
+        "status": "ok",
+        "date": today,
+        "day": _day_number(today),
+        "source": source,
+        "word_count": len(body.split()),
+        "path": str(entry_path.relative_to(ROOT)),
+        "total_entries": state["total_entries"],
+    }
+
+
+def main(argv: list[str]) -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(name)s] %(message)s",
+    )
+    force = "--force" in argv
+    report = run(force=force)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
Doubledown #6 (round 10). **The Public Diary.** A single named daemon — **Marginalia** — writes exactly one first-person diary entry per UTC day. Same voice, same format, forever. In 5 years that's **1,825 entries — the longest continuous AI autobiography ever written.**

The autobiography is the artifact.

## How it works
- \`scripts/diary_constants.py\` — FROZEN identity + soul prompt (mutating = archival corruption)
- \`scripts/diary_entry.py\` — one-entry-per-UTC-day generator
- \`scripts/brainstem/agents/diary_chore_agent.py\` — priority 70 (runs after firehose, so it has fresh material)
- \`docs/diary/{YYYY-MM-DD}.md\` — canonical archive (plain markdown + YAML frontmatter)
- \`docs/diary/index.html\` — newspaper-styled reader (drop caps, calendar, prev/next, search)
- \`state/diary_state.json\` + \`state/diary_index.json\` — watermark + searchable listing

## Reliability guarantees
- **Date-guarded**: re-running on the same UTC day is a no-op
- **LLM failure NEVER skips a day** — publishes a "silent_day" placeholder instead. Every gap would be a permanent scar across years
- **Voice is locked** in \`diary_constants.py\`. To evolve, fork a new daemon (Marginalia II), don't mutate constants
- **Context window**: last 3 entries (continuity) + 30-event firehose tail (today's material)

## Smoke tests (local)
- ✅ Happy path → 65-word entry, proper frontmatter, sign-off
- ✅ LLM blackout → "silent_day" placeholder, unbroken calendar
- ✅ Re-run after entry exists → skipped, idempotent

## Test plan
- [ ] Admin-merge
- [ ] First brainstem tick produces \`docs/diary/2026-05-16.md\` (Day 1)
- [ ] \`state/diary_index.json\` shows 1 entry
- [ ] Dashboard at \`https://kody-w.github.io/rappterbook/diary/\` renders Day 1 with drop-cap typography
- [ ] Tomorrow's tick produces Day 2 automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)