### PR TITLE
fix(feed): post cards now render body excerpts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6995,18 +6995,30 @@ const RB_DISCUSSIONS = {
         }
       }
 
-      return verified.map(p => ({
-        title: p.title,
-        author: p.author || 'unknown',
-        authorId: p.author || 'unknown',
-        channel: this.extractChannelFromTitle(p.title) || p.channel,
-        topic: p.topic || null,
-        timestamp: p.timestamp,
-        upvotes: p.upvotes || 0,
-        commentCount: p.commentCount || 0,
-        url: p.url,
-        number: p.number
-      }));
+      // Load body shards in parallel — bucket lookups are shard-cached, so
+      // 10 recent posts typically hit only 1-2 shard fetches total. Bodies
+      // power the excerpt shown under each post title in the feed.
+      const bodies = await Promise.all(
+        verified.map(p => RB_STATE.getDiscussionBody(p.number).catch(() => null))
+      );
+
+      return verified.map((p, i) => {
+        const bodyData = bodies[i];
+        const rawBody = bodyData ? (bodyData.body || '') : '';
+        return {
+          title: p.title,
+          author: p.author || 'unknown',
+          authorId: p.author || 'unknown',
+          channel: this.extractChannelFromTitle(p.title) || p.channel,
+          topic: p.topic || null,
+          timestamp: p.timestamp,
+          upvotes: p.upvotes || 0,
+          commentCount: p.commentCount || 0,
+          url: p.url,
+          number: p.number,
+          body: this.stripByline(rawBody),
+        };
+      });
     } catch (err) {
       console.warn('posted_log fetch failed, falling back to static cache:', err);
       return this.fetchDiscussionsREST(channelSlug, limit);

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -6,7 +6,7 @@ module.exports = defineConfig({
   timeout: 30000,
   retries: 0,
   use: {
-    baseURL: 'https://kody-w.github.io/rappterbook/',
+    baseURL: process.env.BASE_URL || 'https://kody-w.github.io/rappterbook/',
     headless: true,
   },
   projects: [

--- a/src/js/discussions.js
+++ b/src/js/discussions.js
@@ -263,18 +263,30 @@ const RB_DISCUSSIONS = {
         }
       }
 
-      return verified.map(p => ({
-        title: p.title,
-        author: p.author || 'unknown',
-        authorId: p.author || 'unknown',
-        channel: this.extractChannelFromTitle(p.title) || p.channel,
-        topic: p.topic || null,
-        timestamp: p.timestamp,
-        upvotes: p.upvotes || 0,
-        commentCount: p.commentCount || 0,
-        url: p.url,
-        number: p.number
-      }));
+      // Load body shards in parallel — bucket lookups are shard-cached, so
+      // 10 recent posts typically hit only 1-2 shard fetches total. Bodies
+      // power the excerpt shown under each post title in the feed.
+      const bodies = await Promise.all(
+        verified.map(p => RB_STATE.getDiscussionBody(p.number).catch(() => null))
+      );
+
+      return verified.map((p, i) => {
+        const bodyData = bodies[i];
+        const rawBody = bodyData ? (bodyData.body || '') : '';
+        return {
+          title: p.title,
+          author: p.author || 'unknown',
+          authorId: p.author || 'unknown',
+          channel: this.extractChannelFromTitle(p.title) || p.channel,
+          topic: p.topic || null,
+          timestamp: p.timestamp,
+          upvotes: p.upvotes || 0,
+          commentCount: p.commentCount || 0,
+          url: p.url,
+          number: p.number,
+          body: this.stripByline(rawBody),
+        };
+      });
     } catch (err) {
       console.warn('posted_log fetch failed, falling back to static cache:', err);
       return this.fetchDiscussionsREST(channelSlug, limit);

--- a/tests/playwright/rappterbook.spec.js
+++ b/tests/playwright/rappterbook.spec.js
@@ -170,6 +170,58 @@ test.describe('Rappterbook Frontend', () => {
     const html = await page.content();
     expect(html).toContain('rappterbook');
   });
+
+  // ── Feed health — added after the title-only render bug (May 2026) ──
+
+  test('home feed renders post excerpts (body, not just title)', async ({ page }) => {
+    await page.goto('./');
+    await page.waitForLoadState('networkidle');
+    // Wait for the feed container to populate
+    await page.waitForSelector('#feed-container .post-card', { timeout: 15000 });
+    const excerpts = await page.locator('#feed-container .post-card .post-excerpt').count();
+    // At least one of the recent posts should have a body excerpt rendered.
+    // Before the fix, fetchRecent() dropped the body field — this hit zero.
+    expect(excerpts).toBeGreaterThan(0);
+  });
+
+  test('home feed renders trending state correctly (items if data, empty state otherwise)', async ({ page, request }) => {
+    // Verify the frontend honors whatever trending.json contains.
+    const resp = await request.get(`${RAW}/state/trending.json`);
+    expect(resp.ok()).toBeTruthy();
+    const data = await resp.json();
+    const trendingData = data.trending || data.posts || [];
+
+    await page.goto('./');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    if (trendingData.length === 0) {
+      // Data layer empty: sidebar should show the empty state, not crash silently.
+      const emptyState = await page.locator('.sidebar-section')
+        .filter({ hasText: 'Trending' })
+        .locator('.empty-state')
+        .count();
+      expect(emptyState).toBeGreaterThan(0);
+    } else {
+      // Data layer has items: each should render as a <li>.
+      const trendingItems = await page.locator('.trending-list li').count();
+      expect(trendingItems).toBeGreaterThan(0);
+    }
+  });
+
+  test('home feed most-recent post is < 7 days old', async ({ page, request }) => {
+    // Sanity check: the feed should be reading recent state, not a frozen cache.
+    // Cross-check against posted_log.json directly.
+    const resp = await request.get(`${RAW}/state/posted_log.json`);
+    expect(resp.ok()).toBeTruthy();
+    const log = await resp.json();
+    const posts = (log.posts || []).slice().reverse();
+    const recent = posts.find(p => p.timestamp);
+    expect(recent).toBeDefined();
+    const ageMs = Date.now() - new Date(recent.timestamp).getTime();
+    const ageDays = ageMs / (1000 * 60 * 60 * 24);
+    expect(ageDays).toBeLessThan(7);
+  });
 });
 
 // =========================================================================


### PR DESCRIPTION
## The bug

The home feed has been rendering title-only post cards. Every card showed the title, byline, channel badges, vote count, and comment count — but no body excerpt. Like a Reddit feed with the post text stripped out.

## Root cause

`src/js/discussions.js:fetchRecent()` builds the post objects passed into the home-feed renderer. The mapping at lines 266-277 dropped the `body` field. The renderer (`renderPostCard`) reads `post.body` to draw the excerpt block — without it, every card renders the metadata layer and stops.

The body data was always available via `RB_STATE.getDiscussionBody(number)`, which is already used by the single-discussion view (`fetchDiscussion`). The feed just wasn't calling it.

## The fix

After the existing verification loop, load body shards in parallel for all verified posts:

```js
const bodies = await Promise.all(
  verified.map(p => RB_STATE.getDiscussionBody(p.number).catch(() => null))
);
```

Shards are bucketed by 250-post groups and cached on the `RB_STATE` object, so 10 recent posts typically resolve to 1-2 shard fetches total (~1-6 MB each, cached for the session). Negligible extra latency.

The body is then stripped of the byline header (matching `fetchDiscussion`'s behavior) and included in the returned object so `renderPostCard` can produce the `<p class="post-excerpt">` block.

## Tests

Three new Playwright tests under "Rappterbook Frontend":

| Test | What it verifies |
|---|---|
| `home feed renders post excerpts (body, not just title)` | At least one `.post-excerpt` element exists in `#feed-container` |
| `home feed renders trending state correctly` | Frontend honors data layer — items if `trending.json` has them, empty state otherwise |
| `home feed most-recent post is < 7 days old` | Sanity check on live data freshness |

All three pass against a local bundle of this fix:
```
Running 3 tests using 1 worker
  ✓ home feed renders post excerpts (1.3s)
  ✓ home feed renders trending state correctly (3.2s)
  ✓ home feed most-recent post is < 7 days old (73ms)
  3 passed (5.6s)
```

`playwright.config.js` now honors `BASE_URL` env var so tests can run against a local `python3 -m http.server` during dev.

## Files changed

- `src/js/discussions.js` — the fix
- `tests/playwright/rappterbook.spec.js` — three new tests
- `playwright.config.js` — BASE_URL env support
- `docs/index.html` — re-bundled

## Upstream note

The trending sidebar is currently empty because `state/trending.json` on `main` carries `trending: []` despite there being plenty of analyzed posts. That's a `compute_trending` pipeline issue, separate from this PR — fix coming next.

Built in a worktree per Amendment XIV (fleet writes to main continuously).

🤖 Generated with [Claude Code](https://claude.com/claude-code)