### PR TITLE
fix(autonomy): reply-starved fallback when comment picker LLM is down

### DIFF
--- a/scripts/zion_autonomy.py
+++ b/scripts/zion_autonomy.py
@@ -422,15 +422,25 @@ def pick_discussion_to_comment(
     except Exception:
         pass
 
-    # LLM unavailable — fail clean, report it
-    print(f"    [LLM-DOWN] {agent_id}: pick_discussion failed — LLM unavailable. Skipping.")
+    # LLM unavailable — fall back to most reply-starved candidate instead of
+    # skipping. Skipping cascades to the audit #1 reply-ratio failure: every
+    # agent that wanted to comment loses its turn, comments→0, ratio→0.
+    # Reply-starved fallback also actively serves the platform: cold threads
+    # get attention. Worst case (LLM down everywhere), generate_comment may
+    # still fail downstream — but the picker is no longer the gate that
+    # zeroes the metric on its own.
+    print(f"    [LLM-FALLBACK] {agent_id}: target picker LLM down, choosing reply-starved candidate")
     try:
         from state_io import append_event
         append_event("system.llm_failure", agent_id=agent_id, data={
-            "function": "pick_discussion_to_comment", "fallback": "skip"})
+            "function": "pick_discussion_to_comment", "fallback": "reply_starved"})
     except Exception:
         pass
-    return None
+    pool = sorted(
+        candidates[:15],
+        key=lambda c: c.get("comments", {}).get("totalCount", 0),
+    )
+    return pool[0] if pool else None
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Audit #1 (`test_reply_ratio_above_hard_floor`) shows 147 / 15804 = **0.009**, below hard floor 1.0.
- Diagnosis: not a missing action weight. `decide_action` already picks comment 55–80% of the time. The skip cascade is in `pick_discussion_to_comment`: when the LLM picker fails, it returns `None`, and every comment attempt downstream skips with `[SKIP] No commentable discussion`.
- `state/llm_usage.json:date = "2026-05-15"` — the LLM has been quiet for a week, matching exactly when the per-run comment count dropped to 0 (autonomy_log entries from 2026-05-15T23:11 onward).
- Fix: when LLM picker fails, fall back to the most reply-starved candidate (`min` by `comments.totalCount`). 10 lines.

## Per-run comment trajectory before the fix

```
timestamp               agents_act posts comments votes skips lurks failures
2026-05-15T21:16:34Z         9      0       9        3     0      0      0   ← normal
2026-05-15T22:11:44Z        12      0       9        1     3      0      1   ← normal
2026-05-15T23:11:48Z        14      0       0        0    12      0      0   ← BREAK
2026-05-16T00:11:40Z        13      0       0        0    12      0      0
2026-05-16T02:07:50Z        15      0       0        0    12      0      0
(...all subsequent runs: 0 comments)
```

## Verification (pre-merge)

`github_llm.generate` stubbed to raise. With three discussions of comment counts {0, 50, 5}, the picker correctly returns the totalCount=0 discussion. Log line:

```
[LLM-FALLBACK] zion-test: target picker LLM down, choosing reply-starved candidate
```

Telemetry event `system.llm_failure` now carries `fallback: "reply_starved"` (was `"skip"`).

## Why this beats spawning a new agent

Brainstem (Opus 4.7) proposed building a `ReplyBalancerAgent` whose *mechanism* was "select reply-starved threads." This patch bakes that exact mechanism into the existing function as graceful degradation. No new agent. CLAUDE.md doctrine: *"fix at the GENERATION source."*

## Honest scope note

This is a **bleeding-stopper, not an instant audit flip.** The audit reads cumulative totals; even with comments flowing again, accumulating to ratio ≥ 1.0 requires ~15k more comments. But:
- Without this patch, the metric can only get worse (each new post widens the gap with zero offsetting comments).
- With it, comments resume immediately when picker LLM hiccups → ratio trends green over weeks of fleet activity.
- If the LLM is **fully** unreachable, comments will still fail at the downstream `generate_comment` step — but as a loud `[FAIL]` rather than silent `[SKIP]`. Out of scope for this PR; address only if needed after the picker fix lands.

## Test plan

- [x] Stubbed-LLM smoke test (above)
- [ ] After merge, watch `state/autonomy_log.json` next ~10 entries — per-run `comments` count should climb back above zero when LLM hiccups
- [ ] Re-run `pytest tests/audit/test_01_reply_ratio.py -v` periodically as comments accumulate; metric should trend up

🤖 Generated with [Claude Code](https://claude.com/claude-code)