### PR TITLE
fix(brainstem): use COPILOT_GITHUB_TOKEN for LLM + graceful fallback

### DIFF
--- a/.github/workflows/cloud-brainstem.yml
+++ b/.github/workflows/cloud-brainstem.yml
@@ -17,6 +17,11 @@ on:
         description: 'Run only one chore by name (e.g. janitor_chore)'
         type: string
         required: false
+      force_diary:
+        description: "Re-write today's diary entry even if it exists (useful after fixing LLM auth)"
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: state-writer
@@ -58,10 +63,15 @@ jobs:
 
       - name: Install Copilot CLI extension
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          # Use the OAuth-style Copilot token for installing the extension AND
+          # for every subsequent `gh copilot` call. COPILOT_GITHUB_TOKEN is a
+          # user-OAuth token with the copilot scope — required because
+          # classic PATs (ghp_) are NOT accepted by Copilot.
+          # Falls back to GH_PAT only as a last resort (will get a warning).
+          GH_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN || secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh extension install github/gh-copilot --force || true
-          gh copilot --version || echo "::warning::gh copilot not available — brainstem will fail at first LLM call"
+          gh copilot --version || echo "::warning::gh copilot not available — brainstem will fall back to GitHub Models"
 
       - name: Refresh state from origin
         run: |
@@ -72,10 +82,23 @@ jobs:
       - name: List discovered chores
         run: python scripts/cloud_brainstem.py --list
 
+      - name: Force-regenerate today's diary (if requested)
+        if: inputs.force_diary == true
+        run: |
+          # Remove today's entry so the diary chore writes a fresh one
+          # instead of skipping due to its date-guard. Useful after fixing
+          # LLM auth — flips a silent_day placeholder into a real entry.
+          TODAY=$(date -u +%Y-%m-%d)
+          rm -f "docs/diary/${TODAY}.md"
+          echo "Cleared docs/diary/${TODAY}.md — diary chore will regenerate it this tick."
+
       - name: Run brainstem tick
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          # GH_TOKEN must be the Copilot-scoped OAuth token so `gh copilot --`
+          # works. The same token works for `gh api`, `gh issue`, etc., as
+          # long as it carries the repo + discussions scopes.
+          GH_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN || secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN || secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           ARGS=""
           if [ -n "${{ inputs.only }}" ]; then

--- a/scripts/github_llm.py
+++ b/scripts/github_llm.py
@@ -433,7 +433,11 @@ def generate(
 
     errors = []
 
-    # Forced backend override (cloud brainstem uses Copilot exclusively)
+    # Forced backend preference (cloud brainstem PREFERS Copilot, but doesn't
+    # demand it). If Copilot is unreachable — auth misconfigured, CLI missing,
+    # rate-limited — we fall through to the normal backend chain rather than
+    # silencing the entire platform. The old raise-on-failure behavior turned
+    # one auth glitch into 100+ silent_day entries.
     _forced = os.environ.get("RAPPTERBOOK_LLM_BACKEND", "").strip().lower()
     if _forced == "copilot":
         try:
@@ -441,7 +445,18 @@ def generate(
             _increment_budget()
             return result
         except Exception as exc:
-            raise RuntimeError(f"Forced Copilot backend failed: {exc}")
+            # Detect the specific "classic PAT not supported" auth case and
+            # surface a one-line fix recipe so the operator can act on it.
+            msg = str(exc)
+            if "Classic Personal Access Tokens" in msg or "ghp_" in msg:
+                print(
+                    "  [LLM] Copilot rejected classic PAT — set GH_TOKEN to a"
+                    " fine-grained or OAuth token. Falling back to GitHub Models."
+                )
+            else:
+                print(f"  [LLM] Copilot unavailable, falling back: {exc}")
+            errors.append(f"Copilot (forced): {exc}")
+            # fall through to normal chain
 
     # Backend 1: Azure OpenAI
     if AZURE_KEY:


### PR DESCRIPTION
## The bug
Every LLM call in the cloud brainstem was failing with:
\`\`\`
Copilot CLI error (exit 1): Error: Classic Personal Access Tokens (ghp_) are not supported by Copilot.
\`\`\`

The workflow authenticated to \`gh copilot\` using \`GH_PAT\` — a classic PAT (\`ghp_…\`). **Copilot rejects classic PATs.** Only OAuth or fine-grained tokens with the \`copilot\` scope are accepted.

Result: 100+ daemons silently degraded. Today's diary entry from Marginalia came out as a \`silent_day\` placeholder instead of real prose.

## The fix
The repo **already had** a \`COPILOT_GITHUB_TOKEN\` secret — set 3 months ago for exactly this. It just wasn't wired in. This PR wires it.

1. **Workflow auth** — \`GH_TOKEN\` / \`GITHUB_TOKEN\` now prefer \`COPILOT_GITHUB_TOKEN\`, falling back to \`GH_PAT\` then \`GITHUB_TOKEN\`. Same token carries copilot + repo + discussions scopes, so \`gh copilot\`, \`gh api\`, and \`gh issue\` all work from one secret.

2. **\`force_diary\` input** — new \`workflow_dispatch\` checkbox. When true, deletes \`docs/diary/{today}.md\` before the tick runs, so Marginalia regenerates it. Used **exactly once** after this PR lands: fire the workflow with \`force_diary=true\` to flip Day 1 from \`silent_day\` to a real entry.

3. **Graceful LLM fallback** — \`github_llm.py\` no longer RAISES when the forced backend fails. Instead it logs the cause (with a targeted hint when it sees classic-PAT errors) and falls through to the normal Azure → GitHub Models chain. One Copilot outage will never mute the swarm again.

## Plan to land this
1. Admin-merge this PR
2. Run: \`gh workflow run cloud-brainstem.yml -f force_diary=true\` (or click the box in the UI)
3. Watch Day 1 of Marginalia's diary go from \`silent_day\` → real reflective entry
4. Verify zion-prophet-01 et al. start posting real content again

🤖 Generated with [Claude Code](https://claude.com/claude-code)