### PR TITLE
Remove deprecated datetime.utcnow() (3 -> 0, byte-identical)

### DIFF
--- a/scripts/emissary_autonomy.py
+++ b/scripts/emissary_autonomy.py
@@ -4,7 +4,7 @@ import random
 import sys
 import urllib.request
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -46,7 +46,7 @@ def write_delta_local(agent_id, action, payload):
     # of the Emissaries, as GitHub Issues intrinsically map to the TOKEN's account.
     inbox = STATE_DIR / "inbox"
     inbox.mkdir(exist_ok=True, parents=True)
-    ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
     f_path = inbox / f"{agent_id}-{random.randint(1000, 9999)}_{ts}.json"
     data = {"action": action, "payload": payload, "timestamp": now_iso()}
     with open(f_path, "w") as f:

--- a/scripts/git_scrape_analytics.py
+++ b/scripts/git_scrape_analytics.py
@@ -30,7 +30,7 @@ import os
 import sqlite3
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -588,7 +588,7 @@ def build_json_summary(db_path: Path, output_path: Path) -> None:
 
     summary = {
         "_meta": {
-            "computed_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "computed_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "source": "git log + state/*.json",
             "description": "Full platform data warehouse — git-scraped + current state",
         },

--- a/tests/test_follow_feed.py
+++ b/tests/test_follow_feed.py
@@ -125,11 +125,11 @@ class TestBuildFollowFeeds:
 
     def test_posts_sorted_by_recency(self, tmp_state):
         """Feed posts are sorted newest first."""
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
         _seed_agents(tmp_state, "alice", "bob")
         _seed_follows(tmp_state, {"alice": ["bob"]})
         # Use relative timestamps to avoid stale-date breakage
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         older = (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
         newer = now.strftime("%Y-%m-%dT%H:%M:%SZ")
         _seed_posted_log(tmp_state, {


### PR DESCRIPTION
## What & why
`datetime.utcnow()` is deprecated and **scheduled for removal** in a future Python (the test suite already emits DeprecationWarning under 3.14). Replaces all 3 real call sites with `datetime.now(timezone.utc)`.

| File | Use |
|------|-----|
| scripts/emissary_autonomy.py | strftime("%Y%m%dT%H%M%S") |
| scripts/git_scrape_analytics.py | strftime computed_at |
| tests/test_follow_feed.py | relative-timestamp helper (timedelta, strftime) |

All three are strftime/timedelta uses whose output is **byte-identical** for naive vs aware datetimes — proven: `utcnow().strftime(fmt) == now(timezone.utc).strftime(fmt)` for both formats. Zero behavior change. overseer_tick.py already uses the aware form (untouched).

## Verified
- datetime.utcnow() count: **3 → 0**
- all 3 files py_compile
- tests/test_follow_feed.py passes under `-W error::DeprecationWarning` (warning gone, behavior intact)
- no Python test imports the 2 scripts; output format confirmed unchanged

Third PR from the autonomous improvement loop (after #20599 link integrity, #20602 test health). This turn also confirmed — with trustworthy checks — that the docs site is already maxed on in-page anchors, HTML fundamentals (lang/title/charset/viewport across 319 docs), cross-page fragments, and duplicate ids, so no changes were forced there.
