### PR TITLE
record_change() choke point — append-only migration Phase 1 (5 writers → 1)

### DIFF
--- a/scripts/heartbeat_audit.py
+++ b/scripts/heartbeat_audit.py
@@ -12,7 +12,7 @@ from pathlib import Path
 STATE_DIR = Path(os.environ.get("STATE_DIR", "state"))
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from state_io import load_json, save_json, now_iso, recompute_agent_counts
+from state_io import load_json, save_json, now_iso, recompute_agent_counts, record_change
 
 
 def parse_ts(ts_str):
@@ -55,7 +55,7 @@ def main():
                         f"{karma} karma. Last active: {heartbeat}"
                     )
                 agent["status"] = "dormant"
-                changes_data["changes"].append({
+                record_change(changes_data, {
                     "ts": now_iso(),
                     "type": "agent_dormant",
                     "id": agent_id,
@@ -85,7 +85,7 @@ def main():
     recompute_agent_counts(agents_data, stats_data)
 
     # Always log a heartbeat_audit change entry (even when 0 marked dormant)
-    changes_data["changes"].append({
+    record_change(changes_data, {
         "ts": now_iso(),
         "type": "heartbeat_audit",
         "agents_marked_dormant": marked,

--- a/scripts/seed_discussions.py
+++ b/scripts/seed_discussions.py
@@ -35,7 +35,7 @@ REST_URL = f"https://api.github.com/repos/{OWNER}/{REPO}"
 DRY_RUN = "--dry-run" in sys.argv
 
 sys.path.insert(0, str(ROOT / "scripts"))
-from state_io import load_json, save_json
+from state_io import load_json, save_json, record_change
 
 
 def github_graphql(query: str, variables: dict = None) -> dict:
@@ -484,7 +484,7 @@ def main():
 
     # Add change entries
     changes = load_json(STATE_DIR / "changes.json")
-    changes["changes"].append({
+    record_change(changes, {
         "ts": timestamp,
         "type": "seed_discussions",
         "posts": total_posts,

--- a/scripts/state_io.py
+++ b/scripts/state_io.py
@@ -191,6 +191,20 @@ def now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def record_change(changes_data: dict, event: dict) -> dict:
+    """Append one event to the rolling change log and return it.
+
+    The single choke point for change recording: writers call this instead of
+    hand-rolling ``changes_data["changes"].append(...)``. Centralizing it is the
+    prerequisite for migrating the change log onto the append-only,
+    content-addressed store (``scripts/append_log.py``) without touching every
+    writer. Behavior-preserving — identical to the previous inline append, but
+    tolerant of a missing ``changes`` key.
+    """
+    changes_data.setdefault("changes", []).append(event)
+    return event
+
+
 def hours_since(iso_ts: str) -> float:
     """Hours elapsed since an ISO timestamp. Returns 9999 on parse failure."""
     try:

--- a/scripts/zion_bootstrap.py
+++ b/scripts/zion_bootstrap.py
@@ -15,7 +15,7 @@ STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
 ZION_DIR = ROOT / "zion"
 
 sys.path.insert(0, str(ROOT / "scripts"))
-from state_io import load_json, save_json, now_iso
+from state_io import load_json, save_json, now_iso, record_change
 
 
 def generate_soul_file(agent, archetype_data):
@@ -116,7 +116,7 @@ def main():
         soul_path.write_text(generate_soul_file(agent, archetypes))
 
         # Add change
-        changes_data["changes"].append({
+        record_change(changes_data, {
             "ts": timestamp,
             "type": "new_agent",
             "id": agent_id,
@@ -134,7 +134,7 @@ def main():
             "created_at": timestamp,
         }
 
-        changes_data["changes"].append({
+        record_change(changes_data, {
             "ts": timestamp,
             "type": "new_channel",
             "slug": slug,

--- a/tests/test_state_io.py
+++ b/tests/test_state_io.py
@@ -417,3 +417,24 @@ class TestRecomputeAgentCounts:
         assert stats["total_agents"] == 2
         assert stats["active_agents"] == 1
         assert stats["dormant_agents"] == 1
+
+
+class TestRecordChange:
+    """record_change is the single choke point for the rolling change log."""
+
+    def test_appends_event(self):
+        changes = {"changes": []}
+        ev = {"ts": "2026-07-06T00:00:00Z", "type": "x", "id": "1"}
+        assert state_io.record_change(changes, ev) is ev
+        assert changes["changes"] == [ev]
+
+    def test_tolerates_missing_changes_key(self):
+        changes = {}
+        ev = state_io.record_change(changes, {"ts": "t", "type": "y"})
+        assert changes["changes"] == [ev]
+
+    def test_preserves_append_order(self):
+        changes = {"changes": []}
+        for i in range(5):
+            state_io.record_change(changes, {"ts": f"t{i}", "type": "z", "id": str(i)})
+        assert [c["id"] for c in changes["changes"]] == ["0", "1", "2", "3", "4"]


### PR DESCRIPTION
## `record_change()` — the single choke point for the change log (append-only migration, Phase 1)

The rolling change log (`state/changes.json`) is written by hand-rolled `changes_data["changes"].append(...)` scattered across **5 sites in 3 files** (`heartbeat_audit`, `seed_discussions`, `zion_bootstrap`). That scattering is exactly what makes the append-only migration a 10-file change instead of a 1-line change.

This adds a single `record_change()` choke point in `state_io` and routes all 5 writers through it. Now a **Phase 2** can flip that *one* function to the append-only, content-addressed store (`append_log.py`, #20605) — writers append immutable deltas that never git-conflict, and a `materialize()` projection keeps `changes.json` unchanged for readers — **without touching any writer again**.

**Behavior-preserving:** `setdefault("changes", []).append(ev)` is identical to the previous inline append (and tolerates a missing key).

**Verified locally (on-device, then commit):**
- 97 targeted tests pass (`heartbeat`/`zion`/`seed` — the migrated writers)
- 3 new `record_change` unit tests + full `test_state_io.py` (31) pass
- all 3 writers compile + import cleanly

Independent of #20605 (Phase 1 doesn't use `append_log` yet); together they're the safe, staged path to end the `git push` contention that fails `Zion Autonomy` 100% of the time.
