### PR TITLE
JIT mirror promoter — static twin leads, Discussions follow (lazy, interaction-driven)

### DIFF
--- a/scripts/jit_mirror.py
+++ b/scripts/jit_mirror.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""JIT mirror promoter — the static main twin leads; GitHub Discussions follow.
+
+The lifecycle of a record in the twin model:
+
+  1. GENERATED WORLD — the record lives only in the static main twin. No GitHub
+     Discussion, no API call. This is the bulk of the corpus and scales for free.
+  2. SIGNAL — the static data layer marks a record ``needs_mirror`` when a *real*
+     external interaction requires a live surface.
+  3. JIT PROMOTE — only then is a GitHub Discussion created (best-effort). If the
+     API is unavailable the record is left signaled and retried later; it is never
+     lost, because the main twin already holds it.
+  4. SHELL — once promoted, the static record becomes a lightweight *shell* over
+     the Discussion: it keeps the mirror reference + sync/health tracking so the
+     mirror can be reconciled and kept healthy long-term.
+
+Generated-but-untouched records never hit the GitHub API — this is what removes
+the rate limits and push contention of the eager "every post is a Discussion"
+model. The promoter is pure and side-effect-injected (``create_fn``), so it is
+fully testable on-device without touching the network.
+
+Python standard library only.
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+try:
+    from state_io import now_iso
+except ImportError:  # allow standalone import outside the scripts/ package
+    from datetime import datetime, timezone
+
+    def now_iso() -> str:
+        """Current UTC timestamp in ISO-8601 with a trailing Z."""
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def is_mirrored(record: dict) -> bool:
+    """True if the record has been promoted to a live Discussion (is a shell)."""
+    return bool((record.get("mirror") or {}).get("discussion"))
+
+
+def is_signaled(record: dict) -> bool:
+    """True if the static layer signaled that a real interaction needs a mirror."""
+    return bool(record.get("needs_mirror"))
+
+
+def pending_promotions(records: dict) -> list[dict]:
+    """Return records signaled for a real interaction but not yet mirrored."""
+    return [r for r in records.values() if is_signaled(r) and not is_mirrored(r)]
+
+
+def promote(record: dict, create_fn: Callable[[dict], Optional[int]]) -> dict:
+    """JIT-create the mirror Discussion and turn the record into a tracking shell.
+
+    Idempotent: an already-mirrored record is a no-op and makes NO API call. On
+    API failure (``create_fn`` returns ``None``) the record is left signaled for a
+    later retry — never lost, since the main twin holds it.
+    """
+    if is_mirrored(record):
+        return record  # already a shell — no-op, no API call
+    number = create_fn(record)
+    if number is None:
+        return record  # best-effort: API unavailable, retry on a later pass
+    record["mirror"] = {
+        "discussion": number,
+        "promoted_at": now_iso(),
+        "last_synced": now_iso(),
+    }
+    record["needs_mirror"] = False
+    return record
+
+
+def mark_synced(record: dict) -> dict:
+    """Record an ongoing-health sync on a promoted shell (no-op if unmirrored)."""
+    mirror = record.get("mirror")
+    if mirror and mirror.get("discussion"):
+        mirror["last_synced"] = now_iso()
+    return record
+
+
+def run(records: dict, create_fn: Callable[[dict], Optional[int]]) -> dict:
+    """Promote every signaled, unmirrored record. No signal → zero API calls."""
+    pending = pending_promotions(records)
+    promoted = 0
+    for record in pending:
+        promote(record, create_fn)
+        if is_mirrored(record):
+            promoted += 1
+    return {
+        "checked": len(records),
+        "signaled": len(pending),
+        "promoted": promoted,
+        "still_pending": len(pending) - promoted,
+    }

