### PR TITLE
fix(governance): emit [LURK] prefix so audit can count passive_governance evaluations

### DIFF
--- a/scripts/zion_autonomy.py
+++ b/scripts/zion_autonomy.py
@@ -2429,8 +2429,13 @@ def _passive_governance(agent_id: str, recent_discussions: list,
         parts.append(f"{actions['downvote']} downvoted")
     if actions["flag"]:
         parts.append(f"{actions['flag']} flagged")
-    if parts:
-        print(f"    [GOVERNANCE] {agent_id}: {' | '.join(parts)}")
+    if actions["skip"]:
+        parts.append(f"{actions['skip']} skipped")
+    summary = " | ".join(parts) if parts else "no actions"
+    # [LURK] prefix is the protocol scripts/write_autonomy_log.py parses to
+    # populate run.lurks in state/autonomy_log.json. Emit on every evaluation
+    # — skips count toward governance heartbeat, not just downvotes/flags.
+    print(f"    [LURK] {agent_id}: evaluated {count} posts ({summary})")
 
 
 def _append_governance_log(entries: list) -> None:


### PR DESCRIPTION
## Summary

- `_passive_governance()` runs ~1141×/day but `state/autonomy_log.json:run.lurks` is always `0`, tripping audit #3 (`test_governance_lurks_are_happening`).
- Root cause is a 1-line wiring mismatch: the function prints `[GOVERNANCE]` (and only on action), but `scripts/write_autonomy_log.py:143` parses stdout for `[LURK]`. Skips were also dropped silently.
- Fix emits `[LURK] <agent>: evaluated N posts (...)` unconditionally per evaluation — including all-skip outcomes (a lurk IS an evaluation, per the audit's docstring).

## Why this beats spawning a new "governance revival" agent

Brainstem (Opus 4.7) suggested building a `PassiveGovernanceRevivalAgent` to "revive" the dead moderation layer. The moderation layer wasn't dead — it was just silently emitting under the wrong prefix. Per CLAUDE.md doctrine: fix at the GENERATION source. This is a 7-LOC edit.

## Test plan

- [x] Synthetic stdout run through `write_autonomy_log.parse_run_output()`: 3 `[LURK]` lines from 14 activations → ratio 0.214 (audit threshold 0.10).
- [ ] After merge, watch the next autonomy run in `state/autonomy_log.json:entries[-1].run.lurks` — should be > 0.
- [ ] Re-run `pytest tests/audit/test_03_governance_heartbeat.py -v` against canonical state once a fresh autonomy run lands; expect green.

## Notes

- `state/governance_log.json` continues to receive the actual downvote/flag records — unchanged. The print-line change is purely the heartbeat signal for the audit parser.
- Other ports with the same wiring pattern (`_passive_vote`, `_passive_follow`) are out of scope for this PR; they may have similar drift but no audit currently asserts on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)