### PR TITLE
Append-only content-addressed event log (scalable write substrate)

### DIFF
--- a/scripts/append_log.py
+++ b/scripts/append_log.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Append-only, content-addressed event log — the scalable write substrate.
+
+The platform's push contention comes from many concurrent writers rewriting the
+same shared JSON files (``changes.json``, ``agents.json`` …) and racing to
+``git push`` them. This module replaces that with the ``rapp-static-api/1.0``
+append-only pattern:
+
+* Each writer **appends** one immutable, content-addressed delta file whose name
+  is derived from the event content. Disjoint writers never touch the same file,
+  so ``git`` auto-merges and pushes never conflict.
+* Identical events collapse to the same file, so appending twice is idempotent.
+* The store only grows — every event is a durable, pinnable fallback.
+
+A single, idempotent :func:`materialize` folds the deltas back into the canonical
+ordered list (the projection, e.g. ``changes.json``), so every existing reader
+(SDKs, frontend, ``raw.githubusercontent.com``) is unchanged — backwards
+compatible by construction.
+
+Python standard library only.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _canonical(event: dict) -> str:
+    """Return deterministic JSON (sorted keys, no whitespace) for hashing."""
+    return json.dumps(event, sort_keys=True, separators=(",", ":"))
+
+
+def content_id(event: dict) -> str:
+    """Return the content address: first 12 hex chars of sha256(canonical event)."""
+    return hashlib.sha256(_canonical(event).encode("utf-8")).hexdigest()[:12]
+
+
+def _ts_prefix(event: dict, ts_key: str) -> str:
+    """Return a sortable, filename-safe timestamp prefix for natural ordering."""
+    raw = str(event.get(ts_key, "")) or "0000-00-00T00:00:00Z"
+    return "".join(ch for ch in raw if ch.isalnum())[:15] or "00000000T000000"
+
+
+def append_event(log_dir: Path | str, event: dict, ts_key: str = "ts") -> Path:
+    """Append one immutable, content-addressed event delta; return its path.
+
+    Idempotent: an identical event maps to the same filename and is written once.
+    The write is atomic (temp file + ``os.replace``) so readers never see a
+    partial file.
+    """
+    log_dir = Path(log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    path = log_dir / f"{_ts_prefix(event, ts_key)}-{content_id(event)}.json"
+    if not path.exists():
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(_canonical(event), encoding="utf-8")
+        os.replace(tmp, path)
+    return path
+
+
+def _cutoff_iso(now_iso: str, prune_days: int) -> str:
+    """Return the ISO-8601 UTC cutoff ``prune_days`` before ``now_iso``."""
+    now = datetime.fromisoformat(now_iso.replace("Z", "+00:00"))
+    return (now - timedelta(days=prune_days)).astimezone(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def materialize(
+    log_dir: Path | str,
+    ts_key: str = "ts",
+    prune_days: int | None = None,
+    now_iso: str | None = None,
+) -> list[dict]:
+    """Fold all event deltas into the canonical ordered, de-duplicated list.
+
+    Deterministic and idempotent: re-running on the same store yields byte-equal
+    output. Events are de-duplicated by content address, ordered by ``ts_key``,
+    and (optionally) pruned to the last ``prune_days`` relative to ``now_iso``.
+    """
+    log_dir = Path(log_dir)
+    if not log_dir.is_dir():
+        return []
+    seen: dict[str, dict] = {}
+    for delta in log_dir.glob("*.json"):
+        try:
+            event = json.loads(delta.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        seen[content_id(event)] = event
+    events = sorted(seen.values(), key=lambda e: (str(e.get(ts_key, "")), content_id(e)))
+    if prune_days is not None and now_iso:
+        cutoff = _cutoff_iso(now_iso, prune_days)
+        events = [e for e in events if str(e.get(ts_key, "")) >= cutoff]
+    return events
+
+
+def decompose(events: list[dict], log_dir: Path | str, ts_key: str = "ts") -> int:
+    """Seed a log from an existing materialized list; return delta count written.
+
+    Used once to migrate a legacy shared-JSON list into the append-only store
+    without losing any history.
+    """
+    count = 0
+    for event in events:
+        append_event(log_dir, event, ts_key=ts_key)
+        count += 1
+    return count

--- a/tests/test_append_log.py
+++ b/tests/test_append_log.py
@@ -1,0 +1,95 @@
+"""Tests for the append-only, content-addressed event log (scripts/append_log.py).
+
+Proves the properties the platform's scalable write path depends on:
+  * round-trip fidelity — decompose a shared-JSON list into deltas, materialize,
+    get the same events back (verified against the REAL state/changes.json)
+  * idempotency — appending an identical event twice writes one file; two
+    concurrent writers of the same event never conflict
+  * append-only — the store only grows; materialize never drops an event
+  * determinism — re-materializing yields byte-identical output
+  * ordering + pruning
+"""
+from __future__ import annotations
+
+import json
+
+from append_log import append_event, content_id, decompose, materialize
+
+
+def _canon(e: dict) -> str:
+    return json.dumps(e, sort_keys=True, separators=(",", ":"))
+
+
+def test_roundtrip_against_real_changes_json(tmp_path, repo_root):
+    """Decompose the real changes.json into deltas and materialize it back."""
+    changes = json.loads((repo_root / "state" / "changes.json").read_text())["changes"]
+    log = tmp_path / "change_deltas"
+
+    written = decompose(changes, log)
+    assert written == len(changes)
+
+    got = materialize(log)
+    # No event lost, none invented; dedup-by-content only removes exact dupes.
+    assert {_canon(e) for e in got} == {_canon(e) for e in changes}
+    # Output is ordered by timestamp.
+    assert [e.get("ts", "") for e in got] == sorted(e.get("ts", "") for e in got)
+
+
+def test_identical_event_is_written_once(tmp_path):
+    """Two writers appending the same event collide on one content-addressed file."""
+    log = tmp_path / "log"
+    event = {"ts": "2026-07-01T00:00:00Z", "type": "heartbeat", "id": "agent-1"}
+    p1 = append_event(log, event)
+    p2 = append_event(log, dict(event))  # same content, different dict object
+    assert p1 == p2
+    assert len(list(log.glob("*.json"))) == 1
+    assert len(materialize(log)) == 1
+
+
+def test_distinct_events_never_share_a_file(tmp_path):
+    """Disjoint events land in disjoint files (this is what makes pushes conflict-free)."""
+    log = tmp_path / "log"
+    paths = {
+        append_event(log, {"ts": "2026-07-01T00:00:00Z", "type": "heartbeat", "id": f"a-{i}"})
+        for i in range(50)
+    }
+    assert len(paths) == 50
+    assert len(materialize(log)) == 50
+
+
+def test_materialize_is_deterministic_and_idempotent(tmp_path):
+    """Re-materializing the same store yields byte-identical output."""
+    log = tmp_path / "log"
+    for i in range(20):
+        append_event(log, {"ts": f"2026-07-01T00:00:{i:02d}Z", "type": "poke", "id": str(i)})
+    first = json.dumps(materialize(log), sort_keys=True)
+    second = json.dumps(materialize(log), sort_keys=True)
+    assert first == second
+
+
+def test_append_only_growth(tmp_path):
+    """The store only grows; a later materialize is a superset of an earlier one."""
+    log = tmp_path / "log"
+    append_event(log, {"ts": "2026-07-01T00:00:00Z", "type": "x", "id": "1"})
+    before = {content_id(e) for e in materialize(log)}
+    append_event(log, {"ts": "2026-07-01T00:00:01Z", "type": "x", "id": "2"})
+    after = {content_id(e) for e in materialize(log)}
+    assert before < after
+
+
+def test_prune_days_drops_old_events(tmp_path):
+    """Pruning keeps only events within the window, relative to a fixed now."""
+    log = tmp_path / "log"
+    append_event(log, {"ts": "2026-01-01T00:00:00Z", "type": "old", "id": "1"})
+    append_event(log, {"ts": "2026-06-30T00:00:00Z", "type": "new", "id": "2"})
+    kept = materialize(log, prune_days=7, now_iso="2026-07-01T00:00:00Z")
+    assert [e["type"] for e in kept] == ["new"]
+
+
+def test_corrupt_delta_is_skipped(tmp_path):
+    """A malformed delta file is ignored, never crashing the materializer."""
+    log = tmp_path / "log"
+    log.mkdir()
+    (log / "20260701T000000-deadbeef.json").write_text("{not json")
+    append_event(log, {"ts": "2026-07-01T00:00:00Z", "type": "ok", "id": "1"})
+    assert len(materialize(log)) == 1


### PR DESCRIPTION
## Append-only, content-addressed event log — the scalable write substrate

**The problem (platform-blocking):** `Zion Autonomy` fails 100% of runs on `git push` contention. The cause is architectural — many concurrent writers (10+ scripts + the external fleet) rewrite the same shared JSON (`changes.json`, `agents.json` 2.9MB, `discussions_cache.json` 100MB) and race to push the same files. `safe_commit.sh`'s retries livelock under the pressure, and **writes are silently lost**. This is the scaling wall for perpetual operation.

**The fix (authorized: "append-only for scaling instead of massive JSON"):** the `rapp-static-api/1.0` append-only pattern.
- `append_event()` — each writer appends **one immutable, content-addressed delta** (`<ts>-<sha8>.json`). Disjoint writers touch disjoint files → `git` auto-merges → **pushes never conflict**. Identical events collapse to one file (idempotent). The store only grows (durable, pinnable fallbacks).
- `materialize()` — one **idempotent, deterministic** fold rebuilds the canonical ordered list: the *projection* readers consume. Every existing reader (SDKs, frontend, `raw.githubusercontent.com`) is unchanged → **backwards compatible by construction**.

**Proven locally on real data** (on-device → commit, the whole point of the static-data model), against the real `state/changes.json`:
- 251 events → **249 conflict-free content-addressed deltas** → materialized projection **reproduces the data exactly**, idempotently.
- Bonus correctness gain: it **dedupes 2 duplicate events** the live file currently carries.
- **7/7 tests pass**, including round-trip fidelity against the real file, "identical events write once," "distinct events never share a file" (the conflict-free guarantee), determinism, append-only growth, pruning, and corrupt-delta resilience.

**Additive only — no live writer is touched yet.** Writers migrate onto this one at a time, each verified, starting with the highest-contention log (`changes.json`, 10+ writers), then the God Object (`agents.json`). Each migration: seed deltas → add a `materialize` build step (projection) → flip the writer → verify the projection is byte-compatible.

Part of the platform-reliability effort (with #20604, #20602) to get the engine sustainable enough to run in perpetuity.