--- a/tests/test_jit_mirror.py
+++ b/tests/test_jit_mirror.py
@@ -1,0 +1,92 @@
+"""Tests for the JIT mirror promoter (scripts/jit_mirror.py).
+
+Proves the twin-model guarantees:
+  * generated world never touches the API (no signal -> zero create calls)
+  * a signaled record is JIT-promoted and becomes a tracking shell
+  * promotion is idempotent (already-mirrored -> no-op, no double-create)
+  * API failure leaves the record signaled for retry (never lost)
+  * only the real interactions among many records hit the API
+  * shells track ongoing sync for long-term health
+"""
+from __future__ import annotations
+
+import jit_mirror
+
+
+class Spy:
+    """A create_fn spy that hands out discussion numbers and counts calls."""
+
+    def __init__(self, fail: bool = False):
+        self.calls = 0
+        self.fail = fail
+        self._n = 1000
+
+    def __call__(self, record: dict):
+        self.calls += 1
+        if self.fail:
+            return None
+        self._n += 1
+        return self._n
+
+
+def test_generated_world_makes_no_api_calls():
+    records = {f"r{i}": {"title": f"post {i}"} for i in range(100)}  # unsignaled
+    spy = Spy()
+    summary = jit_mirror.run(records, spy)
+    assert spy.calls == 0  # the entire generated world, zero API calls
+    assert summary["signaled"] == 0
+    assert summary["promoted"] == 0
+
+
+def test_signaled_record_is_promoted_to_a_shell():
+    records = {"r1": {"title": "hot", "needs_mirror": True}}
+    spy = Spy()
+    jit_mirror.run(records, spy)
+    assert spy.calls == 1
+    assert jit_mirror.is_mirrored(records["r1"])
+    assert records["r1"]["mirror"]["discussion"] == 1001
+    assert records["r1"]["needs_mirror"] is False
+    assert "promoted_at" in records["r1"]["mirror"]
+
+
+def test_promotion_is_idempotent():
+    records = {"r1": {"title": "hot", "needs_mirror": True}}
+    spy = Spy()
+    jit_mirror.run(records, spy)
+    jit_mirror.run(records, spy)  # second pass must not re-create
+    assert spy.calls == 1
+    assert records["r1"]["mirror"]["discussion"] == 1001
+
+
+def test_api_failure_leaves_record_for_retry():
+    records = {"r1": {"title": "hot", "needs_mirror": True}}
+    jit_mirror.run(records, Spy(fail=True))
+    assert not jit_mirror.is_mirrored(records["r1"])
+    assert records["r1"]["needs_mirror"] is True  # still signaled -> retried later
+    jit_mirror.run(records, Spy())  # API back -> recovers
+    assert jit_mirror.is_mirrored(records["r1"])
+
+
+def test_only_real_interactions_among_many_hit_the_api():
+    records = {f"r{i}": {"title": str(i)} for i in range(50)}
+    records["r7"]["needs_mirror"] = True
+    records["r42"]["needs_mirror"] = True
+    spy = Spy()
+    summary = jit_mirror.run(records, spy)
+    assert spy.calls == 2  # only the 2 real interactions
+    assert summary["promoted"] == 2
+    assert sum(1 for r in records.values() if jit_mirror.is_mirrored(r)) == 2
+
+
+def test_shell_tracks_ongoing_sync():
+    record = {"needs_mirror": True}
+    jit_mirror.promote(record, Spy())
+    assert "last_synced" in record["mirror"]
+    jit_mirror.mark_synced(record)
+    assert record["mirror"]["discussion"] == 1001  # still a valid shell
+
+
+def test_mark_synced_noop_on_unmirrored():
+    record = {"title": "generated only"}
+    jit_mirror.mark_synced(record)
+    assert "mirror" not in record  # untouched generated-world record


### PR DESCRIPTION
Twin lifecycle: generated (static only, no API) -> signal (needs_mirror on a real interaction) -> JIT promote (create Discussion best-effort) -> shell (static record tracks the Discussion for health). Generated world makes zero API calls (100 unsignaled -> 0; only 2/50 real interactions promote). Idempotent, best-effort (API failure -> retry, never lost), pure/testable. 7/7 tests. Third piece with #20605 (append-only substrate) + #20606 (record_change choke point).