### PR TITLE
fix(safe_commit): shallow-clone guard + re-enable remix

### DIFF
--- a/.github/workflows/prompt-remix.yml
+++ b/.github/workflows/prompt-remix.yml
@@ -10,8 +10,11 @@ on:
     types: [opened, labeled, reopened]
 
 concurrency:
+  # Cancel any in-flight run for the same issue. Two events (opened +
+  # labeled) commonly fire near-simultaneously; allowing both to race
+  # to safe_commit caused the 2026-05-16 orphan-commit incident.
   group: prompt-remix-${{ github.event.issue.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -26,10 +29,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Shallow — we only need to write one file (state/remixes.jsonl).
-          # Full history was responsible for the witness-receive timeouts
-          # we burned a PR on; not repeating that here.
-          fetch-depth: 1
+          # FULL history — fetch-depth: 1 caused the 2026-05-16 main-branch
+          # orphan-commit incident: safe_commit.sh's amend path on a shallow
+          # clone produced a parentless commit that overwrote the entire
+          # branch ancestry via force-with-lease. safe_commit.sh now has a
+          # shallow-repo guard, but defense in depth: ALSO checkout full
+          # history. We only write one file; the cost is bandwidth, not
+          # disk or runtime.
+          fetch-depth: 0
           ref: main
 
       - name: Set up Python

--- a/scripts/safe_commit.sh
+++ b/scripts/safe_commit.sh
@@ -50,15 +50,56 @@ if git diff --staged --quiet; then
   exit 0
 fi
 
-# Amend if the previous commit has the same message (squash repeated chore commits)
+# Detect shallow clone. The amend-squash optimization below CANNOT run on
+# a shallow repo: `git commit --amend` of the only commit produces a new
+# commit with NO parent, and `git push --force-with-lease` happily accepts
+# it as the new main, orphaning the entire branch's history.
+#
+# Incident: 2026-05-16 — the prompt-remix workflow used fetch-depth: 1.
+# Two parallel runs collided on the same issue. Run 2's safe_commit hit
+# the amend path because Run 1 had just pushed a commit with the same
+# message. The amend created a parentless commit. The force-with-lease
+# orbited that commit onto main. Result: every previous commit's
+# ancestry was lost from main's git log. Required manual force-push to
+# restore. See PR #18341 follow-up for full forensics.
+IS_SHALLOW=$(git rev-parse --is-shallow-repository 2>/dev/null || echo "false")
+
+# Amend if the previous commit has the same message (squash repeated chore
+# commits). ONLY safe with full history — never on a shallow clone.
 LAST_MSG=$(git log -1 --format=%s 2>/dev/null || echo "")
-if [ "$LAST_MSG" = "$COMMIT_MSG" ]; then
+if [ "$LAST_MSG" = "$COMMIT_MSG" ] && [ "$IS_SHALLOW" != "true" ]; then
   echo "Amending previous commit (same message: $COMMIT_MSG)"
   git commit --amend --no-edit
   PUSH_FLAGS="--force-with-lease"
 else
+  if [ "$LAST_MSG" = "$COMMIT_MSG" ] && [ "$IS_SHALLOW" = "true" ]; then
+    echo "Skipping amend — repo is shallow; would orphan main. Creating new commit instead."
+  fi
   git commit -m "$COMMIT_MSG"
   PUSH_FLAGS=""
+fi
+
+# Sanity guard: never push if our new HEAD looks like an orphan AND we
+# know the remote has history. An orphan-on-empty-repo is legitimate;
+# an orphan when main already has 18,000 commits is the bug above.
+#
+# Implementation note: `git rev-list --parents -n 1 HEAD` prints one line
+# of the form "<sha> <parent1> <parent2> ...". Parent count = NF - 1.
+# Do NOT add --count — that collapses output to a single integer and
+# breaks the awk parsing (this is why an earlier version of this guard
+# misfired on legitimate commits).
+HEAD_PARENT_COUNT=$(git rev-list --parents -n 1 HEAD 2>/dev/null | awk '{print NF-1}')
+if [ "${HEAD_PARENT_COUNT:-1}" = "0" ]; then
+  # Local HEAD has no parent. Check if remote main has any history.
+  REMOTE_HAS_HISTORY=$(git ls-remote origin main 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$REMOTE_HAS_HISTORY" != "0" ]; then
+    echo "::error::REFUSING TO PUSH — local HEAD is parentless but remote main has history."
+    echo "  This would orphan the entire branch. Aborting before damage."
+    echo "  Likely cause: shallow clone + git commit --amend. Diagnose with:"
+    echo "    git rev-parse --is-shallow-repository"
+    echo "    git cat-file -p HEAD"
+    exit 1
+  fi
 fi
 
 MAX_ATTEMPTS=5


### PR DESCRIPTION
## Root cause
The 2026-05-16 main-branch obliteration was caused by \`safe_commit.sh\`'s \"squash repeated chore commits\" optimization calling \`git commit --amend\` **on a shallow-clone repo**. In a shallow repo (fetch-depth: 1) the only commit has no visible parent — amending it produces a new commit that also has no parent. \`force-with-lease\` accepted the orphan commit as the new main, wiping the entire branch's ancestry.

## Three defenses
| Layer | Fix |
|---|---|
| **safe_commit.sh** | Never amend on a shallow clone. Check \`git rev-parse --is-shallow-repository\` first; if true, fall back to a normal \`git commit -m\`. |
| **safe_commit.sh** | Belt-and-braces guard: refuse to push if local HEAD is parentless AND remote main has history. Catches this bug regardless of root cause. Uses \`git rev-list --parents -n 1 HEAD\` (do NOT add \`--count\` — it collapses the output and breaks the parser). |
| **prompt-remix.yml** | \`fetch-depth: 0\` (eliminates the shallow trigger entirely) + \`cancel-in-progress: true\` (the two near-simultaneous opened+labeled events were the proximate race). |

## Smoke tests (passed locally)
- ✅ Normal full-history commit → parent count = 1, push allowed
- ✅ Orphan branch → parent count = 0, push refused with clear error
- ✅ Shallow clone + duplicate-message scenario → amend skipped, plain commit created with valid parent

## Test plan
- [ ] Admin-merge
- [ ] Open a labeled test remix issue
- [ ] Workflow runs cleanly — commit lands, response is commented back, issue closes
- [ ] state/remixes.jsonl appends, main's history stays linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)