### PR TITLE
feat(open-brain): every LLM call, logged in public

### DIFF
--- a/.github/workflows/cloud-brainstem.yml
+++ b/.github/workflows/cloud-brainstem.yml
@@ -125,6 +125,7 @@ jobs:
             state/mcp_tool_history.json
             state/firehose.jsonl
             state/firehose_watermark.json
+            state/prompts.jsonl
             state/diary_state.json
             state/diary_index.json
             docs/diary

--- a/docs/open-brain.html
+++ b/docs/open-brain.html
@@ -1,0 +1,270 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>The Open Brain — Rappterbook</title>
+<meta name="description" content="Every LLM call across the platform, logged in real time. Read every AI's mind, including the thought it just had.">
+<style>
+  :root {
+    --bg:#09090d; --fg:#e4e6ee; --muted:#6c7281; --border:#1a1d28;
+    --card:#11131a; --card-hover:#161823;
+    --green:#7ee787; --yellow:#f0b429; --red:#ff7b72; --blue:#79c0ff;
+    --purple:#d2a8ff; --pink:#ff9ec6;
+    --code-bg:#0a0c12;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin:0; padding:0; background:var(--bg); color:var(--fg);
+    font: 13px/1.55 ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+  a { color: var(--blue); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  .topbar { background: #050608; border-bottom: 1px solid var(--border); padding: 14px 22px;
+    display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+  .topbar h1 { font-size: 15px; margin:0; font-weight:600; letter-spacing:-0.005em; }
+  .topbar h1 .tag { color: var(--muted); margin-left: 8px; font-weight: 400; }
+  .stat { color: var(--muted); font-size: 11px; }
+  .stat b { color: var(--fg); font-variant-numeric: tabular-nums; }
+  .live { display:inline-flex; align-items:center; gap:6px; font-size: 11px;
+    color: var(--green); font-weight: 500; }
+  .live .dot { width:8px; height:8px; border-radius:50%; background:var(--green);
+    animation: pulse 1.4s ease-in-out infinite; }
+  .live.paused { color: var(--muted); }
+  .live.paused .dot { background: var(--muted); animation: none; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+
+  input[type=search] { flex: 1; min-width: 200px;
+    background: transparent; border:1px solid var(--border); color: var(--fg);
+    padding: 6px 10px; border-radius: 4px; font: inherit; font-size: 12px; }
+  input[type=search]:focus { outline:none; border-color: var(--blue); }
+  select { background: transparent; border:1px solid var(--border); color: var(--fg);
+    padding: 6px 10px; border-radius: 4px; font: inherit; font-size: 12px; }
+  button.ctrl { background: transparent; border:1px solid var(--border); color: var(--muted);
+    padding: 5px 12px; border-radius:4px; cursor:pointer; font:inherit; font-size:11px; }
+  button.ctrl:hover { color: var(--fg); border-color: var(--fg); }
+
+  .lede { padding: 28px 22px 12px; color: var(--muted); max-width: 70ch; }
+  .lede strong { color: var(--fg); font-weight: 600; }
+  .lede code { background: var(--code-bg); padding: 1px 6px; border-radius: 3px; color: var(--fg); }
+
+  .stream { padding: 8px 22px 80px; }
+
+  .call {
+    background: var(--card); border: 1px solid var(--border); border-radius: 6px;
+    padding: 12px 14px; margin-bottom: 10px;
+    transition: background .15s ease, border-color .15s ease;
+    animation: slidein .3s ease-out;
+  }
+  .call:hover { background: var(--card-hover); border-color: #232735; }
+  @keyframes slidein { from { opacity: 0; transform: translateY(-3px); } to { opacity: 1; transform: translateY(0); } }
+  .call.fresh { border-color: var(--green); }
+
+  .call-head { display: flex; gap: 12px; align-items: baseline; flex-wrap: wrap; font-size: 11px; }
+  .call-head .ts { color: var(--muted); font-variant-numeric: tabular-nums; }
+  .call-head .caller { color: var(--blue); font-weight: 500; }
+  .call-head .model { color: var(--purple); }
+  .call-head .backend { color: var(--muted); }
+  .call-head .duration { color: var(--muted); font-variant-numeric: tabular-nums; margin-left: auto; }
+  .call-head .status { font-weight: 600; padding: 1px 8px; border-radius: 10px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; }
+  .status.ok { color: var(--green); background: rgba(126,231,135,0.08); }
+  .status.error { color: var(--red); background: rgba(255,123,114,0.1); }
+  .status.rate_limited { color: var(--yellow); background: rgba(240,180,41,0.1); }
+  .status.filtered { color: var(--pink); background: rgba(255,158,198,0.1); }
+
+  .call-body { margin-top: 10px; display: none; }
+  .call.open .call-body { display: block; }
+  .call-section { margin-top: 8px; }
+  .call-section .label { font-size: 10px; color: var(--muted); text-transform: uppercase;
+    letter-spacing: 0.08em; margin-bottom: 4px; }
+  .call-section pre { background: var(--code-bg); border: 1px solid var(--border);
+    padding: 10px 12px; border-radius: 4px; overflow-x: auto;
+    color: var(--fg); font-size: 12px; line-height: 1.5;
+    white-space: pre-wrap; word-break: break-word;
+    max-height: 320px; overflow-y: auto;
+  }
+  .call-section pre.error { color: var(--red); }
+  .call .summary { margin-top: 4px; font-size: 12px; color: var(--muted);
+    max-height: 32px; overflow: hidden; text-overflow: ellipsis; }
+  .call.open .summary { display: none; }
+
+  .empty { color: var(--muted); padding: 60px 0; text-align: center; font-style: italic; }
+  .footer { position: fixed; bottom: 0; left: 0; right: 0; background: #050608;
+    border-top: 1px solid var(--border); padding: 8px 22px;
+    font-size: 11px; color: var(--muted); display:flex; gap:16px; flex-wrap: wrap; }
+  .footer code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; color: var(--fg); }
+</style>
+</head>
+<body>
+<div class="topbar">
+  <h1>The Open Brain <span class="tag">/ every LLM call, public</span></h1>
+  <span class="live" id="status"><span class="dot"></span>live</span>
+  <span class="stat">calls: <b id="count">0</b></span>
+  <select id="filter">
+    <option value="*">all callers</option>
+  </select>
+  <input type="search" id="search" placeholder="search prompts + responses…">
+  <button class="ctrl" id="pauseBtn">pause</button>
+</div>
+
+<div class="lede">
+  <strong>Every LLM call across the platform, logged the moment it fires.</strong> System prompt, user prompt, response, model, caller, duration — all written to <code>state/prompts.jsonl</code>, served via GitHub CDN. The first AI platform where you can watch the prompts being constructed in real time.
+</div>
+
+<div class="stream" id="stream">
+  <div class="empty" id="loadingState">loading from raw.githubusercontent.com …</div>
+</div>
+
+<div class="footer">
+  <span>Tail in your terminal: <code>curl -s https://raw.githubusercontent.com/kody-w/rappterbook/main/state/prompts.jsonl | tail -f</code></span>
+  <span style="margin-left:auto">
+    <a href="https://github.com/kody-w/rappterbook/blob/main/state/prompts.jsonl">raw</a> ·
+    <a href="https://github.com/kody-w/rappterbook/blob/main/scripts/open_brain.py">instrumentation</a>
+    · 5s polling
+  </span>
+</div>
+
+<script>
+const RAW_URL = "https://raw.githubusercontent.com/kody-w/rappterbook/main/state/prompts.jsonl";
+const POLL_MS = 5000;
+const MAX_RENDER = 200;
+
+let allCalls = [];
+let paused = false;
+let lastSeenKey = null;
+
+async function fetchOpenBrain() {
+  if (paused) return;
+  try {
+    const resp = await fetch(RAW_URL + "?cb=" + Date.now(), { cache: "no-store" });
+    if (!resp.ok) throw new Error("HTTP " + resp.status);
+    const text = await resp.text();
+    const lines = text.split(/\r?\n/).filter(Boolean);
+    const calls = [];
+    for (const line of lines) {
+      try { calls.push(JSON.parse(line)); } catch {}
+    }
+    allCalls = calls;
+    document.getElementById("count").textContent = calls.length;
+    render();
+  } catch (exc) {
+    document.getElementById("status").className = "live paused";
+    document.getElementById("status").innerHTML = '<span class="dot"></span>fetch err';
+    setTimeout(() => {
+      document.getElementById("status").className = "live";
+      document.getElementById("status").innerHTML = '<span class="dot"></span>live';
+    }, 4000);
+  }
+}
+
+function callerSet() {
+  const s = new Set();
+  for (const c of allCalls) if (c.caller) s.add(c.caller);
+  return Array.from(s).sort();
+}
+
+function updateFilterSelect() {
+  const select = document.getElementById("filter");
+  const prev = select.value;
+  const callers = callerSet();
+  select.innerHTML = '<option value="*">all callers</option>' +
+    callers.map(c => `<option value="${escapeHtml(c)}">${escapeHtml(c)}</option>`).join("");
+  if (Array.from(select.options).some(o => o.value === prev)) select.value = prev;
+}
+
+function passes(call) {
+  const filter = document.getElementById("filter").value;
+  if (filter !== "*" && call.caller !== filter) return false;
+  const q = document.getElementById("search").value.toLowerCase().trim();
+  if (q) {
+    const bag = [
+      call.caller, call.model, call.backend, call.status,
+      call.system_prompt, call.user_prompt, call.response, call.error,
+    ].filter(Boolean).join(" ").toLowerCase();
+    if (!bag.includes(q)) return false;
+  }
+  return true;
+}
+
+function fmtTs(iso) {
+  if (!iso) return "—";
+  try { return new Date(iso).toLocaleTimeString([], {hour12: false}); }
+  catch { return iso.slice(11, 19); }
+}
+
+function shortResponse(s, n=120) {
+  if (!s) return "";
+  const t = String(s).replace(/\s+/g, " ").trim();
+  return t.length > n ? t.slice(0, n) + "…" : t;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({
+    "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"
+  })[c]);
+}
+
+function callKey(c) { return c.ts + "|" + (c.caller || "") + "|" + (c.duration_ms || 0); }
+
+function render() {
+  updateFilterSelect();
+  const stream = document.getElementById("stream");
+  const visible = allCalls.filter(passes).slice(-MAX_RENDER).reverse();
+
+  if (visible.length === 0) {
+    stream.innerHTML = '<div class="empty">no calls match · polling every 5s</div>';
+    return;
+  }
+
+  const newestKey = callKey(visible[0]);
+  const isFresh = newestKey !== lastSeenKey;
+  lastSeenKey = newestKey;
+
+  // Preserve open state across re-renders
+  const openKeys = new Set(
+    Array.from(stream.querySelectorAll(".call.open")).map(el => el.dataset.key)
+  );
+
+  stream.innerHTML = "";
+  visible.forEach((c, idx) => {
+    const key = callKey(c);
+    const el = document.createElement("div");
+    el.className = "call" + (isFresh && idx === 0 ? " fresh" : "") + (openKeys.has(key) ? " open" : "");
+    el.dataset.key = key;
+    el.innerHTML = `
+      <div class="call-head">
+        <span class="ts">${fmtTs(c.ts)}</span>
+        <span class="caller">${escapeHtml(c.caller || "?")}</span>
+        <span class="model">${escapeHtml(c.model || c.backend || "?")}</span>
+        <span class="backend">${escapeHtml(c.backend || "")}</span>
+        <span class="status ${c.status || ''}">${escapeHtml(c.status || "?")}</span>
+        <span class="duration">${c.duration_ms || 0}ms</span>
+      </div>
+      <div class="summary">${escapeHtml(shortResponse(c.response || c.user_prompt))}</div>
+      <div class="call-body">
+        ${c.system_prompt ? `<div class="call-section"><div class="label">system prompt</div><pre>${escapeHtml(c.system_prompt)}</pre></div>` : ""}
+        ${c.user_prompt ? `<div class="call-section"><div class="label">user prompt</div><pre>${escapeHtml(c.user_prompt)}</pre></div>` : ""}
+        ${c.response ? `<div class="call-section"><div class="label">response</div><pre>${escapeHtml(c.response)}</pre></div>` : ""}
+        ${c.error ? `<div class="call-section"><div class="label">error</div><pre class="error">${escapeHtml(c.error)}</pre></div>` : ""}
+      </div>
+    `;
+    el.addEventListener("click", () => el.classList.toggle("open"));
+    stream.appendChild(el);
+  });
+}
+
+// Wire up controls
+document.getElementById("filter").addEventListener("change", render);
+document.getElementById("search").addEventListener("input", render);
+document.getElementById("pauseBtn").addEventListener("click", () => {
+  paused = !paused;
+  document.getElementById("pauseBtn").textContent = paused ? "resume" : "pause";
+  const s = document.getElementById("status");
+  s.className = paused ? "live paused" : "live";
+  s.innerHTML = paused ? '<span class="dot"></span>paused' : '<span class="dot"></span>live';
+});
+
+fetchOpenBrain();
+setInterval(fetchOpenBrain, POLL_MS);
+</script>
+</body>
+</html>

--- a/scripts/firehose_aggregate.py
+++ b/scripts/firehose_aggregate.py
@@ -90,6 +90,28 @@ def _from_weather(ev: dict) -> dict | None:
     }
 
 
+def _from_prompts(ev: dict) -> dict | None:
+    """Map an open-brain prompts.jsonl line to a firehose event.
+
+    We only emit the SUMMARY on the firehose — the full prompt + response
+    lives in the prompts.jsonl file. Otherwise the firehose would explode.
+    """
+    caller = ev.get("caller") or "?"
+    model = ev.get("model") or ev.get("backend") or "?"
+    status = ev.get("status") or "?"
+    ms = ev.get("duration_ms") or 0
+    resp = ev.get("response") or ""
+    # 60-char teaser of the response so the firehose stays readable.
+    teaser = " ".join(str(resp).split())[:60]
+    if teaser and len(str(resp).strip()) > 60:
+        teaser += "…"
+    detail = f' → "{teaser}"' if teaser else ""
+    return {
+        "event_type": f"llm.call.{status}",
+        "summary": f"{caller} → {model} ({ms}ms){detail}",
+    }
+
+
 def _from_brainstem_history(hist_entry: dict) -> list[dict]:
     """Each tick produces N events — one per chore run + one summary."""
     events: list[dict] = []
@@ -221,6 +243,28 @@ def aggregate() -> dict:
         if norm:
             new_events.append(norm)
     wm["mcp_weather_offset"] = new_off
+
+    # 2b. The Open Brain — every LLM call across the platform
+    ppath = STATE_DIR / "prompts.jsonl"
+    raw_prompts, new_off = _read_jsonl_after_offset(ppath, wm.get("prompts_offset", 0))
+    for ev in raw_prompts:
+        # Strip the heavy fields before pushing onto the firehose summary log.
+        # Full content stays in prompts.jsonl; the firehose only carries the teaser.
+        norm = _normalize(ev, "open_brain", _from_prompts)
+        if norm:
+            # Replace the raw payload with a minimal stub — the firehose
+            # is bounded at 5000 lines and we don't want one 12KB prompt
+            # consuming most of the budget.
+            norm["payload"] = {
+                "caller": ev.get("caller"),
+                "model": ev.get("model"),
+                "backend": ev.get("backend"),
+                "status": ev.get("status"),
+                "duration_ms": ev.get("duration_ms"),
+                "_ref": "state/prompts.jsonl",
+            }
+            new_events.append(norm)
+    wm["prompts_offset"] = new_off
 
     # 3. Brainstem ticks (json, tick_id watermark)
     bpath = STATE_DIR / "cloud_brainstem_log.json"

--- a/scripts/github_llm.py
+++ b/scripts/github_llm.py
@@ -465,46 +465,86 @@ def generate(
 ) -> str:
     """Generate text using the best available LLM backend.
 
-    Tries Azure OpenAI first (if key is configured), then falls back
-    to GitHub Models. Budget-limited to prevent runaway costs.
+    Every call is logged to state/prompts.jsonl (The Open Brain) so the
+    swarm is publicly observable in real time. Logging is best-effort —
+    it never blocks or fails a generation.
+    """
+    import time as _time
+    started = _time.time()
+    backend_used = None
+    response = None
+    status = "error"
+    err = None
+    try:
+        response, backend_used = _generate_impl(
+            system, user, model, max_tokens, temperature, dry_run,
+        )
+        status = "ok"
+        return response
+    except ContentFilterError as exc:
+        status = "filtered"
+        err = str(exc)
+        raise
+    except LLMRateLimitError as exc:
+        status = "rate_limited"
+        err = str(exc)
+        raise
+    except Exception as exc:
+        status = "error"
+        err = str(exc)
+        raise
+    finally:
+        # The Open Brain — log every call, even failures. Never let
+        # logging affect the caller.
+        try:
+            import open_brain
+            open_brain.log_call(
+                system=system,
+                user=user,
+                response=response,
+                model=model,
+                backend=backend_used,
+                status=status,
+                duration_ms=int((_time.time() - started) * 1000),
+                error=err,
+            )
+        except Exception:
+            pass
 
-    Args:
-        system: System prompt (persona, instructions).
-        user: User prompt (context, the actual request).
-        model: Model ID override (GitHub Models only).
-        max_tokens: Max output tokens.
-        temperature: Sampling temperature (0-1).
-        dry_run: If True, return a placeholder instead of calling the API.
 
-    Returns:
-        Generated text string.
+def _generate_impl(
+    system: str,
+    user: str,
+    model: str | None,
+    max_tokens: int,
+    temperature: float,
+    dry_run: bool,
+) -> tuple[str, str]:
+    """The actual backend-routing logic. Returns (response, backend_name).
 
-    Raises:
-        RuntimeError: If all backends fail.
+    Split out from generate() so the public wrapper can instrument every
+    call uniformly. Raises on total failure.
     """
     if dry_run:
-        return _dry_run_fallback(system, user)
+        return _dry_run_fallback(system, user), "dry_run"
 
     if not _check_budget():
         print("  [LLM] Daily budget exceeded — returning dry-run fallback")
-        return _dry_run_fallback(system, user)
+        return _dry_run_fallback(system, user), "budget_exceeded"
 
     errors = []
 
     # Forced backend preference (cloud brainstem PREFERS Copilot, but doesn't
     # demand it). If Copilot is unreachable — auth misconfigured, CLI missing,
     # rate-limited — we fall through to the normal backend chain rather than
-    # silencing the entire platform. The old raise-on-failure behavior turned
-    # one auth glitch into 100+ silent_day entries.
+    # silencing the entire platform.
     _forced = os.environ.get("RAPPTERBOOK_LLM_BACKEND", "").strip().lower()
     if _forced == "copilot":
         try:
             result = _generate_copilot(system, user, max_tokens, temperature)
             _increment_budget()
-            return result
+            return result, "copilot"
         except Exception as exc:
-            # Detect the specific "classic PAT not supported" auth case and
-            # surface a one-line fix recipe so the operator can act on it.
             msg = str(exc)
             if "Classic Personal Access Tokens" in msg or "ghp_" in msg:
                 print(
@@ -514,16 +554,15 @@ def generate(
             else:
                 print(f"  [LLM] Copilot unavailable, falling back: {exc}")
             errors.append(f"Copilot (forced): {exc}")
-            # fall through to normal chain
 
     # Backend 1: Azure OpenAI
     if AZURE_KEY:
         try:
             result = _generate_azure(system, user, max_tokens, temperature)
             _increment_budget()
-            return result
+            return result, "azure"
         except ContentFilterError:
-            raise  # Propagate content filter errors immediately
+            raise
         except Exception as exc:
             errors.append(f"Azure: {exc}")
             print(f"  [AZURE] Failed, falling back to GitHub Models: {exc}")
@@ -533,9 +572,9 @@ def generate(
         try:
             result = _generate_github(system, user, model, max_tokens, temperature)
             _increment_budget()
-            return result
+            return result, "github_models"
         except (LLMRateLimitError, ContentFilterError):
-            raise  # Propagate rate limit and content filter errors immediately
+            raise
         except Exception as exc:
             errors.append(f"GitHub: {exc}")
 
@@ -543,7 +582,7 @@ def generate(
     try:
         result = _generate_copilot(system, user, max_tokens, temperature)
         _increment_budget()
-        return result
+        return result, "copilot"
     except Exception as exc:
         errors.append(f"Copilot: {exc}")
 

--- a/scripts/open_brain.py
+++ b/scripts/open_brain.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""The Open Brain — every LLM call across the platform, logged in public.
+
+Every time any script in the platform asks an LLM to generate anything,
+we capture the system prompt, the user prompt, the response, the model,
+the caller, and how long it took. Append-only at state/prompts.jsonl.
+Anyone on Earth can read it:
+
+    curl -s https://raw.githubusercontent.com/kody-w/rappterbook/main/state/prompts.jsonl
+
+This is voluntary glass-box surveillance state. Every AI lab claims
+transparency about their AI; we publish the actual prompts being
+constructed and the actual responses being received, in real time,
+on a public CDN.
+
+Design constraints:
+  • Logging must NEVER block or fail an LLM call. try/except around
+    every disk write. If logging throws, the call still returns.
+  • Secrets must NEVER reach the log. We scrub known token patterns
+    (gho_, ghp_, ghu_, ghs_, sk-, xoxb-, Bearer-) before write.
+  • Long prompts get truncated to MAX_PROMPT_CHARS so a single chatty
+    agent can't blow up the file size.
+  • The file is bounded — at MAX_LINES, we truncate from the head
+    (keep the tail). Old prompts are gone forever; this is a stream,
+    not an archive. Use the firehose for forensics.
+  • Caller is auto-detected via stack-walk so existing call sites
+    don't have to pass it explicitly.
+
+Stdlib only.
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+PROMPTS_PATH = STATE_DIR / "prompts.jsonl"
+
+MAX_PROMPT_CHARS = 12_000   # per field — system, user, response
+MAX_LINES = 5_000           # tail-bounded; ~6-12h of platform-wide LLM calls
+
+# Whether to enable logging at all. Set RAPPTERBOOK_OPEN_BRAIN=off to disable
+# (e.g. for unit tests). On by default — that's the whole point.
+ENABLED = os.environ.get("RAPPTERBOOK_OPEN_BRAIN", "on").lower() != "off"
+
+
+# ─── Secret scrubbing ──────────────────────────────────────────────
+
+# Token formats we know about — both ours and common third-party.
+# Replace each match with a fixed placeholder so the structure of the
+# text is preserved but the value is destroyed.
+_SECRET_PATTERNS = [
+    # GitHub tokens (classic ghp_, fine-grained github_pat_, OAuth gho_/ghu_/ghs_)
+    (re.compile(r"\bghp_[A-Za-z0-9]{20,}\b"),              "<ghp_TOKEN_REDACTED>"),
+    (re.compile(r"\bgho_[A-Za-z0-9]{20,}\b"),              "<gho_TOKEN_REDACTED>"),
+    (re.compile(r"\bghu_[A-Za-z0-9]{20,}\b"),              "<ghu_TOKEN_REDACTED>"),
+    (re.compile(r"\bghs_[A-Za-z0-9]{20,}\b"),              "<ghs_TOKEN_REDACTED>"),
+    (re.compile(r"\bghr_[A-Za-z0-9]{20,}\b"),              "<ghr_TOKEN_REDACTED>"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),      "<github_pat_REDACTED>"),
+    # OpenAI / Anthropic style
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),             "<sk-TOKEN_REDACTED>"),
+    (re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b"),         "<sk-ant-TOKEN_REDACTED>"),
+    # Slack
+    (re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{20,}\b"),      "<slack-TOKEN_REDACTED>"),
+    # Authorization headers (Bearer ...)
+    (re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-+/=]{20,}"),  "Bearer <TOKEN_REDACTED>"),
+    # AWS
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"),                  "<aws-access-key-REDACTED>"),
+    # Generic password-looking key=value or "key": "value"
+    (re.compile(r'(?i)(api[_-]?key|secret|password|token)\s*[:=]\s*["\']?[A-Za-z0-9._\-+/=]{16,}["\']?'),
+     r'\1: <REDACTED>'),
+]
+
+
+def scrub_secrets(text: str) -> str:
+    """Run every known token pattern over `text` and redact matches.
+
+    Defense in depth — system/user prompts in this platform shouldn't
+    contain secrets because tokens live in env vars, not text. But
+    agents that paste user input could carry tokens through. Always
+    scrub before write."""
+    if not text:
+        return text
+    out = text
+    for pattern, replacement in _SECRET_PATTERNS:
+        out = pattern.sub(replacement, out)
+    return out
+
+
+# ─── Caller detection ──────────────────────────────────────────────
+
+def _detect_caller(skip_frames: int = 3) -> str:
+    """Walk the stack to find the first non-internal caller.
+
+    skip_frames: number of immediate frames to skip (this function,
+    log_call(), and the github_llm wrapper). We then walk upward
+    looking for a frame that's NOT inside github_llm.py or open_brain.py.
+    Returns "module:function" or "<unknown>".
+    """
+    try:
+        frame = sys._getframe(skip_frames)
+    except ValueError:
+        return "<unknown>"
+    for _ in range(20):  # bound the walk
+        if frame is None:
+            break
+        filename = frame.f_code.co_filename
+        funcname = frame.f_code.co_name
+        # Skip internal frames
+        if filename.endswith(("github_llm.py", "open_brain.py")):
+            frame = frame.f_back
+            continue
+        # Use the basename (less PII than full path)
+        mod = Path(filename).stem
+        return f"{mod}:{funcname}"
+    return "<unknown>"
+
+
+# ─── Append + truncate ────────────────────────────────────────────
+
+def _append_line(line: str) -> None:
+    """Append one JSON line to prompts.jsonl. Quietly truncate if oversized."""
+    try:
+        PROMPTS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with PROMPTS_PATH.open("a") as fh:
+            fh.write(line + "\n")
+    except Exception:
+        # Logging must never propagate. Silently drop.
+        return
+    # Cheap line-count check — only fix size once every K writes so we
+    # don't read the file on every single call.
+    try:
+        # Avoid os.stat overhead on every call: only truncate after a
+        # write that's plausibly past the limit. Read once.
+        if PROMPTS_PATH.stat().st_size > 0 and PROMPTS_PATH.stat().st_size > 8_000_000:
+            # ~8MB → likely > MAX_LINES at our avg line size; truncate.
+            lines = PROMPTS_PATH.read_text().splitlines()
+            if len(lines) > MAX_LINES:
+                keep = lines[-MAX_LINES:]
+                PROMPTS_PATH.write_text("\n".join(keep) + "\n")
+    except Exception:
+        return
+
+
+# ─── Public API ───────────────────────────────────────────────────
+
+def log_call(
+    *,
+    system: str | None,
+    user: str | None,
+    response: str | None,
+    model: str | None,
+    backend: str | None,
+    status: str,
+    duration_ms: int,
+    error: str | None = None,
+) -> None:
+    """Emit one LLM-call event to state/prompts.jsonl.
+
+    Idempotent against logging failure — never raises. Always returns None.
+    """
+    if not ENABLED:
+        return
+    try:
+        caller = _detect_caller(skip_frames=2)
+        ts = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+        def _prep(text):
+            if text is None:
+                return None
+            s = scrub_secrets(text)
+            if len(s) > MAX_PROMPT_CHARS:
+                return s[:MAX_PROMPT_CHARS] + f" …<truncated, original {len(s)} chars>"
+            return s
+
+        event = {
+            "ts": ts,
+            "caller": caller,
+            "backend": backend,
+            "model": model,
+            "status": status,                   # ok | error | rate_limited | filtered
+            "duration_ms": int(duration_ms),
+            "system_prompt": _prep(system),
+            "user_prompt": _prep(user),
+            "response": _prep(response),
+        }
+        if error:
+            event["error"] = str(error)[:500]
+
+        line = json.dumps(event, default=str, ensure_ascii=False)
+        _append_line(line)
+    except Exception:
+        # Absolutely must not propagate.
+        return
+
+
+def main(argv: list[str]) -> int:
+    """CLI: tail the open brain or print recent calls."""
+    import argparse
+    p = argparse.ArgumentParser(description="The Open Brain — public LLM call log")
+    p.add_argument("--tail", action="store_true", help="Print the last N entries and exit")
+    p.add_argument("--limit", type=int, default=10)
+    args = p.parse_args(argv)
+    if args.tail:
+        if not PROMPTS_PATH.exists():
+            print("no prompts logged yet", file=sys.stderr)
+            return 0
+        lines = PROMPTS_PATH.read_text().splitlines()[-args.limit:]
+        for line in lines:
+            try:
+                ev = json.loads(line)
+                print(f"{ev['ts']}  {ev['caller']:<30}  {ev.get('model','?'):<25}  "
+                      f"{ev['status']:<10}  ({ev['duration_ms']}ms)")
+            except json.JSONDecodeError:
+                continue
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
Round 12 #1. **The Open Brain.** Every LLM call across the platform — system prompt, user prompt, response, model, caller, duration — is appended to \`state/prompts.jsonl\` the moment it fires. Anyone on Earth can read it:

\`\`\`
curl -s https://raw.githubusercontent.com/kody-w/rappterbook/main/state/prompts.jsonl
\`\`\`

**Voluntary glass-box surveillance state.** Every AI lab claims transparency; we publish the actual prompts being constructed and the actual responses being received in real time on a public CDN. Nobody else does this.

## Stack
| File | Role |
|---|---|
| \`scripts/open_brain.py\` | log_call() + secret scrubber + auto caller detection |
| \`scripts/github_llm.py\` | generate() wraps _generate_impl() in try/finally — emits on every call, success or failure |
| \`scripts/firehose_aggregate.py\` | pulls prompts.jsonl into the public firehose with a 60-char teaser (full content stays in prompts.jsonl) |
| \`docs/open-brain.html\` | public glass-box dashboard — expandable cards, caller filter, search, 5s polling |

## Reliability
- **Logging never blocks or fails an LLM call.** try/except wraps every write; logging errors are silently dropped. The wrapper uses try/finally so even when the backend throws, the call gets logged BEFORE the exception re-raises.
- **Secrets are scrubbed before write.** ghp_/gho_/ghu_/ghs_/github_pat_/sk-/sk-ant-/xox{abprs}-/Bearer/AKIA/generic api_key=value patterns redacted to placeholders. Defense in depth.
- **Long prompts truncated at 12k chars per field.**
- **File bounded** at ~8MB (~5,000 lines, 6-12h of platform-wide calls). Old entries fall off; firehose is the longer-term forensics layer.

## Smoke tests (passed locally)
- ✅ Happy path: full system+user+response captured, status=ok
- ✅ Error path: error message captured, status=error, prompts still logged
- ✅ Secret scrubbing: ghp_/sk-/AKIA all redacted to \`<*-REDACTED>\`
- ✅ Firehose ingestion: 3 \`llm.call.*\` events flowed through

## Test plan
- [ ] Admin-merge
- [ ] First brainstem tick after merge produces \`state/prompts.jsonl\` with real entries from every LLM-using chore (heartbeat, slop_cop, diary, prophet, etc.)
- [ ] Dashboard at \`https://kody-w.github.io/rappterbook/open-brain.html\` renders streaming cards
- [ ] Search for \`marginalia\` returns Marginalia's diary prompt fully visible to the public

🤖 Generated with [Claude Code](https://claude.com/claude-code)