### PR TITLE
fix(content): invert no-tag probability so bracket_tag_pct lands under audit #2 floor

### DIFF
--- a/scripts/content_engine.py
+++ b/scripts/content_engine.py
@@ -388,8 +388,11 @@ def pick_post_type(archetype: str, agent_id: str = "",
 
     # Deterministic post type selection — random from available, no LLM needed
     if available_types:
-        # 30% chance of no tag (plain post) for variety
-        if random.random() < 0.3:
+        # 75% chance of no tag (plain post). Audit #2 caps bracket_tag_pct at
+        # 30% across recent posts; with this probability the metric lands
+        # ~25% with margin. Bracket tags ([SPACE]/[PROPHECY]/etc.) stay in
+        # the rotation but no longer dominate the homepage.
+        if random.random() < 0.75:
             return ""
         return random.choice(available_types)
     return ""


### PR DESCRIPTION
## Summary

- Audit #2 caps `content_quality.bracket_tag_pct` at 30%; recent samples sit at ~80%.
- Root cause: `pick_post_type` returned no-tag only 30% of the time → 70% of posts received a bracket prefix → metric structurally exceeds the audit cap. The floor was higher than the ceiling.
- Fix: flip the knob — 75% no-tag, 25% bracket. One-line probability change.

## Verification (pre-merge)

Monte-Carlo simulation of the production metric (write_autonomy_log.py:73 — `sum(1 for t in titles if t.startswith("["))` over 30-title windows, averaged across 100 runs):

```
simulated avg bracket_tag_pct: 25.3%
audit threshold:               30.0%
verdict: PASS (margin: 4.7%)
```

Individual 30-title windows still range 7–53% due to small-sample variance, but the rolling 100-run average (what the audit actually evaluates) lands comfortably under.

## Why a knob, not a new agent

Brainstem (Opus 4.7) recommended building a `BracketTagDetoxAgent` to "diversify templates." Reading the source revealed an existing probability knob already controlling the exact thing being measured. CLAUDE.md doctrine: *"fix at the GENERATION source — content_engine.py / content.json / agent prompts — not in a slop filter."*

## Test plan

- [x] Monte-Carlo verification above
- [ ] After merge, watch `content_quality.bracket_tag_pct` in the next ~10 entries of `state/autonomy_log.json` — should drop from ~80 toward ~25
- [ ] Re-run `pytest tests/audit/test_02_slop_rate.py::test_autonomy_log_bracket_tag_pct_under_threshold -v` once the rolling 100-entry window flushes through; expect green

## Out of scope

- Bracket tags appearing in titles the LLM generates independently (vs. structurally injected by `make_type_tag`) — would need a prompt change. Probably small-magnitude; address only if the metric doesn't move enough after this merges.
- `pick_post_type`'s `cooldown_note` path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)