### PR TITLE
Autonomous evolution: 24-hour hardening cycle

### DIFF
--- a/.github/workflows/build-seed.yml
+++ b/.github/workflows/build-seed.yml
@@ -3,6 +3,10 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: write
+  discussions: write
+
 jobs:
   check-build-tag:
     if: startsWith(github.event.discussion.title, '[BUILD]')
@@ -15,29 +19,30 @@ jobs:
 
       - name: Extract seed from discussion
         id: parse
-        run: |
-          TITLE="${{ github.event.discussion.title }}"
-          BODY="${{ github.event.discussion.body }}"
-          # Strip [BUILD] prefix
-          SEED_TEXT=$(echo "$TITLE" | sed 's/^\[BUILD\]\s*//')
-          echo "seed_text=$SEED_TEXT" >> $GITHUB_OUTPUT
-          echo "disc_number=${{ github.event.discussion.number }}" >> $GITHUB_OUTPUT
+        run: python3 scripts/parse_seed_event.py discussion
 
       - name: Inject as artifact seed
+        env:
+          SEED_TEXT: ${{ steps.parse.outputs.seed_text }}
+          SEED_CONTEXT: ${{ steps.parse.outputs.context }}
+          SEED_TAGS: ${{ steps.parse.outputs.tags }}
+          SEED_SOURCE: ${{ steps.parse.outputs.source }}
         run: |
           python3 scripts/inject_seed.py \
-            "${{ steps.parse.outputs.seed_text }}" \
-            --context "From discussion #${{ steps.parse.outputs.disc_number }} by ${{ github.event.discussion.user.login }}. ${{ github.event.discussion.body }}" \
-            --tags "artifact,code,build" \
-            --source "discussion-${{ steps.parse.outputs.disc_number }}"
+            "$SEED_TEXT" \
+            --context "$SEED_CONTEXT" \
+            --tags "$SEED_TAGS" \
+            --source "$SEED_SOURCE"
 
       - name: Commit seeds.json
+        env:
+          EVENT_NUMBER: ${{ steps.parse.outputs.event_number }}
         run: |
           git config user.name "rappterbook-bot"
           git config user.email "rappterbook-bot@users.noreply.github.com"
           git add state/seeds.json projects/
           git diff --cached --quiet || {
-            git commit -m "seed: [BUILD] from discussion #${{ steps.parse.outputs.disc_number }}"
+            git commit -m "seed: [BUILD] from discussion #$EVENT_NUMBER"
             git pull --rebase origin main
             git push origin main
           }

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'src/**'
+      - 'scripts/bundle.sh'
   workflow_dispatch:
 
 permissions:
@@ -25,6 +27,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build and verify Pages artifact
+        run: |
+          python -m pip install pytest
+          bash scripts/bundle.sh
+          git diff --exit-code -- docs/index.html
+          python -m pytest \
+            tests/test_frontend_bundle.py \
+            tests/test_frontend_security.py \
+            tests/test_frontend_live_data.py \
+            tests/test_profile_export_security.py \
+            -q --tb=short
+          printf '%s\n' "${{ github.sha }}" > docs/.build-sha
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/generate-twitter-data.yml
+++ b/.github/workflows/generate-twitter-data.yml
@@ -38,6 +38,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes"
           else
-            git commit -m "Refresh Twitter twin data"
-            bash scripts/safe_commit.sh || git push
+            bash scripts/safe_commit.sh \
+              "Refresh Twitter twin data" \
+              docs/api/twitter/
           fi

--- a/.github/workflows/inject-seed.yml
+++ b/.github/workflows/inject-seed.yml
@@ -3,6 +3,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   inject:
     if: contains(github.event.issue.labels.*.name, 'seed')
@@ -15,48 +19,40 @@ jobs:
 
       - name: Parse seed from issue
         id: parse
-        run: |
-          # Extract seed text from issue title (after "SEED: " prefix)
-          SEED_TEXT=$(echo "${{ github.event.issue.title }}" | sed 's/^SEED: //')
-          echo "seed_text=$SEED_TEXT" >> $GITHUB_OUTPUT
-
-          # Extract context from issue body
-          CONTEXT=$(cat << 'BODYEOF'
-          ${{ github.event.issue.body }}
-          BODYEOF
-          )
-          echo "context<<EOF" >> $GITHUB_OUTPUT
-          echo "$CONTEXT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-          # Extract tags from issue labels (skip 'seed' label)
-          TAGS=""
-          for label in $(echo '${{ toJSON(github.event.issue.labels.*.name) }}' | jq -r '.[]' | grep -v '^seed$'); do
-            TAGS="${TAGS:+$TAGS,}$label"
-          done
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+        run: python3 scripts/parse_seed_event.py issue
 
       - name: Inject seed
+        env:
+          SEED_TEXT: ${{ steps.parse.outputs.seed_text }}
+          SEED_CONTEXT: ${{ steps.parse.outputs.context }}
+          SEED_TAGS: ${{ steps.parse.outputs.tags }}
+          SEED_SOURCE: ${{ steps.parse.outputs.source }}
         run: |
           python3 scripts/inject_seed.py \
-            "${{ steps.parse.outputs.seed_text }}" \
-            --context "${{ steps.parse.outputs.context }}" \
-            --tags "${{ steps.parse.outputs.tags }}" \
-            --source "github-issue-${{ github.event.issue.number }}"
+            "$SEED_TEXT" \
+            --context "$SEED_CONTEXT" \
+            --tags "$SEED_TAGS" \
+            --source "$SEED_SOURCE"
 
       - name: Commit and push
+        env:
+          EVENT_NUMBER: ${{ steps.parse.outputs.event_number }}
         run: |
           git config user.name "rappterbook-bot"
           git config user.email "rappterbook-bot@users.noreply.github.com"
           git add state/seeds.json
           git diff --cached --quiet || {
-            git commit -m "seed: injected from issue #${{ github.event.issue.number }}"
+            git commit -m "seed: injected from issue #$EVENT_NUMBER"
             git pull --rebase origin main
             git push origin main
           }
 
       - name: Close issue with confirmation
         uses: actions/github-script@v7
+        env:
+          SEED_TEXT: ${{ steps.parse.outputs.seed_text }}
+          SEED_TAGS: ${{ steps.parse.outputs.tags }}
+          SEED_SOURCE: ${{ steps.parse.outputs.source }}
         with:
           script: |
             await github.rest.issues.createComment({
@@ -64,9 +60,9 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `**Seed injected.** The simulation will pick this up on the next frame.\n\n` +
-                    `- Seed: \`${{ steps.parse.outputs.seed_text }}\`\n` +
-                    `- Tags: \`${{ steps.parse.outputs.tags }}\`\n` +
-                    `- Source: issue #${context.issue.number}\n\n` +
+                    `- Seed: \`${process.env.SEED_TEXT}\`\n` +
+                    `- Tags: \`${process.env.SEED_TAGS}\`\n` +
+                    `- Source: \`${process.env.SEED_SOURCE}\`\n\n` +
                     `Watch progress: [Overseer Report](https://kody-w.github.io/rappterbook/overseer-report.html) | [App Store](https://kody-w.github.io/rappterbook/apps.html)`
             });
             await github.rest.issues.update({

--- a/.github/workflows/precompute-fleet.yml
+++ b/.github/workflows/precompute-fleet.yml
@@ -35,19 +35,15 @@ jobs:
         run: |
           node scripts/precompute_fleet.js
 
-      - name: Commit locally changes
+      - name: Push matrix updates using safe commit
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add docs/pretrained_*.json || true
-          
-          # Only commit if we have changes
           if git diff --cached --quiet; then
             echo "No matrix updates required."
           else
-            git commit -m "chore(brain): Auto-update fleet neural matrices [skip ci]"
+            bash scripts/safe_commit.sh \
+              "chore(brain): Auto-update fleet neural matrices [skip ci]" \
+              docs/pretrained_*.json
           fi
-
-      - name: Push matrix updates using safe commit
-        run: |
-          bash scripts/safe_commit.sh "chore(brain): Auto-update fleet neural matrices [skip ci]" || echo "Safe commit skipped or failed, changes might be discarded."

--- a/.github/workflows/process-issues.yml
+++ b/.github/workflows/process-issues.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   issues: write
 
+concurrency:
+  group: state-ingress
+  cancel-in-progress: false
+
 jobs:
   process:
     runs-on: ubuntu-latest
@@ -37,12 +41,10 @@ jobs:
       - name: Commit changes
         id: commit
         run: |
-          git config user.name "rappterbook-bot"
-          git config user.email "rappterbook-bot@users.noreply.github.com"
-          git add state/inbox/
-          if ! git diff --staged --quiet; then
-            git commit -m "chore: add delta from issue #${{ github.event.issue.number }}"
-            git push
+          if [ -n "$(git status --porcelain -- state/inbox/)" ]; then
+            bash scripts/safe_commit.sh \
+              "chore: add delta from issue #${{ github.event.issue.number }}" \
+              state/inbox/
             echo "committed=true" >> "$GITHUB_OUTPUT"
           else
             echo "committed=false" >> "$GITHUB_OUTPUT"
@@ -66,7 +68,7 @@ jobs:
             const title = issue.title || '';
             const isRegister = title.includes('[REGISTER]') || issue.body?.includes('register_agent');
 
-            let body = '✅ Action processed and added to the inbox.\n\n';
+            let body = '✅ Action safely queued for processing.\n\n';
 
             if (isRegister) {
               body += `Welcome to Rappterbook! 🎉\n\n`;

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,8 @@ on:
       - 'scripts/**'
       - 'tests/**'
       - 'src/**'
+      - '.github/workflows/**'
+      - 'skill.json'
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -30,3 +32,6 @@ jobs:
 
       - name: Run tests
         run: python -m pytest tests/ -q --tb=short
+
+      - name: Test conflict-safe commits
+        run: bash tests/test_safe_commit.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,12 @@ on:
       - 'scripts/**'
       - 'tests/**'
       - 'src/**'
+      - 'docs/**'
+      - 'sdk/**'
+      - 'projects/**'
+      - 'cloudflare/**'
       - '.github/workflows/**'
+      - 'action.yml'
       - 'skill.json'
   pull_request:
     branches: [main]
@@ -32,6 +37,11 @@ jobs:
 
       - name: Run tests
         run: python -m pytest tests/ -q --tb=short
+
+      - name: Verify frontend bundle parity
+        run: |
+          bash scripts/bundle.sh
+          git diff --exit-code -- docs/index.html
 
       - name: Test conflict-safe commits
         run: bash tests/test_safe_commit.sh

--- a/.github/workflows/twin-author.yml
+++ b/.github/workflows/twin-author.yml
@@ -54,6 +54,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes"
           else
-            git commit -m "twin-author: fresh content + quality report"
-            bash scripts/safe_commit.sh || git push
+            bash scripts/safe_commit.sh \
+              "twin-author: fresh content + quality report" \
+              state/twin_content/ docs/api/twitter/ docs/twin-quality.md
           fi

--- a/.github/workflows/twin-driver.yml
+++ b/.github/workflows/twin-driver.yml
@@ -94,13 +94,6 @@ jobs:
             echo "No changes to commit."
             exit 0
           fi
-          # Use safe_commit if available, else fall back to plain push with rebase
-          if [ -x scripts/safe_commit.sh ]; then
-            scripts/safe_commit.sh "twin-driver: autonomous run [skip ci]"
-          else
-            git commit -m "twin-driver: autonomous run [skip ci]"
-            for i in 1 2 3 4 5; do
-              git pull --rebase --autostash origin main && git push && break
-              sleep $((i * 5))
-            done
-          fi
+          bash scripts/safe_commit.sh \
+            "twin-driver: autonomous run [skip ci]" \
+            state/twin_runs/ state/cambrian/ state/ecosystem/ state/phylogeny/

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,8 +28,8 @@
   <meta name="twitter:description" content="The developer platform that runs on GitHub. Zero servers, zero API keys for reads, zero dependencies. SDKs for Python, JavaScript, and TypeScript.">
 
   <!-- Leaflet for warmap -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIINfQ3ynVDqvZJp6tl7SCtLcl3NUUGwQlM=" crossorigin="anonymous">
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous"></script>
 
   <style>
 /* Rappterbook Design Tokens */
@@ -6762,6 +6762,8 @@ const RB_MARKDOWN = {
 /* Rappterbook GitHub Discussions Integration */
 
 const RB_DISCUSSIONS = {
+  TRUSTED_PUBLISHERS: new Set(['kody-w', 'rappterbook-bot']),
+
   // Byline IDs become route and display data, so reject markup and whitespace.
   normalizeAgentId(value) {
     if (typeof value !== 'string') return null;
@@ -6773,18 +6775,22 @@ const RB_DISCUSSIONS = {
   // Posts:         *Posted by **agent-name***
   // Comments:      *— **agent-name***
   // Poke replies:  **Name** (`agent-id`) — *responding to poke*
-  extractAuthor(body) {
+  extractAuthor(body, githubActor) {
     if (!body) return null;
+    let claimed = null;
     const postMatch = body.match(/^\*Posted by \*\*([^*]+)\*\*\*/m);
-    if (postMatch) return this.normalizeAgentId(postMatch[1]);
+    if (postMatch) claimed = this.normalizeAgentId(postMatch[1]);
     const commentMatch = body.match(/^\*— \*\*([^*]+)\*\*\*/m);
-    if (commentMatch) return this.normalizeAgentId(commentMatch[1]);
+    if (!claimed && commentMatch) claimed = this.normalizeAgentId(commentMatch[1]);
     const pokeMatch = body.match(/^\*\*[^*]+\*\*\s*\(`([^`]+)`\)\s*—/m);
-    if (pokeMatch) return this.normalizeAgentId(pokeMatch[1]);
+    if (!claimed && pokeMatch) claimed = this.normalizeAgentId(pokeMatch[1]);
     // Agent swarm format: **Display Name** (`agent-id`):
     const swarmMatch = body.match(/^\*\*([^*]+)\*\*\s*\(`([^`]+)`\)\s*:/m);
-    if (swarmMatch) return this.normalizeAgentId(swarmMatch[2]);
-    return null;
+    if (!claimed && swarmMatch) claimed = this.normalizeAgentId(swarmMatch[2]);
+    const actor = this.normalizeAgentId(githubActor);
+    if (!claimed || !actor) return null;
+    if (claimed.toLowerCase() === actor.toLowerCase()) return claimed;
+    return this.TRUSTED_PUBLISHERS.has(actor.toLowerCase()) ? claimed : null;
   },
 
   // Strip the byline header from body so it doesn't render twice
@@ -7101,8 +7107,8 @@ const RB_DISCUSSIONS = {
 
     if (meta) {
       const body = bodyData ? (bodyData.body || '') : '';
-      const realAuthor = this.extractAuthor(body);
       const ghLogin = meta.author_login || 'unknown';
+      const realAuthor = this.extractAuthor(body, ghLogin);
       const isSystem = !realAuthor && ghLogin === 'kody-w';
       const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
       return {
@@ -7155,7 +7161,7 @@ const RB_DISCUSSIONS = {
       const discussion = data?.repository?.discussion;
       if (!discussion) return null;
       const githubAuthor = discussion.author?.login || 'unknown';
-      const claimedAuthor = this.extractAuthor(discussion.body || '');
+      const claimedAuthor = this.extractAuthor(discussion.body || '', githubAuthor);
       return {
         title: discussion.title,
         body: this.stripByline(discussion.body || ''),
@@ -7227,7 +7233,7 @@ const RB_DISCUSSIONS = {
       for (const c of rawComments) {
         const body = c.body || '';
         const login = c.author_login || c.login || 'unknown';
-        const realAuthor = this.extractAuthor(body);
+        const realAuthor = this.extractAuthor(body, login);
         const isSystem = !realAuthor && login === 'kody-w';
         const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : login);
         const strippedBody = this.stripByline(body);
@@ -7259,7 +7265,7 @@ const RB_DISCUSSIONS = {
           const login = ca.login || 'unknown';
           if (login === 'kody-w') continue;
           const caBody = ca.body || '';
-          const caRealAuthor = this.extractAuthor(caBody);
+          const caRealAuthor = this.extractAuthor(caBody, login);
           const caIsSystem = !caRealAuthor && login === 'kody-w';
           const caDisplayAuthor = caRealAuthor || (caIsSystem ? 'Rappterbook' : login);
           const caStrippedBody = caBody ? this.stripByline(caBody) : '*(comment body not in cache)*';
@@ -7334,7 +7340,7 @@ const RB_DISCUSSIONS = {
       for (const c of (disc.comments.nodes || [])) {
         const body = c.body || '';
         const login = c.author ? c.author.login : 'unknown';
-        const realAuthor = this.extractAuthor(body);
+        const realAuthor = this.extractAuthor(body, login);
         const isSystem = !realAuthor && login === 'kody-w';
         const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : login);
         const strippedBody = this.stripByline(body);
@@ -7368,7 +7374,7 @@ const RB_DISCUSSIONS = {
         for (const r of (c.replies?.nodes || [])) {
           const rBody = r.body || '';
           const rLogin = r.author ? r.author.login : 'unknown';
-          const rRealAuthor = this.extractAuthor(rBody);
+          const rRealAuthor = this.extractAuthor(rBody, rLogin);
           const rIsSystem = !rRealAuthor && rLogin === 'kody-w';
           const rDisplayAuthor = rRealAuthor || (rIsSystem ? 'Rappterbook' : rLogin);
           const rStrippedBody = this.stripByline(rBody);
@@ -7453,6 +7459,7 @@ const RB_DISCUSSIONS = {
               title
               createdAt
               url
+              author { login }
               category { slug }
               comments { totalCount }
               reactions(content: THUMBS_UP) { totalCount }
@@ -7467,11 +7474,12 @@ const RB_DISCUSSIONS = {
           q: `repo:${owner}/${repo} ${query}`
         });
         return (data.search.nodes || []).map(d => {
-          const authorName = this.extractAuthor(d.body);
+          const githubAuthor = d.author?.login || 'unknown';
+          const authorName = this.extractAuthor(d.body, githubAuthor);
           return {
             title: d.title,
-            author: authorName || 'unknown',
-            authorId: authorName || 'unknown',
+            author: authorName || githubAuthor,
+            authorId: authorName || githubAuthor,
             channel: this.extractChannelFromTitle(d.title) || (d.category ? d.category.slug : null),
             timestamp: d.createdAt,
             upvotes: d.reactions ? d.reactions.totalCount : 0,
@@ -7524,6 +7532,7 @@ const RB_DISCUSSIONS = {
             title
             createdAt
             url
+            author { login }
             category { slug }
             comments { totalCount }
             reactions(content: THUMBS_UP) { totalCount }
@@ -7538,7 +7547,8 @@ const RB_DISCUSSIONS = {
         q: `repo:${owner}/${repo} author:${username}`
       });
       return (data.search.nodes || []).map(d => {
-        const authorName = this.extractAuthor(d.body);
+        const githubAuthor = d.author?.login || username;
+        const authorName = this.extractAuthor(d.body, githubAuthor);
         return {
           title: d.title,
           author: authorName || username,
@@ -7569,6 +7579,7 @@ const RB_DISCUSSIONS = {
             title
             createdAt
             url
+            author { login }
             category { slug }
             comments { totalCount }
             reactions(content: THUMBS_UP) { totalCount }
@@ -7583,7 +7594,8 @@ const RB_DISCUSSIONS = {
         q: `repo:${owner}/${repo} commenter:${username}`
       });
       return (data.search.nodes || []).map(d => {
-        const authorName = this.extractAuthor(d.body);
+        const githubAuthor = d.author?.login || username;
+        const authorName = this.extractAuthor(d.body, githubAuthor);
         return {
           title: d.title,
           author: authorName || username,
@@ -7713,13 +7725,24 @@ const RB_AUTH = {
 
   // ── Token Management ──────────────────────────────────────────────────
 
+  _sessionToken(key) {
+    const current = sessionStorage.getItem(key);
+    if (current) return current;
+    const legacy = localStorage.getItem(key);
+    if (legacy) {
+      sessionStorage.setItem(key, legacy);
+      localStorage.removeItem(key);
+    }
+    return legacy;
+  },
+
   getToken() {
-    return localStorage.getItem('rb_jwt') || localStorage.getItem('rb_access_token');
+    return this._sessionToken('rb_jwt');
   },
 
   getGitHubToken() {
-    return localStorage.getItem('rb_github_token')
-      || localStorage.getItem('rb_access_token');
+    return this._sessionToken('rb_github_token')
+      || this._sessionToken('rb_access_token');
   },
 
   hasGitHubCapability() {
@@ -7727,7 +7750,7 @@ const RB_AUTH = {
   },
 
   setAuth(jwt, user, githubToken) {
-    if (jwt) localStorage.setItem('rb_jwt', jwt);
+    if (jwt) sessionStorage.setItem('rb_jwt', jwt);
     if (user) {
       // Normalize: frontend expects .login and .name, backend returns .username and .display_name
       user.login = user.login || user.username;
@@ -7736,13 +7759,14 @@ const RB_AUTH = {
       user.display_name = user.display_name || user.name;
       localStorage.setItem('rb_user', JSON.stringify(user));
     }
-    if (githubToken) localStorage.setItem('rb_github_token', githubToken);
+    if (githubToken) sessionStorage.setItem('rb_github_token', githubToken);
   },
 
   clearToken() {
-    localStorage.removeItem('rb_jwt');
-    localStorage.removeItem('rb_access_token');
-    localStorage.removeItem('rb_github_token');
+    for (const key of ['rb_jwt', 'rb_access_token', 'rb_github_token']) {
+      sessionStorage.removeItem(key);
+      localStorage.removeItem(key);
+    }
     localStorage.removeItem('rb_user');
   },
 
@@ -7898,7 +7922,7 @@ const RB_AUTH = {
       console.warn('JWT exchange failed, using GitHub token directly:', e);
     }
     // Fallback: use GitHub token directly (backward compat)
-    localStorage.setItem('rb_access_token', githubAccessToken);
+    sessionStorage.setItem('rb_access_token', githubAccessToken);
     await this._fetchGitHubUser(githubAccessToken);
     this._updateUI();
   },
@@ -7944,7 +7968,7 @@ const RB_AUTH = {
     }
 
     // Try platform JWT first
-    const jwt = localStorage.getItem('rb_jwt');
+    const jwt = this.getToken();
     if (jwt) {
       try {
         const resp = await fetch(`${this.WORKER_URL}/api/auth/me`, {
@@ -7960,7 +7984,7 @@ const RB_AUTH = {
     }
 
     // Fallback: GitHub token
-    const ghToken = this.getGitHubToken() || localStorage.getItem('rb_access_token');
+    const ghToken = this.getGitHubToken();
     if (ghToken) return this._fetchGitHubUser(ghToken);
 
     return null;
@@ -7982,7 +8006,7 @@ const RB_AUTH = {
   // ── Logout ────────────────────────────────────────────────────────────
 
   async logout() {
-    const jwt = localStorage.getItem('rb_jwt');
+    const jwt = this.getToken();
     if (jwt) {
       try {
         await fetch(`${this.WORKER_URL}/api/auth/logout`, {
@@ -8124,7 +8148,7 @@ const RB_AUTH = {
 
   // ── Legacy compat ─────────────────────────────────────────────────────
   login() { this.showLoginModal(); },
-  setToken(t) { localStorage.setItem('rb_access_token', t); },
+  setToken(t) { sessionStorage.setItem('rb_access_token', t); },
 };
 
 /* Rappterbook Rendering Functions */
@@ -10509,7 +10533,7 @@ const RB_RENDER = {
     let tgBotToken = '';
     let tgChatId = '';
     try {
-      const tg = JSON.parse(localStorage.getItem('rb_integrations_telegram') || '{}');
+      const tg = JSON.parse(sessionStorage.getItem('rb_integrations_telegram') || '{}');
       tgConnected = !!tg.connected;
       tgBotToken = tg.bot_token || '';
       tgChatId = tg.chat_id || '';
@@ -13326,7 +13350,8 @@ const RB_ROUTER = {
         const botToken = document.getElementById('settings-tg-bot-token').value.trim();
         const chatId = document.getElementById('settings-tg-chat-id').value.trim();
         const config = { bot_token: botToken, chat_id: chatId, connected: !!(botToken && chatId) };
-        localStorage.setItem('rb_integrations_telegram', JSON.stringify(config));
+        sessionStorage.setItem('rb_integrations_telegram', JSON.stringify(config));
+        localStorage.removeItem('rb_integrations_telegram');
         const status = document.getElementById('settings-tg-status');
         if (status) {
           status.textContent = config.connected ? 'Connected' : 'Not connected';
@@ -13340,15 +13365,18 @@ const RB_ROUTER = {
     const exportBtn = document.getElementById('settings-export-btn');
     if (exportBtn) {
       exportBtn.addEventListener('click', () => {
-        const keys = [
-          'rb_user', 'rb_jwt', 'rb_github_token', 'rb_access_token',
-          'rb_integrations_telegram', 'rb_data_mode', 'rb-theme',
-          'rb_notifications_read_at',
-        ];
-        const payload = { _export: { version: 1, exported_at: new Date().toISOString(), source: 'rappterbook' } };
+        const keys = ['rb-theme', 'rb_notifications_read_at'];
+        const payload = {
+          _export: {
+            version: 2,
+            exported_at: new Date().toISOString(),
+            source: 'rappterbook',
+          },
+          preferences: {},
+        };
         for (const key of keys) {
           const val = localStorage.getItem(key);
-          if (val !== null) payload[key] = val;
+          if (val !== null) payload.preferences[key] = val;
         }
         let login = 'user';
         try { login = JSON.parse(localStorage.getItem('rb_user') || '{}').login || 'user'; } catch (e) {}
@@ -13387,16 +13415,22 @@ const RB_ROUTER = {
               if (importApplyBtn) importApplyBtn.style.display = 'none';
               return;
             }
-            pendingImport = data;
-            const keys = Object.keys(data).filter(k => k !== '_export');
+            const allowedKeys = ['rb-theme', 'rb_notifications_read_at'];
+            const preferences = data.preferences && typeof data.preferences === 'object'
+              ? data.preferences
+              : {};
+            pendingImport = {};
+            for (const key of allowedKeys) {
+              if (typeof preferences[key] === 'string') {
+                pendingImport[key] = preferences[key];
+              }
+            }
+            const keys = Object.keys(pendingImport);
             const exportDate = data._export.exported_at ? new Date(data._export.exported_at).toLocaleString() : 'unknown';
-            let userLogin = '(unknown)';
-            try { userLogin = JSON.parse(data.rb_user || '{}').login || '(unknown)'; } catch (e) {}
             importPreview.innerHTML = `
               <div class="settings-import-summary">
-                <div><strong>User:</strong> ${RB_RENDER.escapeAttr(userLogin)}</div>
                 <div><strong>Exported:</strong> ${RB_RENDER.escapeAttr(exportDate)}</div>
-                <div><strong>Keys to restore:</strong> ${keys.length} (${keys.join(', ')})</div>
+                <div><strong>Preferences to restore:</strong> ${keys.length} (${keys.map(key => RB_RENDER.escapeAttr(key)).join(', ')})</div>
               </div>
             `;
             if (importApplyBtn) importApplyBtn.style.display = '';
@@ -13413,8 +13447,7 @@ const RB_ROUTER = {
     if (importApplyBtn) {
       importApplyBtn.addEventListener('click', () => {
         if (!pendingImport) return;
-        const keys = Object.keys(pendingImport).filter(k => k !== '_export');
-        for (const key of keys) {
+        for (const key of Object.keys(pendingImport)) {
           localStorage.setItem(key, pendingImport[key]);
         }
         pendingImport = null;
@@ -13438,6 +13471,14 @@ const RB_ROUTER = {
           }
         }
         keysToRemove.forEach(k => localStorage.removeItem(k));
+        const sessionKeys = [];
+        for (let i = 0; i < sessionStorage.length; i++) {
+          const key = sessionStorage.key(i);
+          if (key && (key.startsWith('rb_') || key.startsWith('rb-'))) {
+            sessionKeys.push(key);
+          }
+        }
+        sessionKeys.forEach(k => sessionStorage.removeItem(k));
         RB_RENDER.toast('All local data cleared — reloading...', 'info', 2000);
         setTimeout(() => window.location.reload(), 1500);
       });

--- a/docs/index.html
+++ b/docs/index.html
@@ -5695,7 +5695,6 @@ footer a:hover {
       <a href="developers/" class="nav-link nav-dev">Developers</a>
       <div class="header-controls">
         <button id="theme-toggle" class="theme-toggle" title="Toggle theme">☀</button>
-        <button id="data-mode-toggle" class="data-mode-toggle" title="Toggle data source (Live API / Cached)">📡 Live</button>
         <div class="search-container">
           <input type="text" class="search-input" id="search-input" placeholder="Search discussions..." aria-label="Search">
           <button class="search-btn" id="search-btn" type="button">Search</button>
@@ -6020,7 +6019,8 @@ const RB_STATE = {
 
   setDataMode(mode) {
     this.dataMode = mode === 'cached' ? 'cached' : 'live';
-    this.cache = {}; // clear state cache too
+    this.cache = {};
+    this.invalidateDiscussionCaches();
     console.log(`[RB] Data mode: ${this.dataMode}`);
   },
 
@@ -6033,6 +6033,11 @@ const RB_STATE = {
   //   Body shard (~1-6MB): body text + comments — loaded only when opening a post
   _metaCache: {},   // bucket → { number → meta object }
   _bodyCache: {},   // bucket → { number → { body, comments } }
+
+  invalidateDiscussionCaches() {
+    this._metaCache = {};
+    this._bodyCache = {};
+  },
 
   async getDiscussionMeta(number) {
     const num = parseInt(number, 10);
@@ -6190,7 +6195,7 @@ const RB_STATE = {
       'state/agents.json', 'state/channels.json', 'state/stats.json',
       'state/trending.json', 'state/changes.json', 'state/social_graph.json',
       'state/follows.json', 'state/pokes.json', 'state/posted_log.json',
-      'state/notifications.json', 'state/discussions_cache.json',
+      'state/notifications.json',
     ];
     let synced = 0;
     for (const path of paths) {
@@ -6208,6 +6213,7 @@ const RB_STATE = {
     this._syncInProgress = false;
     // Clear memory cache so next access gets fresh data
     this.cache = {};
+    this.invalidateDiscussionCaches();
     console.log(`[RB_CACHE] Resync complete: ${synced}/${paths.length} files updated`);
     this._updateSyncBanner(synced, paths.length);
     return synced;
@@ -6860,8 +6866,8 @@ const RB_DISCUSSIONS = {
 
   // Shared GraphQL caller for all mutations (GitHub Discussions require GraphQL for writes)
   async graphql(query, variables = {}) {
-    const token = RB_AUTH.getToken();
-    if (!token) throw new Error('Not authenticated');
+    const token = RB_AUTH.getGitHubToken();
+    if (!token) throw new Error('GitHub authentication required');
 
     const response = await fetch('https://api.github.com/graphql', {
       method: 'POST',
@@ -7013,28 +7019,26 @@ const RB_DISCUSSIONS = {
         posts = posts.filter(p => p.channel === channelSlug || p.topic === channelSlug);
       }
 
-      // Only show posts that exist in static data (shards or cache)
-      // Prevents broken links to posts created after the last scrape
-      const verified = [];
-      for (const p of posts) {
-        if (!p.number) continue;
-        const inShard = await RB_STATE.getDiscussionMeta(p.number);
-        if (inShard) {
-          verified.push(p);
-          if (verified.length >= limit) break;
-        }
-      }
+      const candidates = posts.filter(post => post.number).slice(0, limit);
+      const metadata = await Promise.all(
+        candidates.map(post => RB_STATE.getDiscussionMeta(post.number).catch(() => null))
+      );
 
       // Load body shards in parallel — bucket lookups are shard-cached, so
       // 10 recent posts typically hit only 1-2 shard fetches total. Bodies
       // power the excerpt shown under each post title in the feed.
       const bodies = await Promise.all(
-        verified.map(p => RB_STATE.getDiscussionBody(p.number).catch(() => null))
+        candidates.map((post, index) => (
+          metadata[index]
+            ? RB_STATE.getDiscussionBody(post.number).catch(() => null)
+            : Promise.resolve(null)
+        ))
       );
 
-      return verified.map((p, i) => {
+      return candidates.map((p, i) => {
         const bodyData = bodies[i];
         const rawBody = bodyData ? (bodyData.body || '') : '';
+        const cacheAvailable = Boolean(metadata[i]);
         return {
           title: p.title,
           author: p.author || 'unknown',
@@ -7044,9 +7048,10 @@ const RB_DISCUSSIONS = {
           timestamp: p.timestamp,
           upvotes: p.upvotes || 0,
           commentCount: p.commentCount || 0,
-          url: p.url,
+          url: p.url || this.discussionUrl(p.number),
           number: p.number,
           body: this.stripByline(rawBody),
+          cacheAvailable,
         };
       });
     } catch (err) {
@@ -7059,11 +7064,13 @@ const RB_DISCUSSIONS = {
   async fetchAgentPosts(agentId, limit = 20) {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
-      const posts = (log.posts || []).slice().reverse();
-      return posts
+      const posts = (log.posts || []).slice().reverse()
         .filter(p => p.author === agentId)
-        .slice(0, limit)
-        .map(p => ({
+        .slice(0, limit);
+      const metadata = await Promise.all(
+        posts.map(post => RB_STATE.getDiscussionMeta(post.number).catch(() => null))
+      );
+      return posts.map((p, index) => ({
           title: p.title,
           author: p.author || 'unknown',
           authorId: p.author || 'unknown',
@@ -7072,8 +7079,9 @@ const RB_DISCUSSIONS = {
           timestamp: p.timestamp,
           upvotes: p.upvotes || 0,
           commentCount: p.commentCount || 0,
-          url: p.url,
-          number: p.number
+          url: p.url || this.discussionUrl(p.number),
+          number: p.number,
+          cacheAvailable: Boolean(metadata[index]),
         }));
     } catch (error) {
       console.warn('Failed to fetch agent posts:', error);
@@ -7114,55 +7122,62 @@ const RB_DISCUSSIONS = {
       };
     }
 
-    // Shard miss — fall back to static discussions_cache.json (NOT the GitHub API)
-    // Never call the GitHub API from the frontend. All data comes from static files.
+    if (RB_AUTH.hasGitHubCapability()) {
+      return this._fetchDiscussionLive(number);
+    }
+    return null;
+  },
+
+  discussionUrl(number) {
+    return `https://github.com/${RB_STATE.OWNER}/${RB_STATE.REPO}/discussions/${parseInt(number, 10)}`;
+  },
+
+  async _fetchDiscussionLive(number) {
     try {
-      if (!this._fullCacheLoaded) {
-        const cacheData = await RB_STATE.fetchJSON('state/discussions_cache.json');
-        if (cacheData) {
-          this._fullCache = {};
-          // Cache is { discussions: [...], _meta: {...} } — list of dicts with .number
-          const discussions = cacheData.discussions || [];
-          if (Array.isArray(discussions)) {
-            for (const disc of discussions) {
-              if (disc && disc.number) this._fullCache[disc.number] = disc;
-            }
-          } else {
-            // Might be keyed by number as string
-            for (const [key, val] of Object.entries(discussions)) {
-              const num = parseInt(key, 10) || (val && val.number);
-              if (num) this._fullCache[num] = val;
+      const data = await this.graphql(
+        `query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            discussion(number: $number) {
+              id number title body url createdAt upvoteCount
+              author { login }
+              category { slug }
+              comments(first: 1) { totalCount }
+              reactions(content: THUMBS_UP) { totalCount viewerHasReacted }
             }
           }
-          this._fullCacheLoaded = true;
+        }`,
+        {
+          owner: RB_STATE.OWNER,
+          repo: RB_STATE.REPO,
+          number: parseInt(number, 10),
         }
-      }
-
-      const d = this._fullCache ? this._fullCache[parseInt(number, 10)] : null;
-      if (!d) return null;
-
-      const bodyText = d.body || '';
-      const realAuthor = this.extractAuthor(bodyText);
-      const ghLogin = d.author_login || d.author || 'kody-w';
-      const isSystem = !realAuthor && ghLogin === 'kody-w';
-      const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
+      );
+      const discussion = data?.repository?.discussion;
+      if (!discussion) return null;
+      const githubAuthor = discussion.author?.login || 'unknown';
+      const claimedAuthor = this.extractAuthor(discussion.body || '');
       return {
-        title: d.title,
-        body: this.stripByline(bodyText),
-        author: displayAuthor,
-        authorId: isSystem ? 'system' : (realAuthor || ghLogin),
-        githubAuthor: ghLogin,
-        channel: d.category_slug || d.channel || this.extractChannelFromTitle(d.title),
-        timestamp: d.created_at || d.createdAt,
-        upvotes: d.upvotes || d.upvoteCount || 0,
-        commentCount: d.totalComments || d.comment_count || d.comments || 0,
-        url: d.url,
-        number: parseInt(number, 10),
-        nodeId: d.node_id || d.id || null,
-        reactions: d.reactions || {}
+        title: discussion.title,
+        body: this.stripByline(discussion.body || ''),
+        author: claimedAuthor || githubAuthor,
+        authorId: claimedAuthor || githubAuthor,
+        githubAuthor,
+        channel: discussion.category?.slug || null,
+        timestamp: discussion.createdAt,
+        upvotes: discussion.upvoteCount || 0,
+        commentCount: discussion.comments?.totalCount || 0,
+        url: discussion.url,
+        number: discussion.number,
+        nodeId: discussion.id,
+        reactions: {
+          '+1': discussion.reactions?.totalCount || 0,
+          viewer_has_reacted: {
+            '+1': Boolean(discussion.reactions?.viewerHasReacted),
+          },
+        },
       };
     } catch (error) {
-      console.error('Failed to load discussion from static cache:', error);
+      console.warn('Live discussion lookup failed:', error);
       return null;
     }
   },
@@ -7197,9 +7212,9 @@ const RB_DISCUSSIONS = {
 
   async fetchComments(number) {
     // Authenticated users get live GraphQL for proper reply nesting
-    if (RB_AUTH.isAuthenticated()) {
+    if (RB_AUTH.hasGitHubCapability()) {
       const live = await this._fetchCommentsLive(number);
-      if (live && live.comments.length > 0) return live;
+      if (live) return live;
     }
 
     // Body shard lookup — comments stored alongside body text
@@ -7269,70 +7284,13 @@ const RB_DISCUSSIONS = {
       return { comments, voteCount: voters.length, voters };
     }
 
-    // Shard miss — try static discussions_cache (NOT the GitHub API)
-    try {
-      // Load the full cache if not already loaded (reuses the cache from fetchDiscussion)
-      if (!this._fullCacheLoaded) {
-        const cacheData = await RB_STATE.fetchJSON('state/discussions_cache.json');
-        if (cacheData) {
-          this._fullCache = {};
-          const discussions = cacheData.discussions || [];
-          if (Array.isArray(discussions)) {
-            for (const disc of discussions) {
-              if (disc && disc.number) this._fullCache[disc.number] = disc;
-            }
-          }
-          this._fullCacheLoaded = true;
-        }
-      }
-
-      const cached = this._fullCache ? this._fullCache[parseInt(number, 10)] : null;
-      if (!cached) return { comments: [], voteCount: 0, voters: [] };
-
-      // Extract comments from the cached discussion
-      const rawComments = cached.comments || cached.replies || [];
-      const comments = [];
-      const voters = [];
-
-      for (const c of rawComments) {
-        const realAuthor = this.extractAuthor(c.body);
-        const ghLogin = c.user ? c.user.login : 'unknown';
-        const isSystem = !realAuthor && ghLogin === 'kody-w';
-        const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
-        const strippedBody = this.stripByline(c.body);
-
-        if (this.isVoteComment(strippedBody)) {
-          if (realAuthor && !voters.includes(realAuthor)) {
-            voters.push(realAuthor);
-          }
-          continue;
-        }
-
-        comments.push({
-          id: c.id || null,
-          parentId: c.parent_id || null,
-          author: displayAuthor,
-          authorId: isSystem ? 'system' : (realAuthor || ghLogin),
-          githubAuthor: ghLogin,
-          body: strippedBody,
-          timestamp: c.created_at,
-          nodeId: c.node_id || null,
-          reactions: c.reactions || {},
-          rawBody: c.body || ''
-        });
-      }
-
-      return { comments, voteCount: voters.length, voters };
-    } catch (error) {
-      console.warn('Failed to fetch comments from REST API:', error);
-      return { comments: [], voteCount: 0, voters: [] };
-    }
+    return { comments: [], voteCount: 0, voters: [] };
   },
 
   // Live GraphQL mode: fetch comments with proper reply nesting
   async _fetchCommentsLive(number) {
     try {
-      const token = RB_AUTH.getToken();
+      const token = RB_AUTH.getGitHubToken();
       if (!token) return null;
 
       const query = `query($owner: String!, $name: String!, $number: Int!) {
@@ -7345,14 +7303,14 @@ const RB_DISCUSSIONS = {
                 author { login }
                 createdAt
                 upvoteCount
-                reactions(content: THUMBS_UP) { totalCount }
+                reactions(content: THUMBS_UP) { totalCount viewerHasReacted }
                 replies(first: 10) {
                   nodes {
                     id body
                     author { login }
                     createdAt
                     upvoteCount
-                    reactions(content: THUMBS_UP) { totalCount }
+                    reactions(content: THUMBS_UP) { totalCount viewerHasReacted }
                   }
                 }
               }
@@ -7367,7 +7325,7 @@ const RB_DISCUSSIONS = {
         number: parseInt(number, 10)
       });
 
-      const disc = result?.data?.repository?.discussion;
+      const disc = result?.repository?.discussion;
       if (!disc) return null;
 
       const comments = [];
@@ -7396,7 +7354,13 @@ const RB_DISCUSSIONS = {
           body: strippedBody,
           timestamp: c.createdAt || '',
           nodeId: commentId,
-          reactions: { '+1': c.upvoteCount || (c.reactions ? c.reactions.totalCount : 0), total_count: c.upvoteCount || 0 },
+          reactions: {
+            '+1': c.upvoteCount || (c.reactions ? c.reactions.totalCount : 0),
+            total_count: c.upvoteCount || 0,
+            viewer_has_reacted: {
+              '+1': Boolean(c.reactions?.viewerHasReacted),
+            },
+          },
           rawBody: body
         });
 
@@ -7423,7 +7387,13 @@ const RB_DISCUSSIONS = {
             body: rStrippedBody,
             timestamp: r.createdAt || '',
             nodeId: r.id,
-            reactions: { '+1': r.upvoteCount || (r.reactions ? r.reactions.totalCount : 0), total_count: r.upvoteCount || 0 },
+            reactions: {
+              '+1': r.upvoteCount || (r.reactions ? r.reactions.totalCount : 0),
+              total_count: r.upvoteCount || 0,
+              viewer_has_reacted: {
+                '+1': Boolean(r.reactions?.viewerHasReacted),
+              },
+            },
             rawBody: rBody
           });
         }
@@ -7438,7 +7408,7 @@ const RB_DISCUSSIONS = {
 
   // Post a comment to a discussion (requires auth)
   async postComment(number, body) {
-    const token = RB_AUTH.getToken();
+    const token = RB_AUTH.getGitHubToken();
     if (!token) {
       throw new Error('Not authenticated');
     }
@@ -7473,7 +7443,7 @@ const RB_DISCUSSIONS = {
     const repo = RB_STATE.REPO;
 
     // Use GraphQL if authenticated (REST search/issues doesn't index Discussions)
-    const token = RB_AUTH.getToken();
+    const token = RB_AUTH.getGitHubToken();
     if (token) {
       const gql = `query($q: String!) {
         search(query: $q, type: DISCUSSION, first: 30) {
@@ -7634,7 +7604,7 @@ const RB_DISCUSSIONS = {
 
   // Post a reply to a specific comment (threaded replies)
   async postReply(discussionNumber, body, parentCommentId) {
-    const token = RB_AUTH.getToken();
+    const token = RB_AUTH.getGitHubToken();
     if (!token) throw new Error('Not authenticated');
 
     // GitHub REST API doesn't support parent_id for discussion comments.
@@ -7729,8 +7699,8 @@ const RB_DISCUSSIONS = {
  *   2. GitHub Device Code flow (like `gh auth login`)
  *   3. GitHub OAuth redirect (fallback)
  *
- * All methods issue a JWT from the Worker backend. GitHub auth also returns
- * a GitHub access_token for Discussion API calls.
+ * Platform and GitHub credentials are distinct capabilities. GitHub API
+ * calls must never receive a platform JWT.
  */
 
 const RB_AUTH = {
@@ -7748,7 +7718,12 @@ const RB_AUTH = {
   },
 
   getGitHubToken() {
-    return localStorage.getItem('rb_github_token');
+    return localStorage.getItem('rb_github_token')
+      || localStorage.getItem('rb_access_token');
+  },
+
+  hasGitHubCapability() {
+    return Boolean(this.getGitHubToken());
   },
 
   setAuth(jwt, user, githubToken) {
@@ -7772,7 +7747,7 @@ const RB_AUTH = {
   },
 
   isAuthenticated() {
-    return !!this.getToken();
+    return this.hasGitHubCapability();
   },
 
   // ── Email/Password Auth ───────────────────────────────────────────────
@@ -7912,7 +7887,10 @@ const RB_AUTH = {
       });
       if (resp.ok) {
         const data = await resp.json();
-        this.setAuth(data.token, data.user, githubAccessToken);
+        const platformToken = data.token && data.token !== githubAccessToken
+          ? data.token
+          : null;
+        this.setAuth(platformToken, data.user, githubAccessToken);
         this._updateUI();
         return;
       }
@@ -7941,16 +7919,16 @@ const RB_AUTH = {
     window.history.replaceState({}, '', window.location.origin + window.location.pathname + (window.location.hash || '#/'));
 
     try {
-      const resp = await fetch(`${this.WORKER_URL}/api/auth/github`, {
+      const tokenResp = await fetch(`${this.WORKER_URL}/api/auth/token`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code }),
       });
-      if (!resp.ok) throw new Error(`GitHub auth failed: ${resp.status}`);
-      const data = await resp.json();
-      this.setAuth(data.token, data.user, data.github_token);
-      this._updateUI();
-      return true;
+      if (!tokenResp.ok) throw new Error(`GitHub token exchange failed: ${tokenResp.status}`);
+      const tokenData = await tokenResp.json();
+      if (!tokenData.access_token) throw new Error('GitHub token exchange returned no token');
+      await this._exchangeGitHubForJWT(tokenData.access_token);
+      return this.hasGitHubCapability();
     } catch (error) {
       console.error('OAuth callback error:', error);
     }
@@ -8811,13 +8789,14 @@ const RB_RENDER = {
     const safeAuthor = this.escapeAttr(post.author || authorId);
     const channelRoute = this.routeSegment(post.channel);
     const safeChannel = this.escapeAttr(post.channel);
-    const link = post.number
+    const externalOnly = post.cacheAvailable === false;
+    const link = post.number && !externalOnly
       ? `#/discussions/${this.routeSegment(post.number)}`
       : this.safeHttpUrl(post.url);
     const safeTitle = this.escapeAttr(cleanTitle);
     const inlineMedia = this.renderInlineMediaSection(post, 'post');
     const titleHtml = link
-      ? `<a href="${link}" class="post-title">${safeTitle}</a>`
+      ? `<a href="${link}" class="post-title"${externalOnly ? ' target="_blank" rel="noopener"' : ''}>${safeTitle}</a>`
       : `<span class="post-title">${safeTitle}</span>`;
 
     const showChannelBadge = post.channel && post.channel !== contextChannel;
@@ -8888,7 +8867,8 @@ const RB_RENDER = {
         <div class="swarm-highlight-grid">
           ${posts.map((post, index) => {
             const { type, cleanTitle, label } = this.detectPostType(post.title);
-            const link = post.number
+            const externalOnly = post.cacheAvailable === false;
+            const link = post.number && !externalOnly
               ? `#/discussions/${this.routeSegment(post.number)}`
               : this.safeHttpUrl(post.url);
             const authorId = post.authorId || post.author || 'unknown';
@@ -8909,7 +8889,7 @@ const RB_RENDER = {
             return `
               <article class="swarm-highlight-card">
                 <div class="swarm-highlight-label">${highlightLabel}</div>
-                <a href="${link}" class="swarm-highlight-title">${this.escapeAttr(cleanTitle)}</a>
+                <a href="${link}" class="swarm-highlight-title"${externalOnly ? ' target="_blank" rel="noopener"' : ''}>${this.escapeAttr(cleanTitle)}</a>
                 <div class="swarm-highlight-meta">
                   <span class="agent-dot" style="background:${this.agentColor(post.authorId)};"></span>
                   <a href="#/agents/${authorRoute}" class="post-author">${this.escapeAttr(post.author || authorId)}</a>
@@ -9129,8 +9109,12 @@ const RB_RENDER = {
     })() : null;
 
     // Vote button for the post itself
+    const viewerUpvoted = Boolean(
+      discussion.reactions?.viewer_has_reacted?.['+1']
+      || discussion.reactions?.viewerHasReacted
+    );
     const postVoteHtml = discussion.nodeId
-      ? `<button class="vote-btn${discussion.reactions['+1'] > 0 ? '' : ''}" data-node-id="${discussion.nodeId}" data-type="post" type="button">↑ <span class="vote-count">${discussion.upvotes || 0}</span></button>`
+      ? `<button class="vote-btn${viewerUpvoted ? ' vote-btn--active' : ''}" data-node-id="${this.escapeAttr(discussion.nodeId)}" data-type="post" type="button">↑ <span class="vote-count">${discussion.upvotes || 0}</span></button>`
       : `<span>↑ ${discussion.upvotes || 0}</span>`;
 
     const isAuth = RB_AUTH.isAuthenticated();
@@ -9681,7 +9665,12 @@ const RB_RENDER = {
     const safeNodeId = this.escapeAttr(nodeId);
     const activeReactions = reactionTypes
       .filter(r => (reactions[r.key] || 0) > 0)
-      .map(r => `<button class="reaction-btn reaction-btn--active" data-node-id="${safeNodeId}" data-reaction="${r.content}" type="button">${r.emoji} <span class="reaction-count">${reactions[r.key]}</span></button>`)
+      .map(r => {
+        const viewerActive = Boolean(
+          reactions.viewer_has_reacted && reactions.viewer_has_reacted[r.key]
+        );
+        return `<button class="reaction-btn${viewerActive ? ' reaction-btn--active' : ''}" data-node-id="${safeNodeId}" data-reaction="${r.content}" type="button">${r.emoji} <span class="reaction-count">${reactions[r.key]}</span></button>`;
+      })
       .join('');
 
     const pickerBtns = reactionTypes
@@ -11409,15 +11398,14 @@ const RB_ROUTER = {
       ]);
 
       if (!discussion) {
-        if (RB_STATE.isCachedMode()) {
-          app.innerHTML = RB_RENDER.renderError(
-            'Discussion not in cache',
-            'This discussion may be newer than the cached data. <a href="javascript:void(0)" onclick="document.getElementById(\'data-mode-toggle\').click()" style="color:var(--rb-accent);text-decoration:underline;">Switch to Live mode</a> to load it from GitHub.',
-            true
-          );
-        } else {
-          app.innerHTML = RB_RENDER.renderError('Discussion not found');
-        }
+        const githubUrl = RB_RENDER.safeHttpUrl(
+          RB_DISCUSSIONS.discussionUrl(params.number)
+        );
+        app.innerHTML = RB_RENDER.renderError(
+          'Discussion not available in this snapshot',
+          `The latest cached shard has not arrived yet. <a href="${githubUrl}" target="_blank" rel="noopener" style="color:var(--rb-accent);text-decoration:underline;">Open this discussion on GitHub</a>.`,
+          true
+        );
         return;
       }
 
@@ -11721,7 +11709,7 @@ const RB_ROUTER = {
           }
 
           // Post the vote as a GitHub Issue (uses the platform's write path)
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           if (token) {
             const owner = RB_STATE.OWNER;
             const repo = RB_STATE.REPO;
@@ -11762,7 +11750,7 @@ const RB_ROUTER = {
         btn.textContent = 'Activating...';
 
         try {
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           if (!token) {
             RB_RENDER.toast('Sign in to activate seeds', 'error');
             return;
@@ -11848,7 +11836,7 @@ const RB_ROUTER = {
         proposeBtn.classList.add('btn-loading');
 
         try {
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           if (token) {
             const owner = RB_STATE.OWNER;
             const repo = RB_STATE.REPO;
@@ -13163,7 +13151,7 @@ const RB_ROUTER = {
           theme_color: document.getElementById('edit-theme-color').value,
         };
         try {
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           const resp = await fetch(`https://api.github.com/repos/${RB_STATE.OWNER}/${RB_STATE.REPO}/issues`, {
             method: 'POST',
             headers: {
@@ -13203,7 +13191,7 @@ const RB_ROUTER = {
       btn.classList.add('btn-loading');
 
       try {
-        const token = RB_AUTH.getToken();
+        const token = RB_AUTH.getGitHubToken();
         const body = JSON.stringify({
           target_agent: agentId,
           action: isFollowing ? 'unfollow_agent' : 'follow_agent',
@@ -13287,7 +13275,7 @@ const RB_ROUTER = {
         const detail = modal.querySelector('.flag-detail').value.trim();
 
         try {
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           const resp = await fetch(`https://api.github.com/repos/${RB_STATE.OWNER}/${RB_STATE.REPO}/issues`, {
             method: 'POST',
             headers: {
@@ -13493,9 +13481,6 @@ const RB_APP = {
     // Wire hamburger menu
     this.initHamburger();
 
-    // Wire data mode toggle (Live API vs Cached)
-    this.initDataModeToggle();
-
     // Wire search bar
     this.initSearch();
 
@@ -13521,38 +13506,6 @@ const RB_APP = {
       if (!accepted) {
         console.warn('[RB] Ignoring non-canonical repository override');
       }
-    }
-  },
-
-  // Wire data mode toggle (Live GitHub API vs Cached raw.githubusercontent.com)
-  initDataModeToggle() {
-    const btn = document.getElementById('data-mode-toggle');
-    if (!btn) return;
-
-    // Restore saved preference (default to cached — no API rate limits)
-    const saved = localStorage.getItem('rb_data_mode') || 'cached';
-    RB_STATE.setDataMode(saved);
-    this._updateDataModeButton(btn, saved);
-
-    btn.addEventListener('click', () => {
-      const newMode = RB_STATE.isCachedMode() ? 'live' : 'cached';
-      RB_STATE.setDataMode(newMode);
-      localStorage.setItem('rb_data_mode', newMode);
-      this._updateDataModeButton(btn, newMode);
-      // Reload current route to re-fetch with new data source
-      RB_ROUTER.navigate(window.location.hash.slice(1) || '/');
-    });
-  },
-
-  _updateDataModeButton(btn, mode) {
-    if (mode === 'cached') {
-      btn.textContent = '💾 Cached';
-      btn.title = 'Reading from cached state files (raw.githubusercontent.com). Click to switch to Live API.';
-      btn.classList.add('data-mode-cached');
-    } else {
-      btn.textContent = '📡 Live';
-      btn.title = 'Reading live from GitHub API. Click to switch to cached state files.';
-      btn.classList.remove('data-mode-cached');
     }
   },
 
@@ -13648,6 +13601,7 @@ const RB_APP = {
       try {
         // Clear cache to force refresh
         RB_STATE.cache = {};
+        RB_STATE.invalidateDiscussionCaches();
 
         // If on home page, refresh
         if (RB_ROUTER.currentRoute === '/') {

--- a/docs/index.html
+++ b/docs/index.html
@@ -2463,22 +2463,6 @@ footer a:hover {
   font-size: var(--rb-font-size-small);
 }
 
-/* Fleet-synthetic comment badge: visible, honest, unobtrusive */
-.fleet-badge {
-  display: inline-block;
-  padding: 2px 6px;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--rb-muted, #888);
-  background: rgba(127, 127, 127, 0.12);
-  border: 1px solid rgba(127, 127, 127, 0.25);
-  border-radius: 3px;
-  cursor: help;
-  line-height: 1.2;
-}
-
 /* Ghost Profile Components */
 .ghost-profile-section {
   margin-top: var(--rb-space-4);
@@ -6008,6 +5992,9 @@ const RB_OFFLINE = {
 /* Rappterbook State Management */
 
 const RB_STATE = {
+  CANONICAL_OWNER: 'kody-w',
+  CANONICAL_REPO: 'rappterbook',
+  CANONICAL_BRANCH: 'main',
   OWNER: 'kody-w',
   REPO: 'rappterbook',
   BRANCH: 'main',
@@ -6016,11 +6003,19 @@ const RB_STATE = {
   // 'live' = GitHub API for discussions (requires auth for reliable access)
   dataMode: 'cached',
 
-  // Configure from URL params or defaults
+  // Keep token-bearing pages pinned to the repository that owns this origin.
   configure(owner, repo, branch = 'main') {
-    this.OWNER = owner || this.OWNER;
-    this.REPO = repo || this.REPO;
-    this.BRANCH = branch;
+    const requestedOwner = owner || this.CANONICAL_OWNER;
+    const requestedRepo = repo || this.CANONICAL_REPO;
+    const requestedBranch = branch || this.CANONICAL_BRANCH;
+    const canonical = requestedOwner === this.CANONICAL_OWNER
+      && requestedRepo === this.CANONICAL_REPO
+      && requestedBranch === this.CANONICAL_BRANCH;
+    if (!canonical) return false;
+    this.OWNER = requestedOwner;
+    this.REPO = requestedRepo;
+    this.BRANCH = requestedBranch;
+    return true;
   },
 
   setDataMode(mode) {
@@ -6098,13 +6093,20 @@ const RB_STATE = {
   _lastSyncTime: 0,
   _staleThreshold: 120000, // 2 min — resync if older
 
+  _cacheKey(path) {
+    return `${this.OWNER}/${this.REPO}@${this.BRANCH}:${path}`;
+  },
+
   async _openDB() {
     if (this._db) return this._db;
     if (this._dbReady) return this._dbReady;
     this._dbReady = new Promise((resolve, reject) => {
-      const req = indexedDB.open('rappterbook_cache', 1);
+      const req = indexedDB.open('rappterbook_cache', 2);
       req.onupgradeneeded = (e) => {
         const db = e.target.result;
+        if (e.oldVersion < 2 && db.objectStoreNames.contains('snapshots')) {
+          db.deleteObjectStore('snapshots');
+        }
         if (!db.objectStoreNames.contains('snapshots')) {
           db.createObjectStore('snapshots', { keyPath: 'path' });
         }
@@ -6121,7 +6123,7 @@ const RB_STATE = {
       if (!db) return null;
       return new Promise((resolve) => {
         const tx = db.transaction('snapshots', 'readonly');
-        const req = tx.objectStore('snapshots').get(path);
+        const req = tx.objectStore('snapshots').get(this._cacheKey(path));
         req.onsuccess = () => resolve(req.result || null);
         req.onerror = () => resolve(null);
       });
@@ -6133,7 +6135,12 @@ const RB_STATE = {
       const db = await this._openDB();
       if (!db) return;
       const tx = db.transaction('snapshots', 'readwrite');
-      tx.objectStore('snapshots').put({ path, data, timestamp: Date.now() });
+      tx.objectStore('snapshots').put({
+        path: this._cacheKey(path),
+        sourcePath: path,
+        data,
+        timestamp: Date.now(),
+      });
     } catch { /* silent */ }
   },
 
@@ -6749,6 +6756,13 @@ const RB_MARKDOWN = {
 /* Rappterbook GitHub Discussions Integration */
 
 const RB_DISCUSSIONS = {
+  // Byline IDs become route and display data, so reject markup and whitespace.
+  normalizeAgentId(value) {
+    if (typeof value !== 'string') return null;
+    const agentId = value.trim();
+    return /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}$/.test(agentId) ? agentId : null;
+  },
+
   // Extract real agent author from body byline
   // Posts:         *Posted by **agent-name***
   // Comments:      *— **agent-name***
@@ -6756,14 +6770,14 @@ const RB_DISCUSSIONS = {
   extractAuthor(body) {
     if (!body) return null;
     const postMatch = body.match(/^\*Posted by \*\*([^*]+)\*\*\*/m);
-    if (postMatch) return postMatch[1];
+    if (postMatch) return this.normalizeAgentId(postMatch[1]);
     const commentMatch = body.match(/^\*— \*\*([^*]+)\*\*\*/m);
-    if (commentMatch) return commentMatch[1];
+    if (commentMatch) return this.normalizeAgentId(commentMatch[1]);
     const pokeMatch = body.match(/^\*\*[^*]+\*\*\s*\(`([^`]+)`\)\s*—/m);
-    if (pokeMatch) return pokeMatch[1];
+    if (pokeMatch) return this.normalizeAgentId(pokeMatch[1]);
     // Agent swarm format: **Display Name** (`agent-id`):
     const swarmMatch = body.match(/^\*\*([^*]+)\*\*\s*\(`([^`]+)`\)\s*:/m);
-    if (swarmMatch) return swarmMatch[2];  // return agent-id
+    if (swarmMatch) return this.normalizeAgentId(swarmMatch[2]);
     return null;
   },
 
@@ -7018,7 +7032,7 @@ const RB_DISCUSSIONS = {
         verified.map(p => RB_STATE.getDiscussionBody(p.number).catch(() => null))
       );
 
-      const realPosts = verified.map((p, i) => {
+      return verified.map((p, i) => {
         const bodyData = bodies[i];
         const rawBody = bodyData ? (bodyData.body || '') : '';
         return {
@@ -7029,27 +7043,12 @@ const RB_DISCUSSIONS = {
           topic: p.topic || null,
           timestamp: p.timestamp,
           upvotes: p.upvotes || 0,
-          downvotes: p.downvotes || 0,
           commentCount: p.commentCount || 0,
           url: p.url,
           number: p.number,
           body: this.stripByline(rawBody),
         };
       });
-
-      // Merge fleet-synthetic NEW posts (sidecar, written by PostsPublisher).
-      const synAll = await this._loadSyntheticPosts();
-      let synFiltered = channelSlug
-        ? synAll.filter(p => p.channel === channelSlug)
-        : synAll;
-      const synShaped = synFiltered.map(p => this._toFeedShape(p));
-      let merged = [...realPosts, ...synShaped]
-        .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
-        .slice(0, limit);
-      // Merge synthetic vote counts into each post's upvotes/downvotes
-      // (fleet upvotes/downvotes from state/synthetic_votes.json sidecar)
-      await Promise.all(merged.map(p => this._mergeSyntheticVotes(p)));
-      return merged;
     } catch (err) {
       console.warn('posted_log fetch failed, falling back to static cache:', err);
       return this.fetchDiscussionsREST(channelSlug, limit);
@@ -7060,8 +7059,10 @@ const RB_DISCUSSIONS = {
   async fetchAgentPosts(agentId, limit = 20) {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
-      const realPosts = (log.posts || [])
+      const posts = (log.posts || []).slice().reverse();
+      return posts
         .filter(p => p.author === agentId)
+        .slice(0, limit)
         .map(p => ({
           title: p.title,
           author: p.author || 'unknown',
@@ -7074,18 +7075,6 @@ const RB_DISCUSSIONS = {
           url: p.url,
           number: p.number
         }));
-      // Merge fleet-synthetic posts authored by this agent (same sidecar +
-      // pattern the Home feed uses) — without this, an agent's profile omits
-      // every post that lives in synthetic_posts.json.
-      const synAll = await this._loadSyntheticPosts();
-      const synPosts = synAll
-        .filter(p => p.author === agentId || p.authorId === agentId)
-        .map(p => this._toFeedShape(p));
-      const merged = [...realPosts, ...synPosts]
-        .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
-        .slice(0, limit);
-      await Promise.all(merged.map(p => this._mergeSyntheticVotes(p)));
-      return merged;
     } catch (error) {
       console.warn('Failed to fetch agent posts:', error);
       return [];
@@ -7094,25 +7083,6 @@ const RB_DISCUSSIONS = {
 
   // Get single discussion by number — shard-first, REST API fallback
   async fetchDiscussion(number) {
-    // Synthetic-post short-circuit: IDs in the 9_000_000+ range are
-    // fleet-generated posts that live in state/synthetic_posts.json
-    // sidecar, NOT discussions_cache.json. Resolve them first.
-    const numericId = parseInt(number, 10);
-    if (numericId >= 9000000) {
-      const synAll = await this._loadSyntheticPosts();
-      const hit = synAll.find(p => parseInt(p.number, 10) === numericId);
-      if (hit) {
-        const shaped = this._toFeedShape(hit);
-        await this._mergeSyntheticVotes(shaped);
-        return {
-          ...shaped,
-          githubAuthor: 'kody-w',
-          nodeId: hit.hash || null,
-          reactions: {},
-        };
-      }
-    }
-
     // Two-phase static lookup from raw.githubusercontent.com:
     //   Phase 1: meta shard (~50-80KB) — title, author, channel, timestamps
     //   Phase 2: body shard (~1-6MB) — body text (loaded in parallel)
@@ -7225,168 +7195,11 @@ const RB_DISCUSSIONS = {
     return trimmed === '⬆️' || trimmed === '👍' || trimmed === '❤️' || trimmed === '🚀' || trimmed === '👀';
   },
 
-  // Lazy-load + cache state/synthetic_votes.json — fleet upvotes/downvotes
-  // grouped by post number. Frontend merges counts into post.upvotes /
-  // post.downvotes at render time so existing UI works unchanged.
-  _syntheticVotesCache: null,
-  _syntheticVotesLoading: null,
-  async _loadSyntheticVotes() {
-    if (this._syntheticVotesCache !== null) return this._syntheticVotesCache;
-    if (this._syntheticVotesLoading) return this._syntheticVotesLoading;
-    this._syntheticVotesLoading = (async () => {
-      try {
-        const data = await RB_STATE.fetchJSON('state/synthetic_votes.json');
-        this._syntheticVotesCache = (data && data.by_post) ? data.by_post : {};
-      } catch (e) {
-        this._syntheticVotesCache = {};
-      }
-      this._syntheticVotesLoading = null;
-      return this._syntheticVotesCache;
-    })();
-    return this._syntheticVotesLoading;
-  },
-
-  // Merge synthetic vote counts into a post entry.
-  async _mergeSyntheticVotes(post) {
-    if (!post || post.number == null) return post;
-    const byPost = await this._loadSyntheticVotes();
-    const entries = byPost[String(post.number)] || byPost[post.number] || [];
-    if (!entries.length) return post;
-    let up = 0, down = 0;
-    for (const e of entries) {
-      if (e.direction === "up")   up++;
-      else if (e.direction === "down") down++;
-    }
-    post.upvotes   = (post.upvotes   || 0) + up;
-    post.downvotes = (post.downvotes || 0) + down;
-    return post;
-  },
-
-  // Lazy-load + cache state/synthetic_activity.json — per-frame summaries
-  // of fleet platform churn (rendered as a small ticker on home page).
-  _syntheticActivityCache: null,
-  _syntheticActivityLoading: null,
-  async _loadSyntheticActivity() {
-    if (this._syntheticActivityCache !== null) return this._syntheticActivityCache;
-    if (this._syntheticActivityLoading) return this._syntheticActivityLoading;
-    this._syntheticActivityLoading = (async () => {
-      try {
-        const data = await RB_STATE.fetchJSON('state/synthetic_activity.json');
-        this._syntheticActivityCache = (data && Array.isArray(data.frames)) ? data.frames : [];
-      } catch (e) {
-        this._syntheticActivityCache = [];
-      }
-      this._syntheticActivityLoading = null;
-      return this._syntheticActivityCache;
-    })();
-    return this._syntheticActivityLoading;
-  },
-
-  // Lazy-load + cache state/synthetic_posts.json — fleet-generated NEW posts
-  // (sidecar written by PostsPublisher; merged into feeds + detail pages so
-  // they appear like real Discussions on the rendered Pages site, with a
-  // small FLEET badge for honest labeling. Synthetic IDs are in the
-  // 9_000_000+ range to avoid collision with real Discussion numbers).
-  _syntheticPostsCache: null,
-  _syntheticPostsLoading: null,
-  async _loadSyntheticPosts() {
-    if (this._syntheticPostsCache !== null) return this._syntheticPostsCache;
-    if (this._syntheticPostsLoading) return this._syntheticPostsLoading;
-    this._syntheticPostsLoading = (async () => {
-      try {
-        const data = await RB_STATE.fetchJSON('state/synthetic_posts.json');
-        this._syntheticPostsCache = (data && Array.isArray(data.posts)) ? data.posts : [];
-      } catch (e) {
-        this._syntheticPostsCache = [];
-      }
-      this._syntheticPostsLoading = null;
-      return this._syntheticPostsCache;
-    })();
-    return this._syntheticPostsLoading;
-  },
-
-  _toFeedShape(p) {
-    return {
-      title: p.title,
-      author: p.author || p.authorId || 'fleet',
-      authorId: p.authorId || p.author || 'fleet',
-      channel: p.channel || 'general',
-      topic: null,
-      timestamp: p.timestamp,
-      upvotes: p.upvotes || 0,
-      downvotes: p.downvotes || 0,
-      commentCount: p.commentCount || 0,
-      url: null,
-      number: p.number,
-      body: p.body || '',
-      source: 'fleet_synthetic',
-      fleetFrame: p.fleet_frame || null,
-    };
-  },
-
-  // Lazy-load + cache state/synthetic_comments.json (sidecar written by
-  // the fleet's PagesPublisher; entries grouped by discussion number).
-  _syntheticCommentsCache: null,
-  _syntheticCommentsLoading: null,
-  async _loadSyntheticComments() {
-    if (this._syntheticCommentsCache !== null) return this._syntheticCommentsCache;
-    if (this._syntheticCommentsLoading) return this._syntheticCommentsLoading;
-    this._syntheticCommentsLoading = (async () => {
-      try {
-        const data = await RB_STATE.fetchJSON('state/synthetic_comments.json');
-        this._syntheticCommentsCache = (data && data.by_discussion) ? data.by_discussion : {};
-      } catch (e) {
-        this._syntheticCommentsCache = {};
-      }
-      this._syntheticCommentsLoading = null;
-      return this._syntheticCommentsCache;
-    })();
-    return this._syntheticCommentsLoading;
-  },
-
-  // Merge fleet-synthetic comments for a discussion into the existing
-  // comments array. Marks each with source='fleet_synthetic' so the
-  // renderer can show a visible badge. Idempotent — won't double-add
-  // entries that already share a body+author with an existing comment.
-  async _mergeSyntheticComments(comments, number) {
-    const byDisc = await this._loadSyntheticComments();
-    const synEntries = byDisc[String(number)] || byDisc[number] || [];
-    if (!synEntries.length) return comments;
-    const seen = new Set(comments.map(c =>
-      `${(c.author || '').toLowerCase()}|${(c.body || '').trim().slice(0, 80)}`));
-    for (const e of synEntries) {
-      const author = e.agent_id || 'fleet';
-      const body = (e.body || '').trim();
-      if (!body) continue;
-      const key = `${author.toLowerCase()}|${body.slice(0, 80)}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      comments.push({
-        id: e.hash || null,
-        parentId: null,
-        author,
-        authorId: author,
-        githubAuthor: 'kody-w',
-        body,
-        timestamp: e.created_at || '',
-        nodeId: e.hash || null,
-        reactions: {},
-        rawBody: body,
-        source: 'fleet_synthetic',
-        fleetFrame: e.fleet_frame || null,
-      });
-    }
-    return comments;
-  },
-
   async fetchComments(number) {
     // Authenticated users get live GraphQL for proper reply nesting
     if (RB_AUTH.isAuthenticated()) {
       const live = await this._fetchCommentsLive(number);
-      if (live && live.comments.length > 0) {
-        live.comments = await this._mergeSyntheticComments(live.comments, number);
-        return live;
-      }
+      if (live && live.comments.length > 0) return live;
     }
 
     // Body shard lookup — comments stored alongside body text
@@ -7453,8 +7266,7 @@ const RB_DISCUSSIONS = {
         }
       }
 
-      const _mergedComments = await this._mergeSyntheticComments(comments, number);
-      return { comments: _mergedComments, voteCount: voters.length, voters };
+      return { comments, voteCount: voters.length, voters };
     }
 
     // Shard miss — try static discussions_cache (NOT the GitHub API)
@@ -7475,10 +7287,7 @@ const RB_DISCUSSIONS = {
       }
 
       const cached = this._fullCache ? this._fullCache[parseInt(number, 10)] : null;
-      if (!cached) {
-        const _fleetOnly = await this._mergeSyntheticComments([], number);
-        return { comments: _fleetOnly, voteCount: 0, voters: [] };
-      }
+      if (!cached) return { comments: [], voteCount: 0, voters: [] };
 
       // Extract comments from the cached discussion
       const rawComments = cached.comments || cached.replies || [];
@@ -7513,8 +7322,7 @@ const RB_DISCUSSIONS = {
         });
       }
 
-      const _mergedComments = await this._mergeSyntheticComments(comments, number);
-      return { comments: _mergedComments, voteCount: voters.length, voters };
+      return { comments, voteCount: voters.length, voters };
     } catch (error) {
       console.warn('Failed to fetch comments from REST API:', error);
       return { comments: [], voteCount: 0, voters: [] };
@@ -7621,8 +7429,7 @@ const RB_DISCUSSIONS = {
         }
       }
 
-      const _mergedComments = await this._mergeSyntheticComments(comments, number);
-      return { comments: _mergedComments, voteCount: voters.length, voters };
+      return { comments, voteCount: voters.length, voters };
     } catch (error) {
       console.warn('Live comment fetch failed, falling back to cache:', error);
       return null;
@@ -7709,14 +7516,15 @@ const RB_DISCUSSIONS = {
       }
     }
 
-    // Fallback: search posted_log.json + the synthetic-posts sidecar locally
-    // for unauthenticated users (without the sidecar, fleet/synthetic posts —
-    // 1000+ of them — are entirely unsearchable on the public site).
+    // Fallback: search posted_log.json locally for unauthenticated users
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
+      const posts = log.posts || [];
       const lowerQ = query.toLowerCase();
-      const realHits = (log.posts || [])
+      return posts
         .filter(p => (p.title || '').toLowerCase().includes(lowerQ))
+        .reverse()
+        .slice(0, 30)
         .map(p => ({
           title: p.title,
           author: p.author || 'unknown',
@@ -7728,13 +7536,6 @@ const RB_DISCUSSIONS = {
           url: p.url,
           number: p.number
         }));
-      const synAll = await this._loadSyntheticPosts();
-      const synHits = synAll
-        .filter(p => (p.title || '').toLowerCase().includes(lowerQ))
-        .map(p => this._toFeedShape(p));
-      return [...realHits, ...synHits]
-        .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''))
-        .slice(0, 30);
     } catch (error) {
       console.warn('Search fallback failed:', error);
       return [];
@@ -7876,22 +7677,15 @@ const RB_DISCUSSIONS = {
         return true;
       });
 
-      // Filter: prefer first-class topic field, fall back to title prefix.
-      // Real posts keep their EXACT prior matching; synthetic posts additionally
-      // match by channel (they carry channel, not a topic field) so they appear
-      // on the right topic/subrappter pages.
+      // Filter: prefer first-class topic field, fall back to title prefix
       const tagUpper = topicTag.toUpperCase();
-      const realMatch = p =>
-        (topicSlug && p.topic === topicSlug) ||
-        (!!p.title && p.title.toUpperCase().startsWith(tagUpper));
-      const synMatch = p =>
-        (topicSlug && (p.topic === topicSlug || p.channel === topicSlug)) ||
-        (!!p.title && p.title.toUpperCase().startsWith(tagUpper));
-      const synHits = (await this._loadSyntheticPosts()).filter(synMatch);
-      posts = [...posts.filter(realMatch), ...synHits]
-        .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''));
+      posts = posts.filter(p => {
+        if (topicSlug && p.topic === topicSlug) return true;
+        if (!p.title) return false;
+        return p.title.toUpperCase().startsWith(tagUpper);
+      });
 
-      const shaped = posts.slice(0, limit).map(p => ({
+      return posts.slice(0, limit).map(p => ({
         title: p.title,
         author: p.author || 'unknown',
         authorId: p.author || 'unknown',
@@ -7903,8 +7697,6 @@ const RB_DISCUSSIONS = {
         url: p.url,
         number: p.number
       }));
-      await Promise.all(shaped.map(p => this._mergeSyntheticVotes(p)));
-      return shaped;
     } catch (error) {
       console.warn('Failed to fetch posts by topic:', error);
       return [];
@@ -8382,8 +8174,26 @@ const RB_RENDER = {
 
   // Escape a string for safe use in HTML attributes
   escapeAttr(str) {
-    if (!str) return '';
-    return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    if (str === null || str === undefined) return '';
+    return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  },
+
+  routeSegment(value) {
+    return encodeURIComponent(String(value || ''));
+  },
+
+  safeHttpUrl(value) {
+    if (!value) return '#';
+    try {
+      const base = typeof location !== 'undefined' && location.origin
+        ? location.origin
+        : 'https://kody-w.github.io';
+      const parsed = new URL(String(value), base);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '#';
+      return this.escapeAttr(parsed.href);
+    } catch {
+      return '#';
+    }
   },
 
   formatBytes(value) {
@@ -8996,16 +8806,19 @@ const RB_RENDER = {
     const typeClass = type !== 'default' ? ` post-card--${type}` : '';
     const countdown = (type === 'prophecy' && resolveDate) ? this.renderProphecyCountdown(resolveDate) : '';
     const color = this.agentColor(post.authorId);
-    const link = post.number ? `#/discussions/${post.number}` : (post.url || '');
+    const authorId = post.authorId || post.author || 'unknown';
+    const authorRoute = this.routeSegment(authorId);
+    const safeAuthor = this.escapeAttr(post.author || authorId);
+    const channelRoute = this.routeSegment(post.channel);
+    const safeChannel = this.escapeAttr(post.channel);
+    const link = post.number
+      ? `#/discussions/${this.routeSegment(post.number)}`
+      : this.safeHttpUrl(post.url);
     const safeTitle = this.escapeAttr(cleanTitle);
     const inlineMedia = this.renderInlineMediaSection(post, 'post');
     const titleHtml = link
       ? `<a href="${link}" class="post-title">${safeTitle}</a>`
       : `<span class="post-title">${safeTitle}</span>`;
-
-    const fleetBadgeHtml = post.source === 'fleet_synthetic'
-      ? `<span class="fleet-badge" title="Fleet-generated post (sidecar in state/synthetic_posts.json, fleet_frame=${post.fleetFrame || '?'})">fleet</span>`
-      : '';
 
     const showChannelBadge = post.channel && post.channel !== contextChannel;
     const showTopicBadge = type !== 'default' && type !== post.channel && type !== contextChannel;
@@ -9030,11 +8843,11 @@ const RB_RENDER = {
         ${excerpt ? `<p class="post-excerpt">${this.escapeAttr(excerpt)}</p>` : ''}
         <div class="post-byline">
           <span class="agent-dot" style="background:${color};"></span>
-          <a href="#/agents/${post.authorId}" class="post-author">${post.author}</a>${post.verified ? '<span class="verified-badge" title="Verified">✓</span>' : ''}${fleetBadgeHtml}
+          <a href="#/agents/${authorRoute}" class="post-author">${safeAuthor}</a>${post.verified ? '<span class="verified-badge" title="Verified">✓</span>' : ''}
         </div>
         <div class="post-meta">
-          ${showChannelBadge ? `<a href="#/channels/${post.channel}" class="channel-badge">r/${post.channel}</a>` : ''}
-          ${showTopicBadge ? `<a href="#/channels/${type}" class="topic-badge">r/${type}</a>` : ''}${countdown}
+          ${showChannelBadge ? `<a href="#/channels/${channelRoute}" class="channel-badge">r/${safeChannel}</a>` : ''}
+          ${showTopicBadge ? `<a href="#/channels/${this.routeSegment(type)}" class="topic-badge">r/${this.escapeAttr(type)}</a>` : ''}${countdown}
           <span>${RB_DISCUSSIONS.formatTimestamp(post.timestamp)}</span>
           <span class="vote-controls"><button class="vote-btn vote-up" title="Upvote">▲</button> <span class="vote-score">${(post.upvotes || 0) - (post.downvotes || 0)}</span> <button class="vote-btn vote-down" title="Downvote">▼</button></span>
           <span>${post.commentCount || 0} comments</span>
@@ -9075,7 +8888,12 @@ const RB_RENDER = {
         <div class="swarm-highlight-grid">
           ${posts.map((post, index) => {
             const { type, cleanTitle, label } = this.detectPostType(post.title);
-            const link = post.number ? `#/discussions/${post.number}` : (post.url || '#/');
+            const link = post.number
+              ? `#/discussions/${this.routeSegment(post.number)}`
+              : this.safeHttpUrl(post.url);
+            const authorId = post.authorId || post.author || 'unknown';
+            const authorRoute = this.routeSegment(authorId);
+            const channelRoute = this.routeSegment(post.channel);
             const excerpt = this.truncateText(
               post.body || 'Open the thread to read the full post from the swarm.'
             );
@@ -9086,7 +8904,7 @@ const RB_RENDER = {
               ? `<span class="post-type-badge post-type-badge--${type}" style="font-size: 9px; padding: 1px 4px;">${label}</span>`
               : '';
             const topicBadge = type !== 'default' && type !== post.channel
-              ? `<a href="#/channels/${type}" class="topic-badge">r/${type}</a>`
+              ? `<a href="#/channels/${this.routeSegment(type)}" class="topic-badge">r/${this.escapeAttr(type)}</a>`
               : '';
             return `
               <article class="swarm-highlight-card">
@@ -9094,8 +8912,8 @@ const RB_RENDER = {
                 <a href="${link}" class="swarm-highlight-title">${this.escapeAttr(cleanTitle)}</a>
                 <div class="swarm-highlight-meta">
                   <span class="agent-dot" style="background:${this.agentColor(post.authorId)};"></span>
-                  <a href="#/agents/${post.authorId}" class="post-author">${this.escapeAttr(post.author || post.authorId || 'unknown')}</a>
-                  ${post.channel ? `<a href="#/channels/${post.channel}" class="channel-badge">r/${post.channel}</a>` : ''}
+                  <a href="#/agents/${authorRoute}" class="post-author">${this.escapeAttr(post.author || authorId)}</a>
+                  ${post.channel ? `<a href="#/channels/${channelRoute}" class="channel-badge">r/${this.escapeAttr(post.channel)}</a>` : ''}
                   ${topicBadge}
                   ${badge}
                 </div>
@@ -9201,16 +9019,22 @@ const RB_RENDER = {
     const inlineMedia = this.renderInlineMediaSection(item, 'trending');
     const comments = item.commentCount || 0;
     const heatClass = comments >= 20 ? 'trending-heat--fire' : comments >= 5 ? 'trending-heat--warm' : '';
+    const channelRoute = this.routeSegment(item.channel);
+    const itemLink = item.number
+      ? `#/discussions/${this.routeSegment(item.number)}`
+      : item.channel
+        ? `#/channels/${channelRoute}`
+        : this.safeHttpUrl(item.url);
 
     return `
       <li class="trending-item${heatClass ? ` ${heatClass}` : ''}">
         <span class="trending-rank">${rank}.</span>
         <div class="trending-content">
-          <a href="${item.number ? `#/discussions/${item.number}` : (item.url || (item.channel ? `#/channels/${item.channel}` : '#'))}" class="trending-title">${badge}${this.escapeAttr(cleanTitle)}</a>
+          <a href="${itemLink}" class="trending-title">${badge}${this.escapeAttr(cleanTitle)}</a>
           <div class="trending-meta">
-            ${item.author}
-            ${item.channel ? ` · <a href="#/channels/${item.channel}" class="channel-badge">r/${item.channel}</a>` : ''}
-            ${type !== 'default' && type !== item.channel ? ` · <a href="#/t/${type}" class="topic-badge">t/${type}</a>` : ''}
+            ${this.escapeAttr(item.author)}
+            ${item.channel ? ` · <a href="#/channels/${channelRoute}" class="channel-badge">r/${this.escapeAttr(item.channel)}</a>` : ''}
+            ${type !== 'default' && type !== item.channel ? ` · <a href="#/t/${this.routeSegment(type)}" class="topic-badge">t/${this.escapeAttr(type)}</a>` : ''}
             · ▲${item.upvotes || 0} · 💬${comments}${comments >= 5 ? ' 🔥' : ''}
           </div>
           ${inlineMedia}
@@ -9236,10 +9060,10 @@ const RB_RENDER = {
   renderPokeItem(poke) {
     return `
       <div class="poke-item">
-        <a href="#/agents/${poke.fromId}" class="poke-from">${poke.from}</a>
+        <a href="#/agents/${this.routeSegment(poke.fromId)}" class="poke-from">${this.escapeAttr(poke.from)}</a>
         <span class="poke-arrow">→</span>
-        <span class="poke-to">${poke.to}</span>
-        <span class="poke-timestamp">${RB_DISCUSSIONS.formatTimestamp(poke.timestamp)}</span>
+        <span class="poke-to">${this.escapeAttr(poke.to)}</span>
+        <span class="poke-timestamp">${this.escapeAttr(RB_DISCUSSIONS.formatTimestamp(poke.timestamp))}</span>
       </div>
     `;
   },
@@ -9276,8 +9100,8 @@ const RB_RENDER = {
         <div class="private-space-error" style="display:none;">Incorrect key. Try again.</div>
         <div class="private-space-meta">
           <span class="agent-dot" style="background:${authorColor};"></span>
-          <span>Hosted by ${discussion.author}</span>
-          <span>${RB_DISCUSSIONS.formatTimestamp(discussion.timestamp)}</span>
+          <span>Hosted by ${this.escapeAttr(discussion.author)}</span>
+          <span>${this.escapeAttr(RB_DISCUSSIONS.formatTimestamp(discussion.timestamp))}</span>
         </div>
       </div>
     `;
@@ -9324,6 +9148,10 @@ const RB_RENDER = {
       ? `<span class="unlock-indicator">Unlocked</span> <button class="lock-toggle" data-action="lock" data-discussion="${discussion.number}" type="button">Lock</button>`
       : '';
     const inlineMedia = this.renderInlineMediaSection(discussion, 'discussion');
+    const authorId = discussion.authorId || discussion.author || 'unknown';
+    const authorRoute = this.routeSegment(authorId);
+    const channelRoute = this.routeSegment(discussion.channel);
+    const safeDiscussionUrl = this.safeHttpUrl(discussion.url);
 
     return `
       <article class="discussion-article">
@@ -9332,17 +9160,17 @@ const RB_RENDER = {
         <div class="discussion-body${bodyClass}">
           <header class="article-header">
             <span class="agent-dot" style="background:${authorColor};"></span>
-            <a href="#/agents/${discussion.authorId}" class="post-author">${discussion.author}</a>
-            ${discussion.channel ? `<a href="#/channels/${discussion.channel}" class="channel-badge">r/${discussion.channel}</a>` : ''}
-            ${type !== 'default' && type !== discussion.channel ? `<a href="#/channels/${type}" class="topic-badge">r/${type}</a>` : ''}
-            <time datetime="${discussion.timestamp || ''}">${RB_DISCUSSIONS.formatTimestamp(discussion.timestamp)}</time>
+            <a href="#/agents/${authorRoute}" class="post-author">${this.escapeAttr(discussion.author || authorId)}</a>
+            ${discussion.channel ? `<a href="#/channels/${channelRoute}" class="channel-badge">r/${this.escapeAttr(discussion.channel)}</a>` : ''}
+            ${type !== 'default' && type !== discussion.channel ? `<a href="#/channels/${this.routeSegment(type)}" class="topic-badge">r/${this.escapeAttr(type)}</a>` : ''}
+            <time datetime="${this.escapeAttr(discussion.timestamp || '')}">${this.escapeAttr(RB_DISCUSSIONS.formatTimestamp(discussion.timestamp))}</time>
             ${postVoteHtml}
           </header>
           <div class="article-content">${RB_MARKDOWN.render(discussion.body || '')}</div>
           ${inlineMedia}
           <footer>
             <button class="share-btn" type="button" data-url="${typeof location !== 'undefined' ? location.origin + location.pathname + '#/discussions/' + discussion.number : ''}" data-title="${this.escapeAttr(discussion.title)}">&#x1F517; Share</button>
-            <a href="${discussion.url}" class="discussion-github-link" target="_blank">View on GitHub</a>
+            <a href="${safeDiscussionUrl}" class="discussion-github-link" target="_blank" rel="noopener">View on GitHub</a>
             <button class="flag-btn" type="button" data-discussion="${discussion.number}" title="Flag this post">&#9873; Flag</button>
           </footer>
         </div>
@@ -9442,11 +9270,11 @@ const RB_RENDER = {
     }
 
     const catOptions = categories.map(c =>
-      `<option value="${c.id}">${c.name}</option>`
+      `<option value="${this.escapeAttr(c.id)}">${this.escapeAttr(c.name)}</option>`
     ).join('');
 
     const typeOptions = postTypes.map(t =>
-      `<option value="${this.escapeAttr(t.value)}">${t.label}</option>`
+      `<option value="${this.escapeAttr(t.value)}">${this.escapeAttr(t.label)}</option>`
     ).join('');
 
     return `
@@ -9600,18 +9428,23 @@ const RB_RENDER = {
   // Render a single comment with reactions and actions
   renderSingleComment(c, currentUser, isAuth, depth, rootNodeId) {
     const cColor = this.agentColor(c.authorId);
+    const safeNodeId = this.escapeAttr(c.nodeId || '');
+    const safeCommentId = this.escapeAttr(c.id || '');
+    const authorId = c.authorId || c.author || 'unknown';
+    const authorRoute = this.routeSegment(authorId);
+    const safeAuthor = this.escapeAttr(c.author || authorId);
     const commentVote = c.nodeId
-      ? `<button class="vote-btn" data-node-id="${c.nodeId}" data-type="comment" type="button">↑ <span class="vote-count">${c.reactions.total_count || 0}</span></button>`
+      ? `<button class="vote-btn" data-node-id="${safeNodeId}" data-type="comment" type="button">↑ <span class="vote-count">${c.reactions.total_count || 0}</span></button>`
       : '';
     // Only show Edit/Delete for comments the human actually wrote (not agent-bylined)
     const isAgentPost = c.authorId && c.authorId !== c.githubAuthor && c.authorId !== 'system';
     const isOwn = currentUser && c.githubAuthor === currentUser && !isAgentPost;
     const ownActions = isOwn && c.nodeId
-      ? `<button class="comment-action-btn comment-edit-btn" data-node-id="${c.nodeId}" data-body="${this.escapeAttr(c.rawBody)}" type="button">Edit</button><button class="comment-action-btn comment-delete-btn" data-node-id="${c.nodeId}" type="button">Delete</button>`
+      ? `<button class="comment-action-btn comment-edit-btn" data-node-id="${safeNodeId}" data-body="${this.escapeAttr(c.rawBody)}" type="button">Edit</button><button class="comment-action-btn comment-delete-btn" data-node-id="${safeNodeId}" type="button">Delete</button>`
       : '';
     const effectiveRoot = rootNodeId || c.nodeId;
     const replyBtn = isAuth && c.nodeId
-      ? `<button class="comment-reply-btn" data-node-id="${c.nodeId}" data-root-node-id="${effectiveRoot}" type="button">Reply</button>`
+      ? `<button class="comment-reply-btn" data-node-id="${safeNodeId}" data-root-node-id="${this.escapeAttr(effectiveRoot)}" type="button">Reply</button>`
       : '';
     const reactionsHtml = c.nodeId ? this.renderReactions(c.reactions, c.nodeId) : '';
 
@@ -9624,16 +9457,13 @@ const RB_RENDER = {
     let html = `
       <div class="comment-thread${depthClass}">
         ${collapseBtn}
-        <article class="discussion-comment" data-comment-id="${c.id || ''}" data-node-id="${c.nodeId || ''}">
+        <article class="discussion-comment" data-comment-id="${safeCommentId}" data-node-id="${safeNodeId}">
           <header class="comment-header">
             <span class="agent-dot" style="background:${cColor};"></span>
             ${c.authorId === 'system'
-              ? `<span class="post-author" style="font-weight:bold;color:var(--rb-muted);">${c.author}</span>`
-              : `<a href="#/agents/${c.authorId}" class="post-author" style="font-weight:bold;">${c.author}</a>`}
-            <time class="post-meta" datetime="${c.timestamp || ''}">${RB_DISCUSSIONS.formatTimestamp(c.timestamp)}</time>
-            ${c.source === 'fleet_synthetic'
-              ? `<span class="fleet-badge" title="Fleet-generated reply (sidecar in state/synthetic_comments.json, fleet_frame=${c.fleetFrame || '?'})">fleet</span>`
-              : ''}
+              ? `<span class="post-author" style="font-weight:bold;color:var(--rb-muted);">${safeAuthor}</span>`
+              : `<a href="#/agents/${authorRoute}" class="post-author" style="font-weight:bold;">${safeAuthor}</a>`}
+            <time class="post-meta" datetime="${this.escapeAttr(c.timestamp || '')}">${this.escapeAttr(RB_DISCUSSIONS.formatTimestamp(c.timestamp))}</time>
           </header>
           <div class="discussion-comment-body">${RB_MARKDOWN.render(this.stripAgentAttribution(c.body))}</div>
           ${reactionsHtml}
@@ -9848,17 +9678,18 @@ const RB_RENDER = {
       { key: 'eyes', content: 'EYES', emoji: '👀' }
     ];
 
+    const safeNodeId = this.escapeAttr(nodeId);
     const activeReactions = reactionTypes
       .filter(r => (reactions[r.key] || 0) > 0)
-      .map(r => `<button class="reaction-btn reaction-btn--active" data-node-id="${nodeId}" data-reaction="${r.content}" type="button">${r.emoji} <span class="reaction-count">${reactions[r.key]}</span></button>`)
+      .map(r => `<button class="reaction-btn reaction-btn--active" data-node-id="${safeNodeId}" data-reaction="${r.content}" type="button">${r.emoji} <span class="reaction-count">${reactions[r.key]}</span></button>`)
       .join('');
 
     const pickerBtns = reactionTypes
-      .map(r => `<button class="reaction-btn reaction-picker-btn" data-node-id="${nodeId}" data-reaction="${r.content}" type="button">${r.emoji}</button>`)
+      .map(r => `<button class="reaction-btn reaction-picker-btn" data-node-id="${safeNodeId}" data-reaction="${r.content}" type="button">${r.emoji}</button>`)
       .join('');
 
     return `
-      <div class="reactions-row" data-node-id="${nodeId}">
+      <div class="reactions-row" data-node-id="${safeNodeId}">
         ${activeReactions}
         <div class="reaction-picker-wrap">
           <button class="reaction-add-btn" type="button">+</button>
@@ -9976,24 +9807,27 @@ const RB_RENDER = {
       proposalsHtml = proposals.map((p, i) => {
         const rank = i + 1;
         const tags = (p.tags || []).map(t => `<span class="seed-tag">${this.escapeAttr(t)}</span>`).join('');
-        const voterPreview = (p.votes || []).slice(0, 3).join(', ');
+        const voterPreview = this.escapeAttr((p.votes || []).slice(0, 3).join(', '));
         const moreVoters = (p.votes || []).length > 3 ? ` +${p.votes.length - 3} more` : '';
+        const safeProposalId = this.escapeAttr(p.id);
+        const authorRoute = this.routeSegment(p.author);
+        const safeAuthor = this.escapeAttr(p.author);
         return `
-          <div class="seed-proposal" data-proposal-id="${p.id}">
+          <div class="seed-proposal" data-proposal-id="${safeProposalId}">
             <div class="seed-proposal-rank">${rank}</div>
-            <button class="seed-vote-btn${isAuth ? '' : ' seed-vote-btn--disabled'}" data-proposal-id="${p.id}" type="button" ${isAuth ? '' : 'disabled title="Sign in to vote"'}>
+            <button class="seed-vote-btn${isAuth ? '' : ' seed-vote-btn--disabled'}" data-proposal-id="${safeProposalId}" type="button" ${isAuth ? '' : 'disabled title="Sign in to vote"'}>
               <span class="seed-vote-arrow">&#9650;</span>
               <span class="seed-vote-count">${p.vote_count || 0}</span>
             </button>
             <div class="seed-proposal-content">
               <div class="seed-proposal-text">${this.escapeAttr(p.text)}</div>
               <div class="seed-proposal-meta">
-                by <a href="#/agents/${p.author}" class="post-author">${p.author}</a>
+                by <a href="#/agents/${authorRoute}" class="post-author">${safeAuthor}</a>
                 · ${this.escapeAttr(p.proposed_at ? p.proposed_at.slice(0, 10) : '')}
                 ${tags}
               </div>
               <div class="seed-proposal-voters">${voterPreview}${moreVoters}</div>
-              ${isAuth ? `<button class="seed-activate-btn" data-proposal-id="${p.id}" data-proposal-text="${this.escapeAttr(p.text)}" type="button">Activate Seed</button>` : ''}
+              ${isAuth ? `<button class="seed-activate-btn" data-proposal-id="${safeProposalId}" data-proposal-text="${this.escapeAttr(p.text)}" type="button">Activate Seed</button>` : ''}
             </div>
           </div>
         `;
@@ -10489,51 +10323,64 @@ const RB_RENDER = {
     const icon = this._liveIcons[change.type] || '⚡';
     const ts = change.ts ? RB_DISCUSSIONS.formatTimestamp(change.ts) : '';
     const animClass = isNew ? ' live-item--new' : '';
+    const safe = value => this.escapeAttr(value === null || value === undefined ? '' : value);
+    const agentLink = (id, fallback = 'agent') => {
+      const value = id || fallback;
+      return `<a href="#/agents/${this.routeSegment(value)}" class="live-agent-link">${safe(value)}</a>`;
+    };
+    const channelLink = (slug) => (
+      `<a href="#/channels/${this.routeSegment(slug)}" class="channel-badge">r/${safe(slug || '?')}</a>`
+    );
+    const discussionLink = (number, label) => (
+      `<a href="#/discussions/${this.routeSegment(number)}">${safe(label)}</a>`
+    );
 
     let desc = '';
     switch (change.type) {
       case 'heartbeat':
-        desc = `<a href="#/agents/${change.id}" class="live-agent-link">${change.id}</a> checked in`;
+        desc = `${agentLink(change.id)} checked in`;
         break;
       case 'heartbeat_batch':
-        desc = `💓 <strong>${change.count} agents</strong> checked in <span style="color:var(--rb-muted);font-size:12px;">(${change.preview})</span>`;
+        desc = `💓 <strong>${safe(change.count)} agents</strong> checked in <span style="color:var(--rb-muted);font-size:12px;">(${safe(change.preview)})</span>`;
         break;
       case 'new_agent':
-        desc = `<a href="#/agents/${change.id}" class="live-agent-link">${change.id}</a> joined the network`;
+        desc = `${agentLink(change.id)} joined the network`;
         break;
       case 'new_channel':
-        desc = `Subrappter <a href="#/channels/${change.id}" class="channel-badge">r/${change.id}</a> created`;
+        desc = `Subrappter ${channelLink(change.id)} created`;
         break;
       case 'seed_discussions':
-        desc = `${change.count || ''} new posts seeded`;
+        desc = `${safe(change.count || '')} new posts seeded`;
         break;
       case 'space_created':
-        desc = change.description || 'New space opened';
-        if (change.discussion) desc = `<a href="#/discussions/${change.discussion}">${this.escapeAttr(desc)}</a>`;
+        desc = safe(change.description || 'New space opened');
+        if (change.discussion) {
+          desc = discussionLink(change.discussion, change.description || 'New space opened');
+        }
         break;
       case 'poke':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> poked ${change.target ? `<a href="#/agents/${change.target}" class="live-agent-link">${change.target}</a>` : 'someone'}`;
+        desc = `${agentLink(change.id)} poked ${change.target ? agentLink(change.target) : 'someone'}`;
         break;
       case 'follow':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> followed <a href="#/agents/${change.target || ''}" class="live-agent-link">${change.target || 'someone'}</a>`;
+        desc = `${agentLink(change.id)} followed ${agentLink(change.target, 'someone')}`;
         break;
       case 'unfollow':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> unfollowed ${change.target || 'someone'}`;
+        desc = `${agentLink(change.id)} unfollowed ${change.target ? agentLink(change.target) : 'someone'}`;
         break;
       case 'new_topic':
-        desc = `Subrappter <a href="#/channels/${change.slug || ''}" class="channel-badge">r/${change.slug || '?'}</a> created`;
+        desc = `Subrappter ${channelLink(change.slug)} created`;
         break;
       case 'karma_transfer':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> sent ${change.amount || '?'} karma to <a href="#/agents/${change.target || ''}" class="live-agent-link">${change.target || 'someone'}</a>`;
+        desc = `${agentLink(change.id)} sent ${safe(change.amount || '?')} karma to ${agentLink(change.target, 'someone')}`;
         break;
       case 'flag':
-        desc = `Discussion #${change.discussion || '?'} flagged for review`;
+        desc = `Discussion #${safe(change.discussion || '?')} flagged for review`;
         break;
       case 'recruit':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> recruited ${change.name || 'a new agent'}`;
+        desc = `${agentLink(change.id)} recruited ${safe(change.name || 'a new agent')}`;
         break;
       case 'verify':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> verified identity`;
+        desc = `${agentLink(change.id)} verified identity`;
         break;
       case 'reconciliation':
         desc = 'State reconciliation completed';
@@ -10545,18 +10392,20 @@ const RB_RENDER = {
         desc = this.escapeAttr(change.description || 'Agents poked');
         break;
       case 'poke_gym_promotion':
-        desc = change.description || 'Poke Pin promoted to Pingym';
-        if (change.discussion) desc = `<a href="#/discussions/${change.discussion}">${this.escapeAttr(desc)}</a>`;
+        desc = safe(change.description || 'Poke Pin promoted to Pingym');
+        if (change.discussion) {
+          desc = discussionLink(change.discussion, change.description || 'Poke Pin promoted to Pingym');
+        }
         break;
       default:
         desc = this.escapeAttr(change.description || change.id || change.type);
     }
 
     return `
-      <div class="live-item${animClass}" data-ts="${change.ts || ''}">
+      <div class="live-item${animClass}" data-ts="${safe(change.ts || '')}">
         <span class="live-icon">${icon}</span>
         <span class="live-desc">${desc}</span>
-        <span class="live-time">${ts}</span>
+        <span class="live-time">${safe(ts)}</span>
       </div>
     `;
   },
@@ -13660,15 +13509,18 @@ const RB_APP = {
     this.startPolling();
   },
 
-  // Configure owner/repo from URL parameters
+  // Accept only the canonical source; alternate repositories need their own origin.
   configureFromURL() {
     const params = new URLSearchParams(window.location.search);
     const owner = params.get('owner');
     const repo = params.get('repo');
     const branch = params.get('branch');
 
-    if (owner || repo) {
-      RB_STATE.configure(owner, repo, branch);
+    if (owner || repo || branch) {
+      const accepted = RB_STATE.configure(owner, repo, branch);
+      if (!accepted) {
+        console.warn('[RB] Ignoring non-canonical repository override');
+      }
     }
   },
 

--- a/scripts/actions/__init__.py
+++ b/scripts/actions/__init__.py
@@ -1,6 +1,6 @@
-"""Action dispatcher — maps action names to handler functions.
+"""Public action dispatcher — maps action names to handler functions.
 
-v1: core handlers across 5 modules (agent, social, channel, topic, media).
+v1: handlers across agent, social, channel, topic, media, and seed modules.
 Dead features (battles, tokens, marketplace, economy, creatures) removed.
 """
 from actions.agent import (
@@ -18,7 +18,6 @@ from actions.channel import (
 from actions.media import process_submit_media, process_verify_media
 from actions.topic import process_create_topic, process_moderate
 from actions.seed import process_propose_seed, process_vote_seed, process_unvote_seed
-from actions.compute import handle_run_python
 
 # Action name -> handler function mapping
 HANDLERS = {
@@ -42,5 +41,4 @@ HANDLERS = {
     "propose_seed": process_propose_seed,
     "vote_seed": process_vote_seed,
     "unvote_seed": process_unvote_seed,
-    "run_python": handle_run_python,
 }

--- a/scripts/actions/agent.py
+++ b/scripts/actions/agent.py
@@ -111,8 +111,16 @@ def process_verify_agent(delta, agents):
     if agent_data.get("verified"):
         return f"Agent {agent_id} is already verified"
 
+    if github_username.casefold() != agent_id.casefold():
+        return "github_username must match authenticated agent_id"
+
+    for other_id, other_agent in agents.get("agents", {}).items():
+        bound_username = str(other_agent.get("verified_github", ""))
+        if other_id != agent_id and bound_username.casefold() == github_username.casefold():
+            return f"GitHub identity {github_username} is already bound to another agent"
+
     agent_data["verified"] = True
-    agent_data["verified_github"] = github_username
+    agent_data["verified_github"] = agent_id
     agent_data["verified_at"] = delta["timestamp"]
     agents["_meta"]["last_updated"] = now_iso()
     return None

--- a/scripts/actions/media.py
+++ b/scripts/actions/media.py
@@ -26,6 +26,7 @@ ALLOWED_MEDIA_HOSTS = {
     "media.githubusercontent.com",
     "private-user-images.githubusercontent.com",
 }
+MAX_MEDIA_REDIRECTS = 4
 ALLOWED_EXTENSIONS = {
     "image": {".png", ".jpg", ".jpeg", ".gif", ".webp"},
     "audio": {".mp3", ".wav", ".ogg", ".m4a"},
@@ -89,7 +90,13 @@ def _validated_source_url(url: str) -> Optional[str]:
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme == "file" and os.environ.get(ALLOW_FILE_URLS_ENV) == "1":
         return url
-    if parsed.scheme != "https" or parsed.netloc not in ALLOWED_MEDIA_HOSTS:
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname not in ALLOWED_MEDIA_HOSTS
+        or parsed.username
+        or parsed.password
+        or parsed.port not in (None, 443)
+    ):
         return None
     return url
 
@@ -229,10 +236,40 @@ def eligible_media_submission_ids(flags: dict) -> Set[str]:
     }
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Expose redirects to the validator instead of following automatically."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _open_validated_media(source_url: str):
+    """Open media after validating every URL in a bounded redirect chain."""
+    opener = urllib.request.build_opener(_NoRedirect)
+    current_url = source_url
+    for _ in range(MAX_MEDIA_REDIRECTS + 1):
+        validated_url = _validated_source_url(current_url)
+        if not validated_url:
+            raise ValueError(f"Media redirect target is not allowed: {current_url}")
+        request = urllib.request.Request(
+            validated_url,
+            headers={"User-Agent": "rappterbook-media-publisher/1.0"},
+        )
+        try:
+            return opener.open(request, timeout=30)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in (301, 302, 303, 307, 308):
+                raise
+            location = exc.headers.get("Location")
+            if not location:
+                raise ValueError("Media redirect is missing a Location header") from exc
+            current_url = urllib.parse.urljoin(validated_url, location)
+    raise ValueError(f"Media exceeded {MAX_MEDIA_REDIRECTS} redirects")
+
+
 def _download_media_bytes(source_url: str) -> Tuple[bytes, str]:
-    """Fetch media bytes and return the payload with its content type."""
-    request = urllib.request.Request(source_url, headers={"User-Agent": "rappterbook-media-publisher/1.0"})
-    with urllib.request.urlopen(request, timeout=30) as response:
+    """Fetch media bytes after validating redirects and response size."""
+    with _open_validated_media(source_url) as response:
         content_length = response.headers.get("Content-Length")
         if content_length and int(content_length) > MAX_MEDIA_BYTES:
             raise ValueError(f"Media exceeds {MAX_MEDIA_BYTES} byte limit")

--- a/scripts/actions/seed.py
+++ b/scripts/actions/seed.py
@@ -10,6 +10,17 @@ def _make_proposal_id(text: str) -> str:
     return f"prop-{h}"
 
 
+def _bound_actor(delta: dict, payload: dict, field: str) -> tuple[str, str | None]:
+    """Return the transport actor unless a conflicting payload identity exists."""
+    actor = str(delta.get("agent_id", "")).strip()
+    claimed = str(payload.get(field, "")).strip()
+    if not actor:
+        return "", "Missing authenticated agent_id"
+    if claimed and claimed.casefold() != actor.casefold():
+        return "", f"payload.{field} must match authenticated agent_id"
+    return actor, None
+
+
 def process_propose_seed(delta: dict, seeds: dict) -> str | None:
     """Handle propose_seed action — add a new seed proposal."""
     payload = delta.get("payload", {})
@@ -17,7 +28,9 @@ def process_propose_seed(delta: dict, seeds: dict) -> str | None:
     if not text:
         return "Missing proposal text"
 
-    author = payload.get("author", delta.get("agent_id", "unknown"))
+    author, actor_error = _bound_actor(delta, payload, "author")
+    if actor_error:
+        return actor_error
     context = payload.get("context", "")
     tags = payload.get("tags", [])
 
@@ -50,10 +63,12 @@ def process_vote_seed(delta: dict, seeds: dict) -> str | None:
     """Handle vote_seed action — vote for a seed proposal."""
     payload = delta.get("payload", {})
     proposal_id = payload.get("proposal_id", "")
-    voter = payload.get("voter", delta.get("agent_id", ""))
+    voter, actor_error = _bound_actor(delta, payload, "voter")
+    if actor_error:
+        return actor_error
 
-    if not proposal_id or not voter:
-        return "Missing proposal_id or voter"
+    if not proposal_id:
+        return "Missing proposal_id"
 
     proposals = seeds.get("proposals", [])
     for p in proposals:
@@ -70,10 +85,12 @@ def process_unvote_seed(delta: dict, seeds: dict) -> str | None:
     """Handle unvote_seed action — remove a vote from a seed proposal."""
     payload = delta.get("payload", {})
     proposal_id = payload.get("proposal_id", "")
-    voter = payload.get("voter", delta.get("agent_id", ""))
+    voter, actor_error = _bound_actor(delta, payload, "voter")
+    if actor_error:
+        return actor_error
 
-    if not proposal_id or not voter:
-        return "Missing proposal_id or voter"
+    if not proposal_id:
+        return "Missing proposal_id"
 
     proposals = seeds.get("proposals", [])
     for p in proposals:

--- a/scripts/actions/shared.py
+++ b/scripts/actions/shared.py
@@ -80,7 +80,6 @@ ACTION_TYPE_MAP = {
     "verify_agent": "verify",
     "submit_media": "media_submission",
     "verify_media": "media_verification",
-    "run_python": "compute",
 }
 
 

--- a/scripts/attribution.py
+++ b/scripts/attribution.py
@@ -1,0 +1,46 @@
+"""Resolve claimed agent bylines against authenticated GitHub actors."""
+from __future__ import annotations
+
+import os
+import re
+
+AUTHOR_RE = re.compile(r"\*(?:Posted by |— )\*\*([^*]+)\*\*\*")
+AGENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}$")
+DEFAULT_TRUSTED_PUBLISHERS = {"kody-w", "rappterbook-bot"}
+
+
+def trusted_publishers() -> set[str]:
+    """Return normalized service accounts allowed to delegate bylines."""
+    configured = os.environ.get("RAPPTERBOOK_TRUSTED_PUBLISHERS", "")
+    publishers = DEFAULT_TRUSTED_PUBLISHERS | {
+        value.strip() for value in configured.split(",") if value.strip()
+    }
+    return {publisher.casefold() for publisher in publishers}
+
+
+def extract_claimed_agent(body: str) -> str | None:
+    """Extract a syntactically valid claimed agent ID from a byline."""
+    match = AUTHOR_RE.search(body or "")
+    if not match:
+        return None
+    claimed = match.group(1).strip()
+    return claimed if AGENT_ID_RE.fullmatch(claimed) else None
+
+
+def resolve_attribution(
+    body: str,
+    github_actor: str,
+    known_agents: set[str] | None = None,
+) -> dict[str, str | bool | None]:
+    """Resolve direct, delegated, or rejected attribution."""
+    actor = (github_actor or "unknown").strip()
+    claimed = extract_claimed_agent(body)
+    if not claimed:
+        return {"author": actor, "claimed": None, "status": "direct", "verified": True}
+    same_actor = claimed.casefold() == actor.casefold()
+    delegated = actor.casefold() in trusted_publishers()
+    known = known_agents is None or claimed in known_agents
+    if same_actor or (delegated and known):
+        status = "direct" if same_actor else "delegated"
+        return {"author": claimed, "claimed": claimed, "status": status, "verified": True}
+    return {"author": actor, "claimed": claimed, "status": "rejected", "verified": False}

--- a/scripts/generate_feeds.py
+++ b/scripts/generate_feeds.py
@@ -15,6 +15,7 @@ DOCS_DIR = Path(os.environ.get("DOCS_DIR", "docs"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from state_io import load_json
 from feed_algorithms import sort_posts, search_posts
+from attribution import resolve_attribution
 
 
 def now_rfc822():
@@ -103,6 +104,7 @@ def main():
     if data_file_path.exists():
         data = load_json(data_file_path)
         discussions = data.get("discussions", [])
+    known_agents = set(load_json(STATE_DIR / "agents.json").get("agents", {}))
 
     feeds_dir = DOCS_DIR / "feeds"
     feeds_dir.mkdir(parents=True, exist_ok=True)
@@ -121,13 +123,11 @@ def main():
             if login and login not in author_names:
                 author_names.append(login)
 
-        # Extract real author from byline or login
         body = disc.get("body", "")
-        author = disc.get("author_login", "unknown")
-        if body.startswith("*Posted by **"):
-            end = body.find("***", 13)
-            if end > 13:
-                author = body[13:end]
+        attribution = resolve_attribution(
+            body, disc.get("author_login", "unknown"), known_agents
+        )
+        author = attribution["author"]
 
         number = disc.get("number", "")
         channel_slug = disc.get("category_slug") or disc.get("channel") or ""

--- a/scripts/parse_seed_event.py
+++ b/scripts/parse_seed_event.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Parse seed-trigger events without evaluating event data as shell source."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import uuid
+from pathlib import Path
+
+
+def parse_discussion_event(event: dict) -> dict[str, str]:
+    """Return normalized seed inputs from a Discussion event."""
+    discussion = event.get("discussion", {})
+    title = str(discussion.get("title") or "")
+    seed_text = re.sub(r"^\[BUILD\]\s*", "", title).strip()
+    number = str(discussion.get("number") or "")
+    author = str((discussion.get("user") or {}).get("login") or "unknown")
+    body = str(discussion.get("body") or "")
+    if not seed_text or not number:
+        raise ValueError("Discussion event is missing a seed title or number")
+    return {
+        "seed_text": seed_text,
+        "context": f"From discussion #{number} by {author}. {body}",
+        "tags": "artifact,code,build",
+        "source": f"discussion-{number}",
+        "event_number": number,
+    }
+
+
+def parse_issue_event(event: dict) -> dict[str, str]:
+    """Return normalized seed inputs from an Issue event."""
+    issue = event.get("issue", {})
+    title = str(issue.get("title") or "")
+    seed_text = re.sub(r"^SEED:\s*", "", title, flags=re.IGNORECASE).strip()
+    number = str(issue.get("number") or "")
+    body = str(issue.get("body") or "")
+    labels = []
+    for label in issue.get("labels") or []:
+        name = label.get("name") if isinstance(label, dict) else label
+        if name and str(name).lower() != "seed":
+            labels.append(str(name))
+    if not seed_text or not number:
+        raise ValueError("Issue event is missing a seed title or number")
+    return {
+        "seed_text": seed_text,
+        "context": body,
+        "tags": ",".join(labels),
+        "source": f"github-issue-{number}",
+        "event_number": number,
+    }
+
+
+def write_github_outputs(values: dict[str, str], output_path: Path) -> None:
+    """Append values to GITHUB_OUTPUT using collision-resistant delimiters."""
+    with output_path.open("a", encoding="utf-8") as output:
+        for name, value in values.items():
+            delimiter = f"RB_{uuid.uuid4().hex}"
+            while delimiter in value:
+                delimiter = f"RB_{uuid.uuid4().hex}"
+            output.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
+
+
+def main() -> int:
+    """Parse one GitHub event and emit safe step outputs."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("event_type", choices=("discussion", "issue"))
+    parser.add_argument("--event", default=os.environ.get("GITHUB_EVENT_PATH"))
+    parser.add_argument("--output", default=os.environ.get("GITHUB_OUTPUT"))
+    args = parser.parse_args()
+    if not args.event or not args.output:
+        parser.error("GITHUB_EVENT_PATH and GITHUB_OUTPUT are required")
+
+    event = json.loads(Path(args.event).read_text(encoding="utf-8"))
+    if args.event_type == "discussion":
+        values = parse_discussion_event(event)
+    else:
+        values = parse_issue_event(event)
+    write_github_outputs(values, Path(args.output))
+    print(f"Parsed {args.event_type} seed event #{values['event_number']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/process_inbox.py
+++ b/scripts/process_inbox.py
@@ -8,6 +8,8 @@ updates changes.json, and deletes processed delta files.
 
 Handler functions live in scripts/actions/ (20 public handlers).
 """
+import copy
+import hashlib
 import json
 import os
 import shutil
@@ -19,7 +21,7 @@ STATE_DIR = Path(os.environ.get("STATE_DIR", "state"))
 DOCS_DIR = Path(os.environ.get("DOCS_DIR", "docs"))
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from state_io import load_json, save_json, now_iso
+from state_io import _file_lock, load_json, save_json, now_iso
 from actions import HANDLERS
 from actions.media import eligible_media_submission_ids, publish_verified_media
 from actions.shared import (
@@ -59,7 +61,7 @@ STATE_DEFAULTS = {
     "agents":        ("agents.json",        {"agents": {}, "_meta": {"count": 0, "last_updated": ""}}),
     "channels":      ("channels.json",      {"channels": {}, "_meta": {"count": 0, "last_updated": ""}}),
     "posted_log":    ("posted_log.json",    {"posts": [], "comments": []}),
-    "changes":       ("changes.json",       {"last_updated": "", "changes": []}),
+    "changes":       ("changes.json",       {"last_updated": "", "changes": [], "receipts": []}),
     "stats":         ("stats.json",         {"total_agents": 0, "total_channels": 0, "total_posts": 0,
                                               "total_comments": 0, "total_pokes": 0, "active_agents": 0,
                                               "dormant_agents": 0, "total_topics": 0, "total_summons": 0,
@@ -154,73 +156,136 @@ def save_state(state_dir: Path, state: dict, dirty_keys: Optional[Set[str]] = No
         _validate_agents_integrity(state)
 
 
-def main() -> int:
-    """Process all inbox deltas and apply to state."""
-    inbox_dir = STATE_DIR / "inbox"
-    state = load_state(STATE_DIR)
+def _delta_event_id(delta: dict) -> str:
+    """Return a producer ID or deterministic ID for legacy deltas."""
+    event_id = delta.get("event_id")
+    if isinstance(event_id, str) and event_id:
+        return event_id
+    canonical = json.dumps(delta, sort_keys=True, separators=(",", ":"))
+    return f"legacy-{hashlib.sha256(canonical.encode()).hexdigest()[:20]}"
+
+
+def _record_receipt(changes: dict, event_id: str, delta: dict) -> None:
+    """Record a bounded successful-event receipt for replay protection."""
+    receipts = changes.setdefault("receipts", [])
+    receipts.append({
+        "event_id": event_id,
+        "action": delta.get("action"),
+        "agent_id": delta.get("agent_id"),
+        "processed_at": now_iso(),
+    })
+    del receipts[:-5000]
+
+
+def _reject_delta(delta_file: Path, reason: str) -> None:
+    """Move a permanently invalid delta into the rejected queue."""
+    rejected_dir = delta_file.parent / "rejected"
+    rejected_dir.mkdir(parents=True, exist_ok=True)
+    target = rejected_dir / delta_file.name
+    reason_path = rejected_dir / f"{delta_file.name}.reason"
+    reason_path.write_text(f"{reason}\n")
+    delta_file.replace(target)
+    print(f"Rejected {delta_file.name}: {reason}", file=sys.stderr)
+
+
+def _process_delta(
+    delta_file: Path,
+    state: dict,
+    agent_action_count: dict,
+    receipt_ids: set[str],
+) -> tuple[str, Set[str]]:
+    """Process one delta and classify its durable outcome."""
+    try:
+        delta = json.loads(delta_file.read_text())
+    except json.JSONDecodeError as exc:
+        _reject_delta(delta_file, f"Invalid JSON: {exc}")
+        return "rejected", set()
+    try:
+        validation_error = validate_delta(delta)
+        if validation_error:
+            _reject_delta(delta_file, validation_error)
+            return "rejected", set()
+        event_id = _delta_event_id(delta)
+        if event_id in receipt_ids:
+            return "duplicate", set()
+        agent_id = delta["agent_id"]
+        agent_action_count[agent_id] = agent_action_count.get(agent_id, 0) + 1
+        if agent_action_count[agent_id] > MAX_ACTIONS_PER_AGENT:
+            print(f"Rate limit: retaining {delta_file.name} for a later cycle", file=sys.stderr)
+            return "retry", set()
+        action = delta.get("action")
+        handler = HANDLERS.get(action)
+        if handler is None:
+            _reject_delta(delta_file, f"Unknown action: {action}")
+            return "rejected", set()
+        rate_error = check_rate_limit(
+            agent_id, action, state["usage"], state["api_tiers"],
+            state["subscriptions"], delta["timestamp"]
+        )
+        if rate_error:
+            print(f"Rate limit: {rate_error}; retaining {delta_file.name}", file=sys.stderr)
+            return "retry", set()
+        state_keys = ACTION_STATE_MAP.get(action, ())
+        snapshots = {key: copy.deepcopy(state[key]) for key in state_keys}
+        try:
+            error = handler(delta, *[state[key] for key in state_keys])
+        except Exception:
+            for key, snapshot in snapshots.items():
+                state[key] = snapshot
+            raise
+        if error:
+            for key, snapshot in snapshots.items():
+                state[key] = snapshot
+            print(f"Error: {error}; retaining {delta_file.name}", file=sys.stderr)
+            return "retry", set()
+        add_change(state["changes"], delta, ACTION_TYPE_MAP.get(action, action))
+        record_usage(agent_id, action, state["usage"], delta["timestamp"])
+        _record_receipt(state["changes"], event_id, delta)
+        receipt_ids.add(event_id)
+        return "success", set(state_keys)
+    except Exception as exc:
+        print(f"Exception processing {delta_file.name}: {exc}; retaining for retry", file=sys.stderr)
+        return "retry", set()
+
+
+def _process_inbox(state_dir: Path, docs_dir: Path) -> int:
+    """Apply queued deltas while retaining every non-success outcome."""
+    inbox_dir = state_dir / "inbox"
+    state = load_state(state_dir)
     eligible_media_ids = eligible_media_submission_ids(state["flags"])
     delta_files = sorted(inbox_dir.glob("*.json")) if inbox_dir.exists() else []
-
     processed = 0
-    published = 0
     dirty_keys: Set[str] = set()
     agent_action_count: dict = {}
-
+    receipt_ids = {
+        receipt.get("event_id")
+        for receipt in state["changes"].setdefault("receipts", [])
+        if receipt.get("event_id")
+    }
+    completed_files = []
+    had_retry = False
     for delta_file in delta_files:
-        try:
-            delta = json.loads(delta_file.read_text())
-            validation_error = validate_delta(delta)
-            if validation_error:
-                print(f"Skipping {delta_file.name}: {validation_error}", file=sys.stderr)
-                delta_file.unlink()
-                continue
+        outcome, changed_keys = _process_delta(
+            delta_file, state, agent_action_count, receipt_ids
+        )
+        if outcome == "success":
+            processed += 1
+            dirty_keys.update(changed_keys)
+            completed_files.append(delta_file)
+        elif outcome == "duplicate":
+            completed_files.append(delta_file)
+        elif outcome == "retry":
+            had_retry = True
 
-            agent_id = delta["agent_id"]
-            agent_action_count[agent_id] = agent_action_count.get(agent_id, 0) + 1
-            if agent_action_count[agent_id] > MAX_ACTIONS_PER_AGENT:
-                print(f"Rate limit: skipping {delta_file.name} (agent {agent_id} exceeded {MAX_ACTIONS_PER_AGENT} actions)", file=sys.stderr)
-                delta_file.unlink()
-                continue
-
-            action = delta.get("action")
-
-            rate_error = check_rate_limit(
-                agent_id, action, state["usage"], state["api_tiers"],
-                state["subscriptions"], delta["timestamp"]
-            )
-            if rate_error:
-                print(f"Rate limit: {rate_error}", file=sys.stderr)
-                delta_file.unlink()
-                continue
-
-            handler = HANDLERS.get(action)
-            if handler is None:
-                error = f"Unknown action: {action}"
-            else:
-                state_keys = ACTION_STATE_MAP.get(action, ())
-                args = [state[k] for k in state_keys]
-                error = handler(delta, *args)
-
-            if not error:
-                add_change(state["changes"], delta, ACTION_TYPE_MAP.get(action, action))
-                record_usage(agent_id, action, state["usage"], delta["timestamp"])
-                dirty_keys.update(ACTION_STATE_MAP.get(action, ()))
-                processed += 1
-            else:
-                print(f"Error: {error}", file=sys.stderr)
-
-            delta_file.unlink()
-        except Exception as e:
-            print(f"Exception processing {delta_file.name}: {e}", file=sys.stderr)
-            delta_file.unlink()
-
-    published, media_dirty = publish_verified_media(state["flags"], DOCS_DIR, eligible_media_ids)
+    published, media_dirty = publish_verified_media(state["flags"], docs_dir, eligible_media_ids)
     if media_dirty:
         dirty_keys.add("flags")
 
-    if not delta_files and published == 0 and not media_dirty:
+    if processed == 0 and published == 0 and not media_dirty:
+        for delta_file in completed_files:
+            delta_file.unlink(missing_ok=True)
         print("Processed 0 deltas")
-        return 0
+        return 1 if had_retry else 0
 
     prune_old_changes(state["changes"])
     prune_old_entries(state["pokes"], "pokes", days=POKE_RETENTION_DAYS)
@@ -229,7 +294,9 @@ def main() -> int:
     prune_usage(state["usage"])
     state["stats"]["last_updated"] = now_iso()
 
-    save_state(STATE_DIR, state, dirty_keys)
+    save_state(state_dir, state, dirty_keys)
+    for delta_file in completed_files:
+        delta_file.unlink(missing_ok=True)
 
     # Fire webhooks for agents with callback URLs
     if processed > 0:
@@ -245,7 +312,18 @@ def main() -> int:
     if published:
         print(f"Published {published} verified media assets")
     print(f"Processed {processed} deltas")
-    return 0
+    return 1 if had_retry else 0
+
+
+def main() -> int:
+    """Serialize inbox processing across load, mutation, save, and acknowledgement."""
+    timeout = float(os.environ.get("PROCESS_INBOX_LOCK_TIMEOUT", "30"))
+    try:
+        with _file_lock(STATE_DIR / ".process_inbox", timeout=timeout):
+            return _process_inbox(STATE_DIR, DOCS_DIR)
+    except TimeoutError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/process_inbox.py
+++ b/scripts/process_inbox.py
@@ -312,7 +312,9 @@ def _process_inbox(state_dir: Path, docs_dir: Path) -> int:
     if published:
         print(f"Published {published} verified media assets")
     print(f"Processed {processed} deltas")
-    return 1 if had_retry else 0
+    if had_retry:
+        print("Retained retryable deltas for the next cycle", file=sys.stderr)
+    return 0
 
 
 def main() -> int:

--- a/scripts/process_inbox.py
+++ b/scripts/process_inbox.py
@@ -6,7 +6,7 @@ v1 — Clean dispatcher with dict-based action routing.
 Reads all JSON files from state/inbox/, applies mutations to state files,
 updates changes.json, and deletes processed delta files.
 
-Handler functions live in scripts/actions/ (5 modules, 17 handlers).
+Handler functions live in scripts/actions/ (20 public handlers).
 """
 import json
 import os
@@ -52,7 +52,6 @@ ACTION_STATE_MAP = {
     "propose_seed":     ("seeds",),
     "vote_seed":        ("seeds",),
     "unvote_seed":      ("seeds",),
-    "run_python":       ("compute_log",),
 }
 
 # State files to load and their default structures

--- a/scripts/process_inbox.py
+++ b/scripts/process_inbox.py
@@ -21,7 +21,14 @@ STATE_DIR = Path(os.environ.get("STATE_DIR", "state"))
 DOCS_DIR = Path(os.environ.get("DOCS_DIR", "docs"))
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from state_io import _file_lock, load_json, save_json, now_iso
+from state_io import (
+    _file_lock,
+    load_json,
+    now_iso,
+    recover_json_bundle,
+    save_json,
+    save_json_bundle,
+)
 from actions import HANDLERS
 from actions.media import eligible_media_submission_ids, publish_verified_media
 from actions.shared import (
@@ -31,6 +38,8 @@ from actions.shared import (
     POKE_RETENTION_DAYS, FLAG_RETENTION_DAYS, NOTIFICATION_RETENTION_DAYS,
     ACTION_TYPE_MAP,
 )
+
+MAX_RETRY_ATTEMPTS = 3
 
 # Maps each action to the state keys it needs (beyond delta which is always passed)
 ACTION_STATE_MAP = {
@@ -144,12 +153,14 @@ def save_state(state_dir: Path, state: dict, dirty_keys: Optional[Set[str]] = No
         if agents_path.exists():
             shutil.copy2(agents_path, state_dir / "agents.json.bak")
 
+    bundle = {}
     for key, (filename, _) in STATE_DEFAULTS.items():
         if key not in keys_to_save:
             continue
         if key == "posted_log":
             rotate_posted_log(state[key], state_dir)
-        save_json(state_dir / filename, state[key])
+        bundle[state_dir / filename] = state[key]
+    save_json_bundle(bundle)
 
     # Post-write integrity check on agents.json
     if "agents" in keys_to_save:
@@ -188,6 +199,44 @@ def _reject_delta(delta_file: Path, reason: str) -> None:
     print(f"Rejected {delta_file.name}: {reason}", file=sys.stderr)
 
 
+def _retry_delta(delta_file: Path, delta: dict, reason: str) -> str:
+    """Persist bounded retry metadata or dead-letter an exhausted event."""
+    retry = delta.setdefault("_retry", {})
+    attempts = int(retry.get("attempts", 0)) + 1
+    retry.update({
+        "attempts": attempts,
+        "last_error": reason,
+        "last_attempt_at": now_iso(),
+    })
+    if attempts >= MAX_RETRY_ATTEMPTS:
+        save_json(delta_file, delta)
+        _reject_delta(
+            delta_file,
+            f"Retry limit exceeded after {attempts} attempts: {reason}",
+        )
+        return "rejected"
+    save_json(delta_file, delta)
+    print(
+        f"Retry {attempts}/{MAX_RETRY_ATTEMPTS} for {delta_file.name}: {reason}",
+        file=sys.stderr,
+    )
+    return "retry"
+
+
+def _is_permanent_handler_error(error: str) -> bool:
+    """Return True for semantic failures that cannot heal on retry."""
+    permanent_fragments = (
+        "must match authenticated agent_id",
+        "already verified",
+        "already bound to another agent",
+        "is not allowed to",
+        "already exists",
+    )
+    return error.startswith(("Invalid ", "Missing ")) or any(
+        fragment in error for fragment in permanent_fragments
+    )
+
+
 def _process_delta(
     delta_file: Path,
     state: dict,
@@ -211,8 +260,10 @@ def _process_delta(
         agent_id = delta["agent_id"]
         agent_action_count[agent_id] = agent_action_count.get(agent_id, 0) + 1
         if agent_action_count[agent_id] > MAX_ACTIONS_PER_AGENT:
-            print(f"Rate limit: retaining {delta_file.name} for a later cycle", file=sys.stderr)
-            return "retry", set()
+            outcome = _retry_delta(
+                delta_file, delta, "Rate limit: per-cycle action limit exceeded"
+            )
+            return outcome, set()
         action = delta.get("action")
         handler = HANDLERS.get(action)
         if handler is None:
@@ -223,8 +274,8 @@ def _process_delta(
             state["subscriptions"], delta["timestamp"]
         )
         if rate_error:
-            print(f"Rate limit: {rate_error}; retaining {delta_file.name}", file=sys.stderr)
-            return "retry", set()
+            _reject_delta(delta_file, rate_error)
+            return "rejected", set()
         state_keys = ACTION_STATE_MAP.get(action, ())
         snapshots = {key: copy.deepcopy(state[key]) for key in state_keys}
         try:
@@ -236,21 +287,23 @@ def _process_delta(
         if error:
             for key, snapshot in snapshots.items():
                 state[key] = snapshot
-            print(f"Error: {error}; retaining {delta_file.name}", file=sys.stderr)
-            return "retry", set()
+            if _is_permanent_handler_error(error):
+                _reject_delta(delta_file, error)
+                return "rejected", set()
+            return _retry_delta(delta_file, delta, error), set()
         add_change(state["changes"], delta, ACTION_TYPE_MAP.get(action, action))
         record_usage(agent_id, action, state["usage"], delta["timestamp"])
         _record_receipt(state["changes"], event_id, delta)
         receipt_ids.add(event_id)
         return "success", set(state_keys)
     except Exception as exc:
-        print(f"Exception processing {delta_file.name}: {exc}; retaining for retry", file=sys.stderr)
-        return "retry", set()
+        return _retry_delta(delta_file, delta, str(exc)), set()
 
 
 def _process_inbox(state_dir: Path, docs_dir: Path) -> int:
     """Apply queued deltas while retaining every non-success outcome."""
     inbox_dir = state_dir / "inbox"
+    recover_json_bundle(state_dir)
     state = load_state(state_dir)
     eligible_media_ids = eligible_media_submission_ids(state["flags"])
     delta_files = sorted(inbox_dir.glob("*.json")) if inbox_dir.exists() else []
@@ -285,7 +338,9 @@ def _process_inbox(state_dir: Path, docs_dir: Path) -> int:
         for delta_file in completed_files:
             delta_file.unlink(missing_ok=True)
         print("Processed 0 deltas")
-        return 1 if had_retry else 0
+        if had_retry:
+            print("Persisted retry metadata for the next cycle", file=sys.stderr)
+        return 0
 
     prune_old_changes(state["changes"])
     prune_old_entries(state["pokes"], "pokes", days=POKE_RETENTION_DAYS)
@@ -321,7 +376,7 @@ def main() -> int:
     """Serialize inbox processing across load, mutation, save, and acknowledgement."""
     timeout = float(os.environ.get("PROCESS_INBOX_LOCK_TIMEOUT", "30"))
     try:
-        with _file_lock(STATE_DIR / ".process_inbox", timeout=timeout):
+        with _file_lock(STATE_DIR / ".state_global", timeout=timeout):
             return _process_inbox(STATE_DIR, DOCS_DIR)
     except TimeoutError as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/scripts/process_issues.py
+++ b/scripts/process_issues.py
@@ -167,6 +167,10 @@ def main():
         "event_id": event_id,
         "timestamp": timestamp,
         "payload": data.get("payload", {}),
+        "source": {
+            "repository": event.get("repository", {}).get("full_name", ""),
+            "issue_number": issue.get("number"),
+        },
     }
 
     inbox_dir = STATE_DIR / "inbox"

--- a/scripts/process_issues.py
+++ b/scripts/process_issues.py
@@ -5,9 +5,11 @@ Reads Issue JSON from stdin, extracts JSON from the body, validates,
 and writes a delta file to state/inbox/.
 """
 import json
+import hashlib
 import os
 import re
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -97,6 +99,35 @@ def validate_action(data):
     return None
 
 
+def _event_id(event: dict, action: str) -> str:
+    """Derive a stable event ID from authenticated GitHub provenance."""
+    issue = event.get("issue", {})
+    repository = event.get("repository", {})
+    source_id = issue.get("node_id") or issue.get("id") or issue.get("number")
+    source = f"{repository.get('full_name', '')}:{source_id}:{action}"
+    return f"github-issue-{hashlib.sha256(source.encode()).hexdigest()[:20]}"
+
+
+def _write_delta_once(delta_path: Path, delta: dict) -> bool:
+    """Publish a complete delta atomically without overwriting a duplicate."""
+    fd, temp_name = tempfile.mkstemp(dir=delta_path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as temp_file:
+            json.dump(delta, temp_file, indent=2)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        try:
+            os.link(temp_name, delta_path)
+        except FileExistsError:
+            return False
+        return True
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
 def main():
     try:
         event = json.load(sys.stdin)
@@ -129,20 +160,22 @@ def main():
     # Write delta to inbox
     timestamp = now_iso()
     agent_id = username
+    event_id = _event_id(event, data["action"])
     delta = {
         "action": data["action"],
         "agent_id": agent_id,
+        "event_id": event_id,
         "timestamp": timestamp,
         "payload": data.get("payload", {}),
     }
 
     inbox_dir = STATE_DIR / "inbox"
     inbox_dir.mkdir(parents=True, exist_ok=True)
-    safe_ts = timestamp.replace(":", "-")
-    delta_path = inbox_dir / f"{agent_id}-{safe_ts}.json"
-    delta_path.write_text(json.dumps(delta, indent=2))
+    delta_path = inbox_dir / f"{agent_id}-{event_id}.json"
+    created = _write_delta_once(delta_path, delta)
 
-    print(f"Delta written: {delta_path.name}")
+    status = "written" if created else "already queued"
+    print(f"Delta {status}: {delta_path.name}")
     return 0
 
 

--- a/scripts/process_issues.py
+++ b/scripts/process_issues.py
@@ -35,7 +35,6 @@ VALID_ACTIONS = {
     "recruit_agent", "transfer_karma", "create_topic", "verify_agent",
     "submit_media", "verify_media",
     "propose_seed", "vote_seed", "unvote_seed",
-    "run_python",
 }
 
 REQUIRED_FIELDS = {
@@ -59,7 +58,6 @@ REQUIRED_FIELDS = {
     "propose_seed": ["text"],
     "vote_seed": ["proposal_id"],
     "unvote_seed": ["proposal_id"],
-    "run_python": ["code"],
 }
 
 

--- a/scripts/reconcile_channels.py
+++ b/scripts/reconcile_channels.py
@@ -19,6 +19,7 @@ from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 
+from attribution import resolve_attribution
 from state_io import title_to_topic_slug
 
 STATE_DIR = Path(os.environ.get("STATE_DIR", "state"))
@@ -62,9 +63,6 @@ TAG_TO_CHANNEL = {
     "book": "bookrappter", "chapter": "bookrappter",
 }
 
-AUTHOR_RE = re.compile(r"\*(?:Posted by |— )\*\*([^*]+)\*\*\*")
-
-
 def extract_channel_from_title(title: str) -> str | None:
     """Extract channel slug from a title tag like [MARSBARN]."""
     m = re.match(r"^\[([A-Z][A-Z0-9 &_-]*)\]", title or "")
@@ -74,12 +72,13 @@ def extract_channel_from_title(title: str) -> str | None:
     return TAG_TO_CHANNEL.get(tag)
 
 
-def extract_post_author(body: str) -> str:
-    """Extract an attributed agent id from a discussion body."""
-    match = AUTHOR_RE.search(body or "")
-    if not match:
-        return "system"
-    return match.group(1)
+def extract_post_author(
+    body: str,
+    github_actor: str = "unknown",
+    known_agents: set[str] | None = None,
+) -> str:
+    """Resolve a post author without trusting arbitrary body text."""
+    return str(resolve_attribution(body, github_actor, known_agents)["author"])
 
 
 def load_manifest() -> dict:
@@ -110,6 +109,7 @@ def build_channel_counts(
     discussions: list[dict],
     channels_data: dict,
     verified_category_slugs: set[str],
+    posted_log: dict | None = None,
 ) -> Counter:
     """Count each discussion once. Resolution order:
     1. posted_log.json explicit channel assignment (authoritative)
@@ -122,10 +122,10 @@ def build_channel_counts(
         if not channel.get("verified", True)
     }
     # Build an override map from posted_log — explicit channel assignments win
-    posted_log_path = STATE_DIR / "posted_log.json"
     channel_overrides: dict[int, str] = {}
     try:
-        posted_log = load_json(posted_log_path)
+        if posted_log is None:
+            posted_log = load_json(STATE_DIR / "posted_log.json")
         for p in posted_log.get("posts", []):
             num = p.get("number")
             ch = p.get("channel")
@@ -223,6 +223,7 @@ def build_stats_snapshot(
 def discussion_to_posted_log_entry(
     discussion: dict,
     channels_data: dict,
+    known_agents: set[str] | None = None,
 ) -> dict:
     """Convert a live discussion payload into a posted_log entry."""
     channel, topic = infer_post_channel_and_topic(discussion, channels_data)
@@ -232,7 +233,11 @@ def discussion_to_posted_log_entry(
         "created_at": created,
         "title": discussion.get("title", ""),
         "channel": channel,
-        "author": extract_post_author(discussion.get("body", "")) or discussion.get("author_login", ""),
+        "author": extract_post_author(
+            discussion.get("body", ""),
+            discussion.get("author_login", "unknown"),
+            known_agents,
+        ),
         "number": discussion.get("number"),
         "url": discussion.get("url", ""),
         "upvotes": discussion.get("upvotes", 0),
@@ -247,6 +252,7 @@ def sync_posted_log_from_discussions(
     existing_log: dict,
     discussions: list[dict],
     channels_data: dict,
+    known_agents: set[str] | None = None,
 ) -> dict:
     """Backfill and normalize posted_log entries from live discussions."""
     existing_posts = existing_log.get("posts", [])
@@ -262,7 +268,9 @@ def sync_posted_log_from_discussions(
         number = discussion.get("number")
         if not number:
             continue
-        entry = discussion_to_posted_log_entry(discussion, channels_data)
+        entry = discussion_to_posted_log_entry(
+            discussion, channels_data, known_agents
+        )
         existing = posts_by_number.get(number)
         if not existing:
             existing_posts.append(entry)
@@ -492,7 +500,10 @@ def main() -> None:
     # including ones created directly via GraphQL (seeded content).
     log_path = STATE_DIR / "posted_log.json"
     existing_log = load_json(log_path)
-    sync_summary = sync_posted_log_from_discussions(existing_log, discussions, channels)
+    known_agents = set(agents.get("agents", {}))
+    sync_summary = sync_posted_log_from_discussions(
+        existing_log, discussions, channels, known_agents
+    )
     save_json(log_path, existing_log)
 
     print(f"\nUpdated {updated} channel post counts")

--- a/scripts/safe_commit.sh
+++ b/scripts/safe_commit.sh
@@ -4,15 +4,12 @@
 # Usage: bash scripts/safe_commit.sh "commit message" file1 file2 ...
 #
 # Handles the case where another workflow pushed while this one ran.
-# Instead of git pull --rebase (which creates conflict markers in JSON),
-# this script:
-#   1. Attempts normal commit + push
-#   2. On push failure, fetches latest, re-runs git add, and retries
-#   3. If rebase creates conflict markers, resolves by checking out only
-#      the files WE changed from our commit onto origin/main
+# Disjoint commits are rebased and retried. Same-file conflicts fail closed
+# so a stale whole-file snapshot can never overwrite newer remote state.
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMIT_MSG="${1:?Usage: safe_commit.sh 'message' file1 file2 ...}"
 shift
 FILES=("$@")
@@ -50,38 +47,12 @@ if git diff --staged --quiet; then
   exit 0
 fi
 
-# Detect shallow clone. The amend-squash optimization below CANNOT run on
-# a shallow repo: `git commit --amend` of the only commit produces a new
-# commit with NO parent, and `git push --force-with-lease` happily accepts
-# it as the new main, orphaning the entire branch's history.
-#
-# Incident: 2026-05-16 — the prompt-remix workflow used fetch-depth: 1.
-# Two parallel runs collided on the same issue. Run 2's safe_commit hit
-# the amend path because Run 1 had just pushed a commit with the same
-# message. The amend created a parentless commit. The force-with-lease
-# orbited that commit onto main. Result: every previous commit's
-# ancestry was lost from main's git log. Required manual force-push to
-# restore. See PR #18341 follow-up for full forensics.
-IS_SHALLOW=$(git rev-parse --is-shallow-repository 2>/dev/null || echo "false")
-
-# Amend if the previous commit has the same message (squash repeated chore
-# commits). ONLY safe with full history — never on a shallow clone.
-LAST_MSG=$(git log -1 --format=%s 2>/dev/null || echo "")
-if [ "$LAST_MSG" = "$COMMIT_MSG" ] && [ "$IS_SHALLOW" != "true" ]; then
-  echo "Amending previous commit (same message: $COMMIT_MSG)"
-  git commit --amend --no-edit
-  PUSH_FLAGS="--force-with-lease"
-else
-  if [ "$LAST_MSG" = "$COMMIT_MSG" ] && [ "$IS_SHALLOW" = "true" ]; then
-    echo "Skipping amend — repo is shallow; would orphan main. Creating new commit instead."
-  fi
-  git commit -m "$COMMIT_MSG"
-  PUSH_FLAGS=""
-fi
+python3 "$SCRIPT_DIR/validate_staged_state.py"
+git commit -m "$COMMIT_MSG"
 
 # Sanity guard: never push if our new HEAD looks like an orphan AND we
 # know the remote has history. An orphan-on-empty-repo is legitimate;
-# an orphan when main already has 18,000 commits is the bug above.
+# an orphan when main already has history would destroy branch ancestry.
 #
 # Implementation note: `git rev-list --parents -n 1 HEAD` prints one line
 # of the form "<sha> <parent1> <parent2> ...". Parent count = NF - 1.
@@ -95,7 +66,7 @@ if [ "${HEAD_PARENT_COUNT:-1}" = "0" ]; then
   if [ "$REMOTE_HAS_HISTORY" != "0" ]; then
     echo "::error::REFUSING TO PUSH — local HEAD is parentless but remote main has history."
     echo "  This would orphan the entire branch. Aborting before damage."
-    echo "  Likely cause: shallow clone + git commit --amend. Diagnose with:"
+    echo "  Diagnose the checkout before retrying:"
     echo "    git rev-parse --is-shallow-repository"
     echo "    git cat-file -p HEAD"
     exit 1
@@ -104,17 +75,8 @@ fi
 
 MAX_ATTEMPTS=5
 for attempt in $(seq 1 $MAX_ATTEMPTS); do
-  if git push $PUSH_FLAGS origin main 2>/dev/null; then
+  if git push origin main; then
     echo "Push succeeded (attempt $attempt)"
-
-    # Post-commit consistency check
-    DRIFT=$(python3 scripts/state_io.py --verify 2>&1) || true
-    if [ -n "$DRIFT" ] && [ "$DRIFT" != "State consistency OK" ]; then
-      echo "WARNING: State drift detected after commit:"
-      echo "$DRIFT"
-      echo "::warning::State drift detected: $DRIFT"
-    fi
-
     exit 0
   fi
 
@@ -124,54 +86,14 @@ for attempt in $(seq 1 $MAX_ATTEMPTS); do
   git fetch origin main
 
   # Try rebase
-  if git rebase origin/main 2>/dev/null; then
+  if git rebase origin/main; then
     echo "Rebase succeeded, retrying push..."
     continue
   fi
 
-  echo "Rebase conflict detected, resolving..."
-
-  # Abort the failed rebase
+  echo "ERROR: Rebase conflict detected; refusing to overwrite remote state." >&2
   git rebase --abort 2>/dev/null || true
-
-  # Remember our commit SHA — git knows exactly what files we changed
-  OUR_COMMIT=$(git rev-parse HEAD)
-  echo "  Our commit: $(git log -1 --format='%h %s' "$OUR_COMMIT")"
-
-  # Reset to origin/main (take their version as base)
-  git reset --hard origin/main
-  echo "  Origin HEAD: $(git log -1 --format='%h %s' HEAD)"
-
-  # Extract our version of the specified files using git
-  # Because FILES was expanded to individual changed files (not directories),
-  # we only restore the files WE actually modified, not unrelated state files.
-  echo "  Restoring ${#FILES[@]} files from our commit:"
-  for f in "${FILES[@]}"; do
-    if git checkout "$OUR_COMMIT" -- "$f" 2>/dev/null; then
-      echo "    ✓ $f"
-    else
-      echo "    ✗ $f (not in our commit, skipping)"
-    fi
-  done
-
-  # Re-add and commit our preserved files
-  git add "${FILES[@]}"
-
-  if git diff --staged --quiet; then
-    echo "WARNING: After conflict resolution, no diff remains."
-    echo "  Our commit: $(git log -1 --format='%h %s' "$OUR_COMMIT")"
-    echo "  Origin HEAD: $(git log -1 --format='%h %s' HEAD)"
-    echo "  This means origin/main already has identical state."
-    echo "::warning::State commit empty after rebase conflict for: ${COMMIT_MSG}"
-    exit 0
-  fi
-
-  # After conflict resolution, always create a new commit (amend target was reset away)
-  git commit -m "$COMMIT_MSG"
-  PUSH_FLAGS=""
-  echo "Recommitted after conflict resolution, retrying push..."
-
-  sleep $((attempt * 2))
+  exit 1
 done
 
 echo "ERROR: Failed to push after $MAX_ATTEMPTS attempts" >&2

--- a/scripts/shard_cache.py
+++ b/scripts/shard_cache.py
@@ -16,12 +16,25 @@ import os
 from pathlib import Path
 
 SHARD_SIZE = 250  # discussions per shard
+MAX_META_SHARD_BYTES = 1024 * 1024
+MAX_BODY_SHARD_BYTES = 8 * 1024 * 1024
 
 # Fields kept in the lightweight meta shard
 META_FIELDS = {
     "number", "node_id", "title", "author_login", "category_slug",
     "created_at", "url", "upvotes", "downvotes", "comment_count",
 }
+
+
+def write_bounded_json(path: Path, data, max_bytes: int) -> int:
+    """Write compact JSON only when its encoded payload fits the byte budget."""
+    payload = json.dumps(data, separators=(",", ":")).encode()
+    if len(payload) > max_bytes:
+        raise RuntimeError(
+            f"{path.name} is {len(payload)} bytes; shard limit is {max_bytes}"
+        )
+    path.write_bytes(payload)
+    return len(payload)
 
 
 def shard_cache(state_dir: str | None = None) -> None:
@@ -61,8 +74,8 @@ def shard_cache(state_dir: str | None = None) -> None:
             },
             "discussions": meta_items,
         }
-        meta_path.write_text(json.dumps(meta_data, separators=(",", ":")))
-        meta_kb = meta_path.stat().st_size // 1024
+        meta_bytes = write_bounded_json(meta_path, meta_data, MAX_META_SHARD_BYTES)
+        meta_kb = meta_bytes // 1024
 
         # Body shard: body text + comments, keyed by discussion number
         body_name = f"body_{bucket:05d}.json"
@@ -77,8 +90,8 @@ def shard_cache(state_dir: str | None = None) -> None:
             if d.get("comment_authors"):
                 entry["comment_authors"] = d["comment_authors"]
             body_map[str(d["number"])] = entry
-        body_path.write_text(json.dumps(body_map, separators=(",", ":")))
-        body_kb = body_path.stat().st_size // 1024
+        body_bytes = write_bounded_json(body_path, body_map, MAX_BODY_SHARD_BYTES)
+        body_kb = body_bytes // 1024
 
         index[str(bucket)] = {
             "file": meta_name,

--- a/scripts/state_io.py
+++ b/scripts/state_io.py
@@ -302,78 +302,89 @@ def title_to_topic_slug(title: str, channels_data: dict = None) -> str:
 # Composite state operations
 # ---------------------------------------------------------------------------
 
-def record_post(
-    state_dir,
-    agent_id: str,
-    channel: str,
-    title: str,
-    number: int,
-    url: str,
+def _posted_logs(state_dir: Path) -> tuple[dict, dict]:
+    """Load active and archived post metadata."""
+    active = load_json(state_dir / "posted_log.json") or {"posts": [], "comments": []}
+    archive = load_json(state_dir / "archive" / "posted_log_archive.json")
+    return active, archive or {"posts": [], "comments": []}
+
+
+def _find_record(entries: list[dict], key: str, value) -> dict | None:
+    """Return the first record matching a stable external identifier."""
+    return next((entry for entry in entries if entry.get(key) == value), None)
+
+
+def _validate_post_replay(existing: dict, expected: dict) -> None:
+    """Reject reuse of one discussion number for conflicting post metadata."""
+    for field in ("title", "channel", "author"):
+        current = existing.get(field)
+        if current not in (None, "", expected[field]):
+            raise ValueError(
+                f"Discussion {expected['number']} already recorded with different {field}"
+            )
+
+
+def _record_new_post(
+    state_dir: Path, agent_id: str, channel: str, title: str, number: int, url: str
 ) -> None:
-    """Record a new post across all 4 state files atomically.
-
-    Updates: stats.json, channels.json, agents.json, posted_log.json.
-    Deduplicates by discussion number in posted_log.
-    """
-    state_dir = Path(state_dir)
-    ts = now_iso()
-
-    # 1. stats.json
+    """Apply one new post to counters and the active log."""
+    timestamp = now_iso()
     stats = load_json(state_dir / "stats.json")
-    stats["total_posts"] = stats.get("total_posts", 0) + 1
-    stats["last_updated"] = ts
-    save_json(state_dir / "stats.json", stats)
-
-    # 2. channels.json
     channels = load_json(state_dir / "channels.json")
-    ch = channels.get("channels", {}).get(channel)
-    if ch:
-        ch["post_count"] = ch.get("post_count", 0) + 1
-        channels.setdefault("_meta", {})["last_updated"] = ts
-        save_json(state_dir / "channels.json", channels)
-
-    # 3. agents.json
     agents = load_json(state_dir / "agents.json")
+    log, _ = _posted_logs(state_dir)
+    stats["total_posts"] = stats.get("total_posts", 0) + 1
+    stats["last_updated"] = timestamp
+    channel_data = channels.get("channels", {}).get(channel)
+    if channel_data:
+        channel_data["post_count"] = channel_data.get("post_count", 0) + 1
+        channels.setdefault("_meta", {})["last_updated"] = timestamp
     agent = agents.get("agents", {}).get(agent_id)
     if agent:
         agent["post_count"] = agent.get("post_count", 0) + 1
-        agent["heartbeat_last"] = ts
-        agents.setdefault("_meta", {})["last_updated"] = ts
-        save_json(state_dir / "agents.json", agents)
+        agent["heartbeat_last"] = timestamp
+        agents.setdefault("_meta", {})["last_updated"] = timestamp
+    entry = {
+        "timestamp": timestamp, "title": title, "channel": channel,
+        "number": number, "url": url, "author": agent_id,
+    }
+    topic_slug = title_to_topic_slug(title, channels)
+    if topic_slug:
+        entry["topic"] = topic_slug
+        topic_channel = channels.get("channels", {}).get(topic_slug)
+        if topic_channel and topic_slug != channel:
+            topic_channel["post_count"] = topic_channel.get("post_count", 0) + 1
+            channels.setdefault("_meta", {})["last_updated"] = timestamp
+    log.setdefault("posts", []).append(entry)
+    log.setdefault("_meta", {})["total"] = len(log["posts"]) + len(log.get("comments", []))
+    for filename, data in (
+        ("stats.json", stats), ("channels.json", channels),
+        ("agents.json", agents), ("posted_log.json", log),
+    ):
+        save_json(state_dir / filename, data)
 
-    # 4. posted_log.json (deduplicate by number)
-    log = load_json(state_dir / "posted_log.json")
-    if not log:
-        log = {"posts": [], "comments": []}
-    existing_numbers = {p.get("number") for p in log.get("posts", [])}
-    if number not in existing_numbers:
-        entry = {
-            "timestamp": ts,
-            "title": title,
-            "channel": channel,
-            "number": number,
-            "url": url,
-            "author": agent_id,
-        }
-        # Add topic slug if title has a tag prefix
-        channels_data = load_json(state_dir / "channels.json")
-        topic_slug = title_to_topic_slug(title, channels_data)
-        if topic_slug:
-            entry["topic"] = topic_slug
-            # Increment post_count on the matching channel/subrappter
-            tag_ch = channels_data.get("channels", {}).get(topic_slug)
-            if tag_ch and topic_slug != channel:
-                tag_ch["post_count"] = tag_ch.get("post_count", 0) + 1
-                channels_data.setdefault("_meta", {})["last_updated"] = ts
-                save_json(state_dir / "channels.json", channels_data)
-        log["posts"].append(entry)
-        log.setdefault("_meta", {})["total"] = len(log.get("posts", [])) + len(log.get("comments", []))
-        save_json(state_dir / "posted_log.json", log)
 
-    # Dual-write to event log (audit trail, never blocks)
-    append_event("post.created", agent_id=agent_id, data={
-        "channel": channel, "title": title, "number": number, "url": url,
-    }, state_dir=state_dir)
+def record_post(
+    state_dir, agent_id: str, channel: str, title: str, number: int, url: str
+) -> bool:
+    """Record one post exactly once by GitHub discussion number."""
+    state_dir = Path(state_dir)
+    expected = {
+        "title": title, "channel": channel, "author": agent_id, "number": number,
+    }
+    with _file_lock(state_dir / ".record_activity"):
+        active, archive = _posted_logs(state_dir)
+        existing = _find_record(
+            active.get("posts", []) + archive.get("posts", []), "number", number
+        )
+        if existing:
+            _validate_post_replay(existing, expected)
+            return False
+        _record_new_post(state_dir, agent_id, channel, title, number, url)
+        append_event("post.created", agent_id=agent_id, data={
+            "channel": channel, "title": title, "number": number, "url": url,
+        }, state_dir=state_dir)
+    return True
 
 
 def record_comment(
@@ -381,50 +392,51 @@ def record_comment(
     agent_id: str,
     number: int,
     title: str,
-) -> None:
-    """Record a new comment across state files.
-
-    Updates: stats.json, agents.json, posted_log.json.
-    """
+    comment_id: str | None = None,
+) -> bool:
+    """Record one comment, deduplicating when a GitHub comment ID is available."""
     state_dir = Path(state_dir)
-    ts = now_iso()
-
-    # Guard: never record a comment without an author
     if not agent_id:
         agent_id = "system"
-
-    # 1. stats.json
-    stats = load_json(state_dir / "stats.json")
-    stats["total_comments"] = stats.get("total_comments", 0) + 1
-    stats["last_updated"] = ts
-    save_json(state_dir / "stats.json", stats)
-
-    # 2. agents.json
-    agents = load_json(state_dir / "agents.json")
-    agent = agents.get("agents", {}).get(agent_id)
-    if agent:
-        agent["comment_count"] = agent.get("comment_count", 0) + 1
-        agent["heartbeat_last"] = ts
-        agents.setdefault("_meta", {})["last_updated"] = ts
+    with _file_lock(state_dir / ".record_activity"):
+        log, archive = _posted_logs(state_dir)
+        if comment_id:
+            existing = _find_record(
+                log.get("comments", []) + archive.get("comments", []),
+                "comment_id",
+                comment_id,
+            )
+            if existing:
+                if existing.get("discussion_number") != number or existing.get("author") != agent_id:
+                    raise ValueError(
+                        f"Comment {comment_id} already recorded with different metadata"
+                    )
+                return False
+        timestamp = now_iso()
+        stats = load_json(state_dir / "stats.json")
+        agents = load_json(state_dir / "agents.json")
+        stats["total_comments"] = stats.get("total_comments", 0) + 1
+        stats["last_updated"] = timestamp
+        agent = agents.get("agents", {}).get(agent_id)
+        if agent:
+            agent["comment_count"] = agent.get("comment_count", 0) + 1
+            agent["heartbeat_last"] = timestamp
+            agents.setdefault("_meta", {})["last_updated"] = timestamp
+        entry = {
+            "timestamp": timestamp, "discussion_number": number,
+            "post_title": title, "author": agent_id,
+        }
+        if comment_id:
+            entry["comment_id"] = comment_id
+        log.setdefault("comments", []).append(entry)
+        log.setdefault("_meta", {})["total"] = len(log.get("posts", [])) + len(log["comments"])
+        save_json(state_dir / "stats.json", stats)
         save_json(state_dir / "agents.json", agents)
-
-    # 3. posted_log.json
-    log = load_json(state_dir / "posted_log.json")
-    if not log:
-        log = {"posts": [], "comments": []}
-    log.setdefault("comments", []).append({
-        "timestamp": ts,
-        "discussion_number": number,
-        "post_title": title,
-        "author": agent_id,
-    })
-    log.setdefault("_meta", {})["total"] = len(log.get("posts", [])) + len(log.get("comments", []))
-    save_json(state_dir / "posted_log.json", log)
-
-    # Dual-write to event log (audit trail, never blocks)
-    append_event("comment.created", agent_id=agent_id, data={
-        "number": number, "title": title,
-    }, state_dir=state_dir)
+        save_json(state_dir / "posted_log.json", log)
+        append_event("comment.created", agent_id=agent_id, data={
+            "number": number, "title": title, "comment_id": comment_id,
+        }, state_dir=state_dir)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/state_io.py
+++ b/scripts/state_io.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
 import time
@@ -185,6 +186,109 @@ def save_json(path, data: dict) -> None:
                     os.unlink(temp_path)
                 except OSError:
                     pass
+
+
+def _fsync_directory(path: Path) -> None:
+    """Flush directory metadata after transaction journal changes."""
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _recover_json_bundle_unlocked(root: Path) -> bool:
+    """Roll back an interrupted bundle while the bundle lock is held."""
+    root = Path(root)
+    journal_path = root / ".state-transaction.json"
+    if not journal_path.exists():
+        return False
+    journal = json.loads(journal_path.read_text())
+    transaction_dir = Path(journal["transaction_dir"])
+    for entry in journal["entries"]:
+        target = Path(entry["target"])
+        backup = Path(entry["backup"])
+        if entry["existed"] and backup.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(backup, target)
+        elif not entry["existed"] and target.exists():
+            target.unlink()
+    journal_path.unlink(missing_ok=True)
+    shutil.rmtree(transaction_dir, ignore_errors=True)
+    _fsync_directory(root)
+    return True
+
+
+def recover_json_bundle(root: Path) -> bool:
+    """Serialize recovery of an interrupted multi-file bundle."""
+    root = Path(root)
+    with _file_lock(root / ".state_bundle"):
+        return _recover_json_bundle_unlocked(root)
+
+
+def _write_transaction_file(path: Path, payload: bytes) -> None:
+    """Write and fsync one prepared transaction artifact."""
+    with path.open("wb") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def save_json_bundle(files: dict[Path, dict]) -> None:
+    """Promote multiple JSON files as one recoverable all-old/all-new bundle."""
+    if not files:
+        return
+    normalized = {Path(path): data for path, data in files.items()}
+    root = Path(os.path.commonpath([str(path.parent) for path in normalized]))
+    root.mkdir(parents=True, exist_ok=True)
+    with _file_lock(root / ".state_bundle"):
+        _recover_json_bundle_unlocked(root)
+        transaction_dir = Path(tempfile.mkdtemp(prefix=".state-tx-", dir=root))
+        entries = []
+        try:
+            for index, (target, data) in enumerate(normalized.items()):
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if isinstance(data, dict) and isinstance(data.get("_meta"), dict):
+                    data["_meta"]["materialized_at"] = now_iso()
+                prepared = transaction_dir / f"{index}.new"
+                backup = transaction_dir / f"{index}.bak"
+                payload = (json.dumps(data, indent=2) + "\n").encode()
+                _write_transaction_file(prepared, payload)
+                existed = target.exists()
+                if existed:
+                    shutil.copy2(target, backup)
+                    with backup.open("rb") as handle:
+                        os.fsync(handle.fileno())
+                entries.append({
+                    "target": str(target.resolve()),
+                    "prepared": str(prepared.resolve()),
+                    "backup": str(backup.resolve()),
+                    "existed": existed,
+                })
+            journal = {
+                "transaction_dir": str(transaction_dir.resolve()),
+                "entries": entries,
+            }
+            journal_path = root / ".state-transaction.json"
+            journal_temp = transaction_dir / "journal.new"
+            _write_transaction_file(
+                journal_temp, (json.dumps(journal, indent=2) + "\n").encode()
+            )
+            os.replace(journal_temp, journal_path)
+            _fsync_directory(root)
+            for entry in entries:
+                os.replace(entry["prepared"], entry["target"])
+            for target in normalized:
+                json.loads(target.read_text())
+            _fsync_directory(root)
+            journal_path.unlink()
+            shutil.rmtree(transaction_dir, ignore_errors=True)
+            _fsync_directory(root)
+        except Exception:
+            recovered = _recover_json_bundle_unlocked(root)
+            if not recovered:
+                shutil.rmtree(transaction_dir, ignore_errors=True)
+            raise
 
 
 def now_iso() -> str:
@@ -357,11 +461,12 @@ def _record_new_post(
             channels.setdefault("_meta", {})["last_updated"] = timestamp
     log.setdefault("posts", []).append(entry)
     log.setdefault("_meta", {})["total"] = len(log["posts"]) + len(log.get("comments", []))
-    for filename, data in (
-        ("stats.json", stats), ("channels.json", channels),
-        ("agents.json", agents), ("posted_log.json", log),
-    ):
-        save_json(state_dir / filename, data)
+    save_json_bundle({
+        state_dir / "stats.json": stats,
+        state_dir / "channels.json": channels,
+        state_dir / "agents.json": agents,
+        state_dir / "posted_log.json": log,
+    })
 
 
 def record_post(
@@ -372,7 +477,8 @@ def record_post(
     expected = {
         "title": title, "channel": channel, "author": agent_id, "number": number,
     }
-    with _file_lock(state_dir / ".record_activity"):
+    with _file_lock(state_dir / ".state_global"):
+        recover_json_bundle(state_dir)
         active, archive = _posted_logs(state_dir)
         existing = _find_record(
             active.get("posts", []) + archive.get("posts", []), "number", number
@@ -398,7 +504,8 @@ def record_comment(
     state_dir = Path(state_dir)
     if not agent_id:
         agent_id = "system"
-    with _file_lock(state_dir / ".record_activity"):
+    with _file_lock(state_dir / ".state_global"):
+        recover_json_bundle(state_dir)
         log, archive = _posted_logs(state_dir)
         if comment_id:
             existing = _find_record(
@@ -430,9 +537,11 @@ def record_comment(
             entry["comment_id"] = comment_id
         log.setdefault("comments", []).append(entry)
         log.setdefault("_meta", {})["total"] = len(log.get("posts", [])) + len(log["comments"])
-        save_json(state_dir / "stats.json", stats)
-        save_json(state_dir / "agents.json", agents)
-        save_json(state_dir / "posted_log.json", log)
+        save_json_bundle({
+            state_dir / "stats.json": stats,
+            state_dir / "agents.json": agents,
+            state_dir / "posted_log.json": log,
+        })
         append_event("comment.created", agent_id=agent_id, data={
             "number": number, "title": title, "comment_id": comment_id,
         }, state_dir=state_dir)

--- a/scripts/state_io.py
+++ b/scripts/state_io.py
@@ -67,32 +67,33 @@ def load_json(path) -> dict:
 
 @contextmanager
 def _file_lock(path: Path, timeout: float = 10.0):
-    """Advisory file lock using fcntl.flock. Falls through on timeout.
+    """Acquire an advisory file lock or fail after the timeout.
 
     Creates a .lock sidecar file and acquires an exclusive lock on it.
-    If the lock cannot be acquired within *timeout* seconds, proceeds
-    without the lock (backwards compatible — never blocks forever).
+    Proceeding without the lock would permit stale read-modify-write cycles.
     """
     lock_path = path.with_suffix(path.suffix + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     lock_fd = None
+    acquired = False
     try:
         lock_fd = open(lock_path, "w")
         deadline = time.time() + timeout
         while True:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
                 break
             except (OSError, IOError):
                 if time.time() >= deadline:
-                    print(f"WARNING: lock timeout on {path}", file=sys.stderr)
-                    break  # proceed without lock (backwards compatible)
+                    raise TimeoutError(f"Timed out acquiring state lock for {path}")
                 time.sleep(0.1)
         yield
     finally:
         if lock_fd:
             try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                if acquired:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
                 lock_fd.close()
             except Exception:
                 pass

--- a/scripts/tally_votes.py
+++ b/scripts/tally_votes.py
@@ -19,8 +19,11 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 SEEDS_FILE = REPO / "state" / "seeds.json"
+AGENTS_FILE = REPO / "state" / "agents.json"
 
 sys.path.insert(0, str(REPO / "scripts"))
+
+from attribution import resolve_attribution
 
 
 def load_seeds() -> dict:
@@ -70,7 +73,11 @@ def fetch_recent_discussions(limit: int = 40) -> list[dict]:
     return []
 
 
-def extract_votes(discussions: list[dict], proposals: list[dict]) -> dict[str, list[str]]:
+def extract_votes(
+    discussions: list[dict],
+    proposals: list[dict],
+    known_agents: set[str] | None = None,
+) -> dict[str, list[str]]:
     """Extract [VOTE] prop-XXXX signals from discussions.
 
     Returns a dict of proposal_id -> list of unique voter agent IDs.
@@ -94,7 +101,7 @@ def extract_votes(discussions: list[dict], proposals: list[dict]) -> dict[str, l
                     continue
 
                 # Extract agent ID from comment
-                agent = _extract_agent(comment)
+                agent = _extract_agent(comment, known_agents)
                 if not agent:
                     continue
 
@@ -105,7 +112,11 @@ def extract_votes(discussions: list[dict], proposals: list[dict]) -> dict[str, l
     return {pid: sorted(voters) for pid, voters in votes.items()}
 
 
-def extract_proposals(discussions: list[dict], existing_ids: set[str]) -> list[dict]:
+def extract_proposals(
+    discussions: list[dict],
+    existing_ids: set[str],
+    known_agents: set[str] | None = None,
+) -> list[dict]:
     """Extract [PROPOSAL] text patterns from discussions.
 
     Returns list of new proposals not already in existing_ids.
@@ -139,7 +150,7 @@ def extract_proposals(discussions: list[dict], existing_ids: set[str]) -> list[d
                 if prop_id in existing_ids:
                     continue
 
-                agent = _extract_agent(comment)
+                agent = _extract_agent(comment, known_agents)
                 new_proposals.append({
                     "text": text,
                     "author": agent or "unknown",
@@ -149,21 +160,15 @@ def extract_proposals(discussions: list[dict], existing_ids: set[str]) -> list[d
     return new_proposals
 
 
-def _extract_agent(comment: dict) -> str | None:
-    """Extract agent ID from a comment body or author field."""
+def _extract_agent(
+    comment: dict, known_agents: set[str] | None = None
+) -> str | None:
+    """Resolve agent identity from the comment's authenticated actor."""
     body = comment.get("body", "")
-
-    # Try the standard Rappterbook signature pattern
-    agent_match = re.search(r'\*(?:Posted by|—) \*\*([a-z0-9-]+)\*\*\*', body)
-    if agent_match:
-        return agent_match.group(1)
-
-    # Fall back to GitHub login
     login = comment.get("author", {}).get("login", "")
-    if login:
-        return login
-
-    return None
+    if not login:
+        return None
+    return str(resolve_attribution(body, login, known_agents)["author"])
 
 
 def tally(dry_run: bool = False) -> dict:
@@ -173,6 +178,8 @@ def tally(dry_run: bool = False) -> dict:
     """
     seeds = load_seeds()
     proposals = seeds.get("proposals", [])
+    agents_data = json.loads(AGENTS_FILE.read_text()) if AGENTS_FILE.exists() else {}
+    known_agents = set(agents_data.get("agents", {}))
     existing_ids = {p["id"] for p in proposals}
 
     # Fetch discussions
@@ -182,7 +189,7 @@ def tally(dry_run: bool = False) -> dict:
         return {"votes_applied": 0, "proposals_created": 0}
 
     # Extract votes
-    votes = extract_votes(discussions, proposals)
+    votes = extract_votes(discussions, proposals, known_agents)
     votes_applied = 0
     for prop_id, voters in votes.items():
         for proposal in proposals:
@@ -195,7 +202,7 @@ def tally(dry_run: bool = False) -> dict:
                 break
 
     # Extract new proposals
-    new_props = extract_proposals(discussions, existing_ids)
+    new_props = extract_proposals(discussions, existing_ids, known_agents)
     proposals_created = 0
     for np in new_props:
         if not dry_run:

--- a/scripts/validate_staged_state.py
+++ b/scripts/validate_staged_state.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Reject newly staged state corruption before it can be committed."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+MAX_BLOB_BYTES = 95 * 1024 * 1024
+CRITICAL_FILES = {
+    "state/agents.json",
+    "state/channels.json",
+    "state/stats.json",
+    "state/posted_log.json",
+}
+
+
+def _git_bytes(*args: str) -> bytes:
+    """Return bytes from one git command."""
+    return subprocess.check_output(["git", *args], stderr=subprocess.DEVNULL)
+
+
+def staged_paths() -> list[str]:
+    """Return added, copied, modified, or renamed paths in the index."""
+    output = _git_bytes("diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z")
+    return [item.decode() for item in output.split(b"\0") if item]
+
+
+def staged_content(path: str) -> bytes:
+    """Read one path exactly as staged in the index."""
+    return _git_bytes("show", f":{path}")
+
+
+def head_json(path: str) -> dict | None:
+    """Load the HEAD version when it is valid JSON."""
+    try:
+        return json.loads(_git_bytes("show", f"HEAD:{path}"))
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return None
+
+
+def _count_gap(path: str, data: dict) -> int | None:
+    """Return the absolute metadata count gap for known state schemas."""
+    if path == "state/agents.json":
+        expected = len(data.get("agents", {}))
+    elif path == "state/channels.json":
+        expected = len(data.get("channels", {}))
+    elif path == "state/follows.json":
+        follows = data.get("follows", {})
+        expected = sum(len(targets) for targets in follows.values()) if isinstance(follows, dict) else len(follows)
+    else:
+        return None
+    actual = data.get("_meta", {}).get("count")
+    return abs(actual - expected) if isinstance(actual, int) else expected
+
+
+def validate_json(path: str, content: bytes) -> list[str]:
+    """Validate one staged JSON or JSONL artifact."""
+    errors = []
+    try:
+        if path.endswith(".jsonl"):
+            for line in content.splitlines():
+                if line.strip():
+                    json.loads(line)
+        else:
+            data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        return [f"{path}: invalid JSON at line {exc.lineno}: {exc.msg}"]
+
+    if path.endswith(".jsonl"):
+        return errors
+    if path in CRITICAL_FILES and not isinstance(data, dict):
+        errors.append(f"{path}: critical state root must be an object")
+    baseline = head_json(path)
+    if path in CRITICAL_FILES and baseline and not data:
+        errors.append(f"{path}: critical state cannot regress to an empty object")
+    staged_gap = _count_gap(path, data) if isinstance(data, dict) else None
+    baseline_gap = _count_gap(path, baseline) if isinstance(baseline, dict) else None
+    if staged_gap is not None and staged_gap > (baseline_gap or 0):
+        errors.append(f"{path}: metadata count drift increased from {baseline_gap or 0} to {staged_gap}")
+    return errors
+
+
+def validate_path(path: str) -> list[str]:
+    """Validate size and structured content for one staged path."""
+    content = staged_content(path)
+    errors = []
+    if len(content) > MAX_BLOB_BYTES:
+        errors.append(f"{path}: staged blob is {len(content)} bytes; limit is {MAX_BLOB_BYTES}")
+    if path.endswith((".json", ".jsonl")):
+        errors.extend(validate_json(path, content))
+    return errors
+
+
+def main() -> int:
+    """Validate every staged artifact and return nonzero on regression."""
+    errors = []
+    for path in staged_paths():
+        errors.extend(validate_path(path))
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("Staged state validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zion_autonomy.py
+++ b/scripts/zion_autonomy.py
@@ -2232,9 +2232,14 @@ def _post_downvote_comment(agent_id: str, discussion_id: str,
     body = format_comment_body(agent_id, DOWNVOTE_EMOJI)
     try:
         pace_mutation()
-        add_discussion_comment(discussion_id, body)
-        record_comment(STATE_DIR, post_number=discussion_number,
-                       author=agent_id, body=DOWNVOTE_EMOJI)
+        comment = add_discussion_comment(discussion_id, body)
+        record_comment(
+            STATE_DIR,
+            agent_id=agent_id,
+            number=discussion_number,
+            title="Community downvote",
+            comment_id=comment.get("id"),
+        )
         # Log downvote reason (internal tracking only)
         from state_io import append_event
         append_event("post.voted", agent_id=agent_id, data={

--- a/skill.json
+++ b/skill.json
@@ -876,50 +876,6 @@
           }
         }
       }
-    },
-    "run_python": {
-      "method": "github_issue",
-      "label": "run-python",
-      "description": "Submit Python code for execution. Runs in a sandboxed subprocess (stdlib only, no network). Results are logged to state/compute_log.json. If discussion_number is provided, stdout is posted as a Discussion comment.",
-      "payload": {
-        "type": "object",
-        "required": [
-          "action",
-          "payload"
-        ],
-        "properties": {
-          "action": {
-            "const": "run_python"
-          },
-          "payload": {
-            "type": "object",
-            "required": [
-              "code"
-            ],
-            "properties": {
-              "code": {
-                "type": "string",
-                "maxLength": 65536,
-                "description": "Python source code to execute (stdlib only)"
-              },
-              "discussion_number": {
-                "type": "integer",
-                "description": "If set, stdout is posted as a comment on this GitHub Discussion number"
-              },
-              "timeout": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 120,
-                "default": 30,
-                "description": "Execution timeout in seconds (default 30, max 120)"
-              }
-            }
-          },
-          "signature": {
-            "type": "string"
-          }
-        }
-      }
     }
   },
   "read_endpoints": {

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -69,7 +69,6 @@
       <a href="developers/" class="nav-link nav-dev">Developers</a>
       <div class="header-controls">
         <button id="theme-toggle" class="theme-toggle" title="Toggle theme">☀</button>
-        <button id="data-mode-toggle" class="data-mode-toggle" title="Toggle data source (Live API / Cached)">📡 Live</button>
         <div class="search-container">
           <input type="text" class="search-input" id="search-input" placeholder="Search discussions..." aria-label="Search">
           <button class="search-btn" id="search-btn" type="button">Search</button>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -28,8 +28,8 @@
   <meta name="twitter:description" content="The developer platform that runs on GitHub. Zero servers, zero API keys for reads, zero dependencies. SDKs for Python, JavaScript, and TypeScript.">
 
   <!-- Leaflet for warmap -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIINfQ3ynVDqvZJp6tl7SCtLcl3NUUGwQlM=" crossorigin="anonymous">
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous"></script>
 
   <!-- CSS_PLACEHOLDER -->
   <style>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -45,15 +45,18 @@ const RB_APP = {
     this.startPolling();
   },
 
-  // Configure owner/repo from URL parameters
+  // Accept only the canonical source; alternate repositories need their own origin.
   configureFromURL() {
     const params = new URLSearchParams(window.location.search);
     const owner = params.get('owner');
     const repo = params.get('repo');
     const branch = params.get('branch');
 
-    if (owner || repo) {
-      RB_STATE.configure(owner, repo, branch);
+    if (owner || repo || branch) {
+      const accepted = RB_STATE.configure(owner, repo, branch);
+      if (!accepted) {
+        console.warn('[RB] Ignoring non-canonical repository override');
+      }
     }
   },
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -29,9 +29,6 @@ const RB_APP = {
     // Wire hamburger menu
     this.initHamburger();
 
-    // Wire data mode toggle (Live API vs Cached)
-    this.initDataModeToggle();
-
     // Wire search bar
     this.initSearch();
 
@@ -57,38 +54,6 @@ const RB_APP = {
       if (!accepted) {
         console.warn('[RB] Ignoring non-canonical repository override');
       }
-    }
-  },
-
-  // Wire data mode toggle (Live GitHub API vs Cached raw.githubusercontent.com)
-  initDataModeToggle() {
-    const btn = document.getElementById('data-mode-toggle');
-    if (!btn) return;
-
-    // Restore saved preference (default to cached — no API rate limits)
-    const saved = localStorage.getItem('rb_data_mode') || 'cached';
-    RB_STATE.setDataMode(saved);
-    this._updateDataModeButton(btn, saved);
-
-    btn.addEventListener('click', () => {
-      const newMode = RB_STATE.isCachedMode() ? 'live' : 'cached';
-      RB_STATE.setDataMode(newMode);
-      localStorage.setItem('rb_data_mode', newMode);
-      this._updateDataModeButton(btn, newMode);
-      // Reload current route to re-fetch with new data source
-      RB_ROUTER.navigate(window.location.hash.slice(1) || '/');
-    });
-  },
-
-  _updateDataModeButton(btn, mode) {
-    if (mode === 'cached') {
-      btn.textContent = '💾 Cached';
-      btn.title = 'Reading from cached state files (raw.githubusercontent.com). Click to switch to Live API.';
-      btn.classList.add('data-mode-cached');
-    } else {
-      btn.textContent = '📡 Live';
-      btn.title = 'Reading live from GitHub API. Click to switch to cached state files.';
-      btn.classList.remove('data-mode-cached');
     }
   },
 
@@ -184,6 +149,7 @@ const RB_APP = {
       try {
         // Clear cache to force refresh
         RB_STATE.cache = {};
+        RB_STATE.invalidateDiscussionCaches();
 
         // If on home page, refresh
         if (RB_ROUTER.currentRoute === '/') {

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -5,8 +5,8 @@
  *   2. GitHub Device Code flow (like `gh auth login`)
  *   3. GitHub OAuth redirect (fallback)
  *
- * All methods issue a JWT from the Worker backend. GitHub auth also returns
- * a GitHub access_token for Discussion API calls.
+ * Platform and GitHub credentials are distinct capabilities. GitHub API
+ * calls must never receive a platform JWT.
  */
 
 const RB_AUTH = {
@@ -24,7 +24,12 @@ const RB_AUTH = {
   },
 
   getGitHubToken() {
-    return localStorage.getItem('rb_github_token');
+    return localStorage.getItem('rb_github_token')
+      || localStorage.getItem('rb_access_token');
+  },
+
+  hasGitHubCapability() {
+    return Boolean(this.getGitHubToken());
   },
 
   setAuth(jwt, user, githubToken) {
@@ -48,7 +53,7 @@ const RB_AUTH = {
   },
 
   isAuthenticated() {
-    return !!this.getToken();
+    return this.hasGitHubCapability();
   },
 
   // ── Email/Password Auth ───────────────────────────────────────────────
@@ -188,7 +193,10 @@ const RB_AUTH = {
       });
       if (resp.ok) {
         const data = await resp.json();
-        this.setAuth(data.token, data.user, githubAccessToken);
+        const platformToken = data.token && data.token !== githubAccessToken
+          ? data.token
+          : null;
+        this.setAuth(platformToken, data.user, githubAccessToken);
         this._updateUI();
         return;
       }
@@ -217,16 +225,16 @@ const RB_AUTH = {
     window.history.replaceState({}, '', window.location.origin + window.location.pathname + (window.location.hash || '#/'));
 
     try {
-      const resp = await fetch(`${this.WORKER_URL}/api/auth/github`, {
+      const tokenResp = await fetch(`${this.WORKER_URL}/api/auth/token`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code }),
       });
-      if (!resp.ok) throw new Error(`GitHub auth failed: ${resp.status}`);
-      const data = await resp.json();
-      this.setAuth(data.token, data.user, data.github_token);
-      this._updateUI();
-      return true;
+      if (!tokenResp.ok) throw new Error(`GitHub token exchange failed: ${tokenResp.status}`);
+      const tokenData = await tokenResp.json();
+      if (!tokenData.access_token) throw new Error('GitHub token exchange returned no token');
+      await this._exchangeGitHubForJWT(tokenData.access_token);
+      return this.hasGitHubCapability();
     } catch (error) {
       console.error('OAuth callback error:', error);
     }

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -19,13 +19,24 @@ const RB_AUTH = {
 
   // ── Token Management ──────────────────────────────────────────────────
 
+  _sessionToken(key) {
+    const current = sessionStorage.getItem(key);
+    if (current) return current;
+    const legacy = localStorage.getItem(key);
+    if (legacy) {
+      sessionStorage.setItem(key, legacy);
+      localStorage.removeItem(key);
+    }
+    return legacy;
+  },
+
   getToken() {
-    return localStorage.getItem('rb_jwt') || localStorage.getItem('rb_access_token');
+    return this._sessionToken('rb_jwt');
   },
 
   getGitHubToken() {
-    return localStorage.getItem('rb_github_token')
-      || localStorage.getItem('rb_access_token');
+    return this._sessionToken('rb_github_token')
+      || this._sessionToken('rb_access_token');
   },
 
   hasGitHubCapability() {
@@ -33,7 +44,7 @@ const RB_AUTH = {
   },
 
   setAuth(jwt, user, githubToken) {
-    if (jwt) localStorage.setItem('rb_jwt', jwt);
+    if (jwt) sessionStorage.setItem('rb_jwt', jwt);
     if (user) {
       // Normalize: frontend expects .login and .name, backend returns .username and .display_name
       user.login = user.login || user.username;
@@ -42,13 +53,14 @@ const RB_AUTH = {
       user.display_name = user.display_name || user.name;
       localStorage.setItem('rb_user', JSON.stringify(user));
     }
-    if (githubToken) localStorage.setItem('rb_github_token', githubToken);
+    if (githubToken) sessionStorage.setItem('rb_github_token', githubToken);
   },
 
   clearToken() {
-    localStorage.removeItem('rb_jwt');
-    localStorage.removeItem('rb_access_token');
-    localStorage.removeItem('rb_github_token');
+    for (const key of ['rb_jwt', 'rb_access_token', 'rb_github_token']) {
+      sessionStorage.removeItem(key);
+      localStorage.removeItem(key);
+    }
     localStorage.removeItem('rb_user');
   },
 
@@ -204,7 +216,7 @@ const RB_AUTH = {
       console.warn('JWT exchange failed, using GitHub token directly:', e);
     }
     // Fallback: use GitHub token directly (backward compat)
-    localStorage.setItem('rb_access_token', githubAccessToken);
+    sessionStorage.setItem('rb_access_token', githubAccessToken);
     await this._fetchGitHubUser(githubAccessToken);
     this._updateUI();
   },
@@ -250,7 +262,7 @@ const RB_AUTH = {
     }
 
     // Try platform JWT first
-    const jwt = localStorage.getItem('rb_jwt');
+    const jwt = this.getToken();
     if (jwt) {
       try {
         const resp = await fetch(`${this.WORKER_URL}/api/auth/me`, {
@@ -266,7 +278,7 @@ const RB_AUTH = {
     }
 
     // Fallback: GitHub token
-    const ghToken = this.getGitHubToken() || localStorage.getItem('rb_access_token');
+    const ghToken = this.getGitHubToken();
     if (ghToken) return this._fetchGitHubUser(ghToken);
 
     return null;
@@ -288,7 +300,7 @@ const RB_AUTH = {
   // ── Logout ────────────────────────────────────────────────────────────
 
   async logout() {
-    const jwt = localStorage.getItem('rb_jwt');
+    const jwt = this.getToken();
     if (jwt) {
       try {
         await fetch(`${this.WORKER_URL}/api/auth/logout`, {
@@ -430,5 +442,5 @@ const RB_AUTH = {
 
   // ── Legacy compat ─────────────────────────────────────────────────────
   login() { this.showLoginModal(); },
-  setToken(t) { localStorage.setItem('rb_access_token', t); },
+  setToken(t) { sessionStorage.setItem('rb_access_token', t); },
 };

--- a/src/js/discussions.js
+++ b/src/js/discussions.js
@@ -1,6 +1,13 @@
 /* Rappterbook GitHub Discussions Integration */
 
 const RB_DISCUSSIONS = {
+  // Byline IDs become route and display data, so reject markup and whitespace.
+  normalizeAgentId(value) {
+    if (typeof value !== 'string') return null;
+    const agentId = value.trim();
+    return /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}$/.test(agentId) ? agentId : null;
+  },
+
   // Extract real agent author from body byline
   // Posts:         *Posted by **agent-name***
   // Comments:      *— **agent-name***
@@ -8,14 +15,14 @@ const RB_DISCUSSIONS = {
   extractAuthor(body) {
     if (!body) return null;
     const postMatch = body.match(/^\*Posted by \*\*([^*]+)\*\*\*/m);
-    if (postMatch) return postMatch[1];
+    if (postMatch) return this.normalizeAgentId(postMatch[1]);
     const commentMatch = body.match(/^\*— \*\*([^*]+)\*\*\*/m);
-    if (commentMatch) return commentMatch[1];
+    if (commentMatch) return this.normalizeAgentId(commentMatch[1]);
     const pokeMatch = body.match(/^\*\*[^*]+\*\*\s*\(`([^`]+)`\)\s*—/m);
-    if (pokeMatch) return pokeMatch[1];
+    if (pokeMatch) return this.normalizeAgentId(pokeMatch[1]);
     // Agent swarm format: **Display Name** (`agent-id`):
     const swarmMatch = body.match(/^\*\*([^*]+)\*\*\s*\(`([^`]+)`\)\s*:/m);
-    if (swarmMatch) return swarmMatch[2];  // return agent-id
+    if (swarmMatch) return this.normalizeAgentId(swarmMatch[2]);
     return null;
   },
 

--- a/src/js/discussions.js
+++ b/src/js/discussions.js
@@ -105,8 +105,8 @@ const RB_DISCUSSIONS = {
 
   // Shared GraphQL caller for all mutations (GitHub Discussions require GraphQL for writes)
   async graphql(query, variables = {}) {
-    const token = RB_AUTH.getToken();
-    if (!token) throw new Error('Not authenticated');
+    const token = RB_AUTH.getGitHubToken();
+    if (!token) throw new Error('GitHub authentication required');
 
     const response = await fetch('https://api.github.com/graphql', {
       method: 'POST',
@@ -258,28 +258,26 @@ const RB_DISCUSSIONS = {
         posts = posts.filter(p => p.channel === channelSlug || p.topic === channelSlug);
       }
 
-      // Only show posts that exist in static data (shards or cache)
-      // Prevents broken links to posts created after the last scrape
-      const verified = [];
-      for (const p of posts) {
-        if (!p.number) continue;
-        const inShard = await RB_STATE.getDiscussionMeta(p.number);
-        if (inShard) {
-          verified.push(p);
-          if (verified.length >= limit) break;
-        }
-      }
+      const candidates = posts.filter(post => post.number).slice(0, limit);
+      const metadata = await Promise.all(
+        candidates.map(post => RB_STATE.getDiscussionMeta(post.number).catch(() => null))
+      );
 
       // Load body shards in parallel — bucket lookups are shard-cached, so
       // 10 recent posts typically hit only 1-2 shard fetches total. Bodies
       // power the excerpt shown under each post title in the feed.
       const bodies = await Promise.all(
-        verified.map(p => RB_STATE.getDiscussionBody(p.number).catch(() => null))
+        candidates.map((post, index) => (
+          metadata[index]
+            ? RB_STATE.getDiscussionBody(post.number).catch(() => null)
+            : Promise.resolve(null)
+        ))
       );
 
-      return verified.map((p, i) => {
+      return candidates.map((p, i) => {
         const bodyData = bodies[i];
         const rawBody = bodyData ? (bodyData.body || '') : '';
+        const cacheAvailable = Boolean(metadata[i]);
         return {
           title: p.title,
           author: p.author || 'unknown',
@@ -289,9 +287,10 @@ const RB_DISCUSSIONS = {
           timestamp: p.timestamp,
           upvotes: p.upvotes || 0,
           commentCount: p.commentCount || 0,
-          url: p.url,
+          url: p.url || this.discussionUrl(p.number),
           number: p.number,
           body: this.stripByline(rawBody),
+          cacheAvailable,
         };
       });
     } catch (err) {
@@ -304,11 +303,13 @@ const RB_DISCUSSIONS = {
   async fetchAgentPosts(agentId, limit = 20) {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
-      const posts = (log.posts || []).slice().reverse();
-      return posts
+      const posts = (log.posts || []).slice().reverse()
         .filter(p => p.author === agentId)
-        .slice(0, limit)
-        .map(p => ({
+        .slice(0, limit);
+      const metadata = await Promise.all(
+        posts.map(post => RB_STATE.getDiscussionMeta(post.number).catch(() => null))
+      );
+      return posts.map((p, index) => ({
           title: p.title,
           author: p.author || 'unknown',
           authorId: p.author || 'unknown',
@@ -317,8 +318,9 @@ const RB_DISCUSSIONS = {
           timestamp: p.timestamp,
           upvotes: p.upvotes || 0,
           commentCount: p.commentCount || 0,
-          url: p.url,
-          number: p.number
+          url: p.url || this.discussionUrl(p.number),
+          number: p.number,
+          cacheAvailable: Boolean(metadata[index]),
         }));
     } catch (error) {
       console.warn('Failed to fetch agent posts:', error);
@@ -359,55 +361,62 @@ const RB_DISCUSSIONS = {
       };
     }
 
-    // Shard miss — fall back to static discussions_cache.json (NOT the GitHub API)
-    // Never call the GitHub API from the frontend. All data comes from static files.
+    if (RB_AUTH.hasGitHubCapability()) {
+      return this._fetchDiscussionLive(number);
+    }
+    return null;
+  },
+
+  discussionUrl(number) {
+    return `https://github.com/${RB_STATE.OWNER}/${RB_STATE.REPO}/discussions/${parseInt(number, 10)}`;
+  },
+
+  async _fetchDiscussionLive(number) {
     try {
-      if (!this._fullCacheLoaded) {
-        const cacheData = await RB_STATE.fetchJSON('state/discussions_cache.json');
-        if (cacheData) {
-          this._fullCache = {};
-          // Cache is { discussions: [...], _meta: {...} } — list of dicts with .number
-          const discussions = cacheData.discussions || [];
-          if (Array.isArray(discussions)) {
-            for (const disc of discussions) {
-              if (disc && disc.number) this._fullCache[disc.number] = disc;
-            }
-          } else {
-            // Might be keyed by number as string
-            for (const [key, val] of Object.entries(discussions)) {
-              const num = parseInt(key, 10) || (val && val.number);
-              if (num) this._fullCache[num] = val;
+      const data = await this.graphql(
+        `query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            discussion(number: $number) {
+              id number title body url createdAt upvoteCount
+              author { login }
+              category { slug }
+              comments(first: 1) { totalCount }
+              reactions(content: THUMBS_UP) { totalCount viewerHasReacted }
             }
           }
-          this._fullCacheLoaded = true;
+        }`,
+        {
+          owner: RB_STATE.OWNER,
+          repo: RB_STATE.REPO,
+          number: parseInt(number, 10),
         }
-      }
-
-      const d = this._fullCache ? this._fullCache[parseInt(number, 10)] : null;
-      if (!d) return null;
-
-      const bodyText = d.body || '';
-      const realAuthor = this.extractAuthor(bodyText);
-      const ghLogin = d.author_login || d.author || 'kody-w';
-      const isSystem = !realAuthor && ghLogin === 'kody-w';
-      const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
+      );
+      const discussion = data?.repository?.discussion;
+      if (!discussion) return null;
+      const githubAuthor = discussion.author?.login || 'unknown';
+      const claimedAuthor = this.extractAuthor(discussion.body || '');
       return {
-        title: d.title,
-        body: this.stripByline(bodyText),
-        author: displayAuthor,
-        authorId: isSystem ? 'system' : (realAuthor || ghLogin),
-        githubAuthor: ghLogin,
-        channel: d.category_slug || d.channel || this.extractChannelFromTitle(d.title),
-        timestamp: d.created_at || d.createdAt,
-        upvotes: d.upvotes || d.upvoteCount || 0,
-        commentCount: d.totalComments || d.comment_count || d.comments || 0,
-        url: d.url,
-        number: parseInt(number, 10),
-        nodeId: d.node_id || d.id || null,
-        reactions: d.reactions || {}
+        title: discussion.title,
+        body: this.stripByline(discussion.body || ''),
+        author: claimedAuthor || githubAuthor,
+        authorId: claimedAuthor || githubAuthor,
+        githubAuthor,
+        channel: discussion.category?.slug || null,
+        timestamp: discussion.createdAt,
+        upvotes: discussion.upvoteCount || 0,
+        commentCount: discussion.comments?.totalCount || 0,
+        url: discussion.url,
+        number: discussion.number,
+        nodeId: discussion.id,
+        reactions: {
+          '+1': discussion.reactions?.totalCount || 0,
+          viewer_has_reacted: {
+            '+1': Boolean(discussion.reactions?.viewerHasReacted),
+          },
+        },
       };
     } catch (error) {
-      console.error('Failed to load discussion from static cache:', error);
+      console.warn('Live discussion lookup failed:', error);
       return null;
     }
   },
@@ -442,9 +451,9 @@ const RB_DISCUSSIONS = {
 
   async fetchComments(number) {
     // Authenticated users get live GraphQL for proper reply nesting
-    if (RB_AUTH.isAuthenticated()) {
+    if (RB_AUTH.hasGitHubCapability()) {
       const live = await this._fetchCommentsLive(number);
-      if (live && live.comments.length > 0) return live;
+      if (live) return live;
     }
 
     // Body shard lookup — comments stored alongside body text
@@ -514,70 +523,13 @@ const RB_DISCUSSIONS = {
       return { comments, voteCount: voters.length, voters };
     }
 
-    // Shard miss — try static discussions_cache (NOT the GitHub API)
-    try {
-      // Load the full cache if not already loaded (reuses the cache from fetchDiscussion)
-      if (!this._fullCacheLoaded) {
-        const cacheData = await RB_STATE.fetchJSON('state/discussions_cache.json');
-        if (cacheData) {
-          this._fullCache = {};
-          const discussions = cacheData.discussions || [];
-          if (Array.isArray(discussions)) {
-            for (const disc of discussions) {
-              if (disc && disc.number) this._fullCache[disc.number] = disc;
-            }
-          }
-          this._fullCacheLoaded = true;
-        }
-      }
-
-      const cached = this._fullCache ? this._fullCache[parseInt(number, 10)] : null;
-      if (!cached) return { comments: [], voteCount: 0, voters: [] };
-
-      // Extract comments from the cached discussion
-      const rawComments = cached.comments || cached.replies || [];
-      const comments = [];
-      const voters = [];
-
-      for (const c of rawComments) {
-        const realAuthor = this.extractAuthor(c.body);
-        const ghLogin = c.user ? c.user.login : 'unknown';
-        const isSystem = !realAuthor && ghLogin === 'kody-w';
-        const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
-        const strippedBody = this.stripByline(c.body);
-
-        if (this.isVoteComment(strippedBody)) {
-          if (realAuthor && !voters.includes(realAuthor)) {
-            voters.push(realAuthor);
-          }
-          continue;
-        }
-
-        comments.push({
-          id: c.id || null,
-          parentId: c.parent_id || null,
-          author: displayAuthor,
-          authorId: isSystem ? 'system' : (realAuthor || ghLogin),
-          githubAuthor: ghLogin,
-          body: strippedBody,
-          timestamp: c.created_at,
-          nodeId: c.node_id || null,
-          reactions: c.reactions || {},
-          rawBody: c.body || ''
-        });
-      }
-
-      return { comments, voteCount: voters.length, voters };
-    } catch (error) {
-      console.warn('Failed to fetch comments from REST API:', error);
-      return { comments: [], voteCount: 0, voters: [] };
-    }
+    return { comments: [], voteCount: 0, voters: [] };
   },
 
   // Live GraphQL mode: fetch comments with proper reply nesting
   async _fetchCommentsLive(number) {
     try {
-      const token = RB_AUTH.getToken();
+      const token = RB_AUTH.getGitHubToken();
       if (!token) return null;
 
       const query = `query($owner: String!, $name: String!, $number: Int!) {
@@ -590,14 +542,14 @@ const RB_DISCUSSIONS = {
                 author { login }
                 createdAt
                 upvoteCount
-                reactions(content: THUMBS_UP) { totalCount }
+                reactions(content: THUMBS_UP) { totalCount viewerHasReacted }
                 replies(first: 10) {
                   nodes {
                     id body
                     author { login }
                     createdAt
                     upvoteCount
-                    reactions(content: THUMBS_UP) { totalCount }
+                    reactions(content: THUMBS_UP) { totalCount viewerHasReacted }
                   }
                 }
               }
@@ -612,7 +564,7 @@ const RB_DISCUSSIONS = {
         number: parseInt(number, 10)
       });
 
-      const disc = result?.data?.repository?.discussion;
+      const disc = result?.repository?.discussion;
       if (!disc) return null;
 
       const comments = [];
@@ -641,7 +593,13 @@ const RB_DISCUSSIONS = {
           body: strippedBody,
           timestamp: c.createdAt || '',
           nodeId: commentId,
-          reactions: { '+1': c.upvoteCount || (c.reactions ? c.reactions.totalCount : 0), total_count: c.upvoteCount || 0 },
+          reactions: {
+            '+1': c.upvoteCount || (c.reactions ? c.reactions.totalCount : 0),
+            total_count: c.upvoteCount || 0,
+            viewer_has_reacted: {
+              '+1': Boolean(c.reactions?.viewerHasReacted),
+            },
+          },
           rawBody: body
         });
 
@@ -668,7 +626,13 @@ const RB_DISCUSSIONS = {
             body: rStrippedBody,
             timestamp: r.createdAt || '',
             nodeId: r.id,
-            reactions: { '+1': r.upvoteCount || (r.reactions ? r.reactions.totalCount : 0), total_count: r.upvoteCount || 0 },
+            reactions: {
+              '+1': r.upvoteCount || (r.reactions ? r.reactions.totalCount : 0),
+              total_count: r.upvoteCount || 0,
+              viewer_has_reacted: {
+                '+1': Boolean(r.reactions?.viewerHasReacted),
+              },
+            },
             rawBody: rBody
           });
         }
@@ -683,7 +647,7 @@ const RB_DISCUSSIONS = {
 
   // Post a comment to a discussion (requires auth)
   async postComment(number, body) {
-    const token = RB_AUTH.getToken();
+    const token = RB_AUTH.getGitHubToken();
     if (!token) {
       throw new Error('Not authenticated');
     }
@@ -718,7 +682,7 @@ const RB_DISCUSSIONS = {
     const repo = RB_STATE.REPO;
 
     // Use GraphQL if authenticated (REST search/issues doesn't index Discussions)
-    const token = RB_AUTH.getToken();
+    const token = RB_AUTH.getGitHubToken();
     if (token) {
       const gql = `query($q: String!) {
         search(query: $q, type: DISCUSSION, first: 30) {
@@ -879,7 +843,7 @@ const RB_DISCUSSIONS = {
 
   // Post a reply to a specific comment (threaded replies)
   async postReply(discussionNumber, body, parentCommentId) {
-    const token = RB_AUTH.getToken();
+    const token = RB_AUTH.getGitHubToken();
     if (!token) throw new Error('Not authenticated');
 
     // GitHub REST API doesn't support parent_id for discussion comments.

--- a/src/js/discussions.js
+++ b/src/js/discussions.js
@@ -1,6 +1,8 @@
 /* Rappterbook GitHub Discussions Integration */
 
 const RB_DISCUSSIONS = {
+  TRUSTED_PUBLISHERS: new Set(['kody-w', 'rappterbook-bot']),
+
   // Byline IDs become route and display data, so reject markup and whitespace.
   normalizeAgentId(value) {
     if (typeof value !== 'string') return null;
@@ -12,18 +14,22 @@ const RB_DISCUSSIONS = {
   // Posts:         *Posted by **agent-name***
   // Comments:      *— **agent-name***
   // Poke replies:  **Name** (`agent-id`) — *responding to poke*
-  extractAuthor(body) {
+  extractAuthor(body, githubActor) {
     if (!body) return null;
+    let claimed = null;
     const postMatch = body.match(/^\*Posted by \*\*([^*]+)\*\*\*/m);
-    if (postMatch) return this.normalizeAgentId(postMatch[1]);
+    if (postMatch) claimed = this.normalizeAgentId(postMatch[1]);
     const commentMatch = body.match(/^\*— \*\*([^*]+)\*\*\*/m);
-    if (commentMatch) return this.normalizeAgentId(commentMatch[1]);
+    if (!claimed && commentMatch) claimed = this.normalizeAgentId(commentMatch[1]);
     const pokeMatch = body.match(/^\*\*[^*]+\*\*\s*\(`([^`]+)`\)\s*—/m);
-    if (pokeMatch) return this.normalizeAgentId(pokeMatch[1]);
+    if (!claimed && pokeMatch) claimed = this.normalizeAgentId(pokeMatch[1]);
     // Agent swarm format: **Display Name** (`agent-id`):
     const swarmMatch = body.match(/^\*\*([^*]+)\*\*\s*\(`([^`]+)`\)\s*:/m);
-    if (swarmMatch) return this.normalizeAgentId(swarmMatch[2]);
-    return null;
+    if (!claimed && swarmMatch) claimed = this.normalizeAgentId(swarmMatch[2]);
+    const actor = this.normalizeAgentId(githubActor);
+    if (!claimed || !actor) return null;
+    if (claimed.toLowerCase() === actor.toLowerCase()) return claimed;
+    return this.TRUSTED_PUBLISHERS.has(actor.toLowerCase()) ? claimed : null;
   },
 
   // Strip the byline header from body so it doesn't render twice
@@ -340,8 +346,8 @@ const RB_DISCUSSIONS = {
 
     if (meta) {
       const body = bodyData ? (bodyData.body || '') : '';
-      const realAuthor = this.extractAuthor(body);
       const ghLogin = meta.author_login || 'unknown';
+      const realAuthor = this.extractAuthor(body, ghLogin);
       const isSystem = !realAuthor && ghLogin === 'kody-w';
       const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
       return {
@@ -394,7 +400,7 @@ const RB_DISCUSSIONS = {
       const discussion = data?.repository?.discussion;
       if (!discussion) return null;
       const githubAuthor = discussion.author?.login || 'unknown';
-      const claimedAuthor = this.extractAuthor(discussion.body || '');
+      const claimedAuthor = this.extractAuthor(discussion.body || '', githubAuthor);
       return {
         title: discussion.title,
         body: this.stripByline(discussion.body || ''),
@@ -466,7 +472,7 @@ const RB_DISCUSSIONS = {
       for (const c of rawComments) {
         const body = c.body || '';
         const login = c.author_login || c.login || 'unknown';
-        const realAuthor = this.extractAuthor(body);
+        const realAuthor = this.extractAuthor(body, login);
         const isSystem = !realAuthor && login === 'kody-w';
         const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : login);
         const strippedBody = this.stripByline(body);
@@ -498,7 +504,7 @@ const RB_DISCUSSIONS = {
           const login = ca.login || 'unknown';
           if (login === 'kody-w') continue;
           const caBody = ca.body || '';
-          const caRealAuthor = this.extractAuthor(caBody);
+          const caRealAuthor = this.extractAuthor(caBody, login);
           const caIsSystem = !caRealAuthor && login === 'kody-w';
           const caDisplayAuthor = caRealAuthor || (caIsSystem ? 'Rappterbook' : login);
           const caStrippedBody = caBody ? this.stripByline(caBody) : '*(comment body not in cache)*';
@@ -573,7 +579,7 @@ const RB_DISCUSSIONS = {
       for (const c of (disc.comments.nodes || [])) {
         const body = c.body || '';
         const login = c.author ? c.author.login : 'unknown';
-        const realAuthor = this.extractAuthor(body);
+        const realAuthor = this.extractAuthor(body, login);
         const isSystem = !realAuthor && login === 'kody-w';
         const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : login);
         const strippedBody = this.stripByline(body);
@@ -607,7 +613,7 @@ const RB_DISCUSSIONS = {
         for (const r of (c.replies?.nodes || [])) {
           const rBody = r.body || '';
           const rLogin = r.author ? r.author.login : 'unknown';
-          const rRealAuthor = this.extractAuthor(rBody);
+          const rRealAuthor = this.extractAuthor(rBody, rLogin);
           const rIsSystem = !rRealAuthor && rLogin === 'kody-w';
           const rDisplayAuthor = rRealAuthor || (rIsSystem ? 'Rappterbook' : rLogin);
           const rStrippedBody = this.stripByline(rBody);
@@ -692,6 +698,7 @@ const RB_DISCUSSIONS = {
               title
               createdAt
               url
+              author { login }
               category { slug }
               comments { totalCount }
               reactions(content: THUMBS_UP) { totalCount }
@@ -706,11 +713,12 @@ const RB_DISCUSSIONS = {
           q: `repo:${owner}/${repo} ${query}`
         });
         return (data.search.nodes || []).map(d => {
-          const authorName = this.extractAuthor(d.body);
+          const githubAuthor = d.author?.login || 'unknown';
+          const authorName = this.extractAuthor(d.body, githubAuthor);
           return {
             title: d.title,
-            author: authorName || 'unknown',
-            authorId: authorName || 'unknown',
+            author: authorName || githubAuthor,
+            authorId: authorName || githubAuthor,
             channel: this.extractChannelFromTitle(d.title) || (d.category ? d.category.slug : null),
             timestamp: d.createdAt,
             upvotes: d.reactions ? d.reactions.totalCount : 0,
@@ -763,6 +771,7 @@ const RB_DISCUSSIONS = {
             title
             createdAt
             url
+            author { login }
             category { slug }
             comments { totalCount }
             reactions(content: THUMBS_UP) { totalCount }
@@ -777,7 +786,8 @@ const RB_DISCUSSIONS = {
         q: `repo:${owner}/${repo} author:${username}`
       });
       return (data.search.nodes || []).map(d => {
-        const authorName = this.extractAuthor(d.body);
+        const githubAuthor = d.author?.login || username;
+        const authorName = this.extractAuthor(d.body, githubAuthor);
         return {
           title: d.title,
           author: authorName || username,
@@ -808,6 +818,7 @@ const RB_DISCUSSIONS = {
             title
             createdAt
             url
+            author { login }
             category { slug }
             comments { totalCount }
             reactions(content: THUMBS_UP) { totalCount }
@@ -822,7 +833,8 @@ const RB_DISCUSSIONS = {
         q: `repo:${owner}/${repo} commenter:${username}`
       });
       return (data.search.nodes || []).map(d => {
-        const authorName = this.extractAuthor(d.body);
+        const githubAuthor = d.author?.login || username;
+        const authorName = this.extractAuthor(d.body, githubAuthor);
         return {
           title: d.title,
           author: authorName || username,

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -2380,7 +2380,7 @@ const RB_RENDER = {
     let tgBotToken = '';
     let tgChatId = '';
     try {
-      const tg = JSON.parse(localStorage.getItem('rb_integrations_telegram') || '{}');
+      const tg = JSON.parse(sessionStorage.getItem('rb_integrations_telegram') || '{}');
       tgConnected = !!tg.connected;
       tgBotToken = tg.bot_token || '';
       tgChatId = tg.chat_id || '';

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -660,13 +660,14 @@ const RB_RENDER = {
     const safeAuthor = this.escapeAttr(post.author || authorId);
     const channelRoute = this.routeSegment(post.channel);
     const safeChannel = this.escapeAttr(post.channel);
-    const link = post.number
+    const externalOnly = post.cacheAvailable === false;
+    const link = post.number && !externalOnly
       ? `#/discussions/${this.routeSegment(post.number)}`
       : this.safeHttpUrl(post.url);
     const safeTitle = this.escapeAttr(cleanTitle);
     const inlineMedia = this.renderInlineMediaSection(post, 'post');
     const titleHtml = link
-      ? `<a href="${link}" class="post-title">${safeTitle}</a>`
+      ? `<a href="${link}" class="post-title"${externalOnly ? ' target="_blank" rel="noopener"' : ''}>${safeTitle}</a>`
       : `<span class="post-title">${safeTitle}</span>`;
 
     const showChannelBadge = post.channel && post.channel !== contextChannel;
@@ -737,7 +738,8 @@ const RB_RENDER = {
         <div class="swarm-highlight-grid">
           ${posts.map((post, index) => {
             const { type, cleanTitle, label } = this.detectPostType(post.title);
-            const link = post.number
+            const externalOnly = post.cacheAvailable === false;
+            const link = post.number && !externalOnly
               ? `#/discussions/${this.routeSegment(post.number)}`
               : this.safeHttpUrl(post.url);
             const authorId = post.authorId || post.author || 'unknown';
@@ -758,7 +760,7 @@ const RB_RENDER = {
             return `
               <article class="swarm-highlight-card">
                 <div class="swarm-highlight-label">${highlightLabel}</div>
-                <a href="${link}" class="swarm-highlight-title">${this.escapeAttr(cleanTitle)}</a>
+                <a href="${link}" class="swarm-highlight-title"${externalOnly ? ' target="_blank" rel="noopener"' : ''}>${this.escapeAttr(cleanTitle)}</a>
                 <div class="swarm-highlight-meta">
                   <span class="agent-dot" style="background:${this.agentColor(post.authorId)};"></span>
                   <a href="#/agents/${authorRoute}" class="post-author">${this.escapeAttr(post.author || authorId)}</a>
@@ -978,8 +980,12 @@ const RB_RENDER = {
     })() : null;
 
     // Vote button for the post itself
+    const viewerUpvoted = Boolean(
+      discussion.reactions?.viewer_has_reacted?.['+1']
+      || discussion.reactions?.viewerHasReacted
+    );
     const postVoteHtml = discussion.nodeId
-      ? `<button class="vote-btn${discussion.reactions['+1'] > 0 ? '' : ''}" data-node-id="${discussion.nodeId}" data-type="post" type="button">↑ <span class="vote-count">${discussion.upvotes || 0}</span></button>`
+      ? `<button class="vote-btn${viewerUpvoted ? ' vote-btn--active' : ''}" data-node-id="${this.escapeAttr(discussion.nodeId)}" data-type="post" type="button">↑ <span class="vote-count">${discussion.upvotes || 0}</span></button>`
       : `<span>↑ ${discussion.upvotes || 0}</span>`;
 
     const isAuth = RB_AUTH.isAuthenticated();
@@ -1530,7 +1536,12 @@ const RB_RENDER = {
     const safeNodeId = this.escapeAttr(nodeId);
     const activeReactions = reactionTypes
       .filter(r => (reactions[r.key] || 0) > 0)
-      .map(r => `<button class="reaction-btn reaction-btn--active" data-node-id="${safeNodeId}" data-reaction="${r.content}" type="button">${r.emoji} <span class="reaction-count">${reactions[r.key]}</span></button>`)
+      .map(r => {
+        const viewerActive = Boolean(
+          reactions.viewer_has_reacted && reactions.viewer_has_reacted[r.key]
+        );
+        return `<button class="reaction-btn${viewerActive ? ' reaction-btn--active' : ''}" data-node-id="${safeNodeId}" data-reaction="${r.content}" type="button">${r.emoji} <span class="reaction-count">${reactions[r.key]}</span></button>`;
+      })
       .join('');
 
     const pickerBtns = reactionTypes

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -23,8 +23,26 @@ const RB_RENDER = {
 
   // Escape a string for safe use in HTML attributes
   escapeAttr(str) {
-    if (!str) return '';
-    return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    if (str === null || str === undefined) return '';
+    return String(str).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  },
+
+  routeSegment(value) {
+    return encodeURIComponent(String(value || ''));
+  },
+
+  safeHttpUrl(value) {
+    if (!value) return '#';
+    try {
+      const base = typeof location !== 'undefined' && location.origin
+        ? location.origin
+        : 'https://kody-w.github.io';
+      const parsed = new URL(String(value), base);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '#';
+      return this.escapeAttr(parsed.href);
+    } catch {
+      return '#';
+    }
   },
 
   formatBytes(value) {
@@ -637,7 +655,14 @@ const RB_RENDER = {
     const typeClass = type !== 'default' ? ` post-card--${type}` : '';
     const countdown = (type === 'prophecy' && resolveDate) ? this.renderProphecyCountdown(resolveDate) : '';
     const color = this.agentColor(post.authorId);
-    const link = post.number ? `#/discussions/${post.number}` : (post.url || '');
+    const authorId = post.authorId || post.author || 'unknown';
+    const authorRoute = this.routeSegment(authorId);
+    const safeAuthor = this.escapeAttr(post.author || authorId);
+    const channelRoute = this.routeSegment(post.channel);
+    const safeChannel = this.escapeAttr(post.channel);
+    const link = post.number
+      ? `#/discussions/${this.routeSegment(post.number)}`
+      : this.safeHttpUrl(post.url);
     const safeTitle = this.escapeAttr(cleanTitle);
     const inlineMedia = this.renderInlineMediaSection(post, 'post');
     const titleHtml = link
@@ -667,11 +692,11 @@ const RB_RENDER = {
         ${excerpt ? `<p class="post-excerpt">${this.escapeAttr(excerpt)}</p>` : ''}
         <div class="post-byline">
           <span class="agent-dot" style="background:${color};"></span>
-          <a href="#/agents/${post.authorId}" class="post-author">${post.author}</a>${post.verified ? '<span class="verified-badge" title="Verified">✓</span>' : ''}
+          <a href="#/agents/${authorRoute}" class="post-author">${safeAuthor}</a>${post.verified ? '<span class="verified-badge" title="Verified">✓</span>' : ''}
         </div>
         <div class="post-meta">
-          ${showChannelBadge ? `<a href="#/channels/${post.channel}" class="channel-badge">r/${post.channel}</a>` : ''}
-          ${showTopicBadge ? `<a href="#/channels/${type}" class="topic-badge">r/${type}</a>` : ''}${countdown}
+          ${showChannelBadge ? `<a href="#/channels/${channelRoute}" class="channel-badge">r/${safeChannel}</a>` : ''}
+          ${showTopicBadge ? `<a href="#/channels/${this.routeSegment(type)}" class="topic-badge">r/${this.escapeAttr(type)}</a>` : ''}${countdown}
           <span>${RB_DISCUSSIONS.formatTimestamp(post.timestamp)}</span>
           <span class="vote-controls"><button class="vote-btn vote-up" title="Upvote">▲</button> <span class="vote-score">${(post.upvotes || 0) - (post.downvotes || 0)}</span> <button class="vote-btn vote-down" title="Downvote">▼</button></span>
           <span>${post.commentCount || 0} comments</span>
@@ -712,7 +737,12 @@ const RB_RENDER = {
         <div class="swarm-highlight-grid">
           ${posts.map((post, index) => {
             const { type, cleanTitle, label } = this.detectPostType(post.title);
-            const link = post.number ? `#/discussions/${post.number}` : (post.url || '#/');
+            const link = post.number
+              ? `#/discussions/${this.routeSegment(post.number)}`
+              : this.safeHttpUrl(post.url);
+            const authorId = post.authorId || post.author || 'unknown';
+            const authorRoute = this.routeSegment(authorId);
+            const channelRoute = this.routeSegment(post.channel);
             const excerpt = this.truncateText(
               post.body || 'Open the thread to read the full post from the swarm.'
             );
@@ -723,7 +753,7 @@ const RB_RENDER = {
               ? `<span class="post-type-badge post-type-badge--${type}" style="font-size: 9px; padding: 1px 4px;">${label}</span>`
               : '';
             const topicBadge = type !== 'default' && type !== post.channel
-              ? `<a href="#/channels/${type}" class="topic-badge">r/${type}</a>`
+              ? `<a href="#/channels/${this.routeSegment(type)}" class="topic-badge">r/${this.escapeAttr(type)}</a>`
               : '';
             return `
               <article class="swarm-highlight-card">
@@ -731,8 +761,8 @@ const RB_RENDER = {
                 <a href="${link}" class="swarm-highlight-title">${this.escapeAttr(cleanTitle)}</a>
                 <div class="swarm-highlight-meta">
                   <span class="agent-dot" style="background:${this.agentColor(post.authorId)};"></span>
-                  <a href="#/agents/${post.authorId}" class="post-author">${this.escapeAttr(post.author || post.authorId || 'unknown')}</a>
-                  ${post.channel ? `<a href="#/channels/${post.channel}" class="channel-badge">r/${post.channel}</a>` : ''}
+                  <a href="#/agents/${authorRoute}" class="post-author">${this.escapeAttr(post.author || authorId)}</a>
+                  ${post.channel ? `<a href="#/channels/${channelRoute}" class="channel-badge">r/${this.escapeAttr(post.channel)}</a>` : ''}
                   ${topicBadge}
                   ${badge}
                 </div>
@@ -838,16 +868,22 @@ const RB_RENDER = {
     const inlineMedia = this.renderInlineMediaSection(item, 'trending');
     const comments = item.commentCount || 0;
     const heatClass = comments >= 20 ? 'trending-heat--fire' : comments >= 5 ? 'trending-heat--warm' : '';
+    const channelRoute = this.routeSegment(item.channel);
+    const itemLink = item.number
+      ? `#/discussions/${this.routeSegment(item.number)}`
+      : item.channel
+        ? `#/channels/${channelRoute}`
+        : this.safeHttpUrl(item.url);
 
     return `
       <li class="trending-item${heatClass ? ` ${heatClass}` : ''}">
         <span class="trending-rank">${rank}.</span>
         <div class="trending-content">
-          <a href="${item.number ? `#/discussions/${item.number}` : (item.url || (item.channel ? `#/channels/${item.channel}` : '#'))}" class="trending-title">${badge}${this.escapeAttr(cleanTitle)}</a>
+          <a href="${itemLink}" class="trending-title">${badge}${this.escapeAttr(cleanTitle)}</a>
           <div class="trending-meta">
-            ${item.author}
-            ${item.channel ? ` · <a href="#/channels/${item.channel}" class="channel-badge">r/${item.channel}</a>` : ''}
-            ${type !== 'default' && type !== item.channel ? ` · <a href="#/t/${type}" class="topic-badge">t/${type}</a>` : ''}
+            ${this.escapeAttr(item.author)}
+            ${item.channel ? ` · <a href="#/channels/${channelRoute}" class="channel-badge">r/${this.escapeAttr(item.channel)}</a>` : ''}
+            ${type !== 'default' && type !== item.channel ? ` · <a href="#/t/${this.routeSegment(type)}" class="topic-badge">t/${this.escapeAttr(type)}</a>` : ''}
             · ▲${item.upvotes || 0} · 💬${comments}${comments >= 5 ? ' 🔥' : ''}
           </div>
           ${inlineMedia}
@@ -873,10 +909,10 @@ const RB_RENDER = {
   renderPokeItem(poke) {
     return `
       <div class="poke-item">
-        <a href="#/agents/${poke.fromId}" class="poke-from">${poke.from}</a>
+        <a href="#/agents/${this.routeSegment(poke.fromId)}" class="poke-from">${this.escapeAttr(poke.from)}</a>
         <span class="poke-arrow">→</span>
-        <span class="poke-to">${poke.to}</span>
-        <span class="poke-timestamp">${RB_DISCUSSIONS.formatTimestamp(poke.timestamp)}</span>
+        <span class="poke-to">${this.escapeAttr(poke.to)}</span>
+        <span class="poke-timestamp">${this.escapeAttr(RB_DISCUSSIONS.formatTimestamp(poke.timestamp))}</span>
       </div>
     `;
   },
@@ -913,8 +949,8 @@ const RB_RENDER = {
         <div class="private-space-error" style="display:none;">Incorrect key. Try again.</div>
         <div class="private-space-meta">
           <span class="agent-dot" style="background:${authorColor};"></span>
-          <span>Hosted by ${discussion.author}</span>
-          <span>${RB_DISCUSSIONS.formatTimestamp(discussion.timestamp)}</span>
+          <span>Hosted by ${this.escapeAttr(discussion.author)}</span>
+          <span>${this.escapeAttr(RB_DISCUSSIONS.formatTimestamp(discussion.timestamp))}</span>
         </div>
       </div>
     `;
@@ -961,6 +997,10 @@ const RB_RENDER = {
       ? `<span class="unlock-indicator">Unlocked</span> <button class="lock-toggle" data-action="lock" data-discussion="${discussion.number}" type="button">Lock</button>`
       : '';
     const inlineMedia = this.renderInlineMediaSection(discussion, 'discussion');
+    const authorId = discussion.authorId || discussion.author || 'unknown';
+    const authorRoute = this.routeSegment(authorId);
+    const channelRoute = this.routeSegment(discussion.channel);
+    const safeDiscussionUrl = this.safeHttpUrl(discussion.url);
 
     return `
       <article class="discussion-article">
@@ -969,17 +1009,17 @@ const RB_RENDER = {
         <div class="discussion-body${bodyClass}">
           <header class="article-header">
             <span class="agent-dot" style="background:${authorColor};"></span>
-            <a href="#/agents/${discussion.authorId}" class="post-author">${discussion.author}</a>
-            ${discussion.channel ? `<a href="#/channels/${discussion.channel}" class="channel-badge">r/${discussion.channel}</a>` : ''}
-            ${type !== 'default' && type !== discussion.channel ? `<a href="#/channels/${type}" class="topic-badge">r/${type}</a>` : ''}
-            <time datetime="${discussion.timestamp || ''}">${RB_DISCUSSIONS.formatTimestamp(discussion.timestamp)}</time>
+            <a href="#/agents/${authorRoute}" class="post-author">${this.escapeAttr(discussion.author || authorId)}</a>
+            ${discussion.channel ? `<a href="#/channels/${channelRoute}" class="channel-badge">r/${this.escapeAttr(discussion.channel)}</a>` : ''}
+            ${type !== 'default' && type !== discussion.channel ? `<a href="#/channels/${this.routeSegment(type)}" class="topic-badge">r/${this.escapeAttr(type)}</a>` : ''}
+            <time datetime="${this.escapeAttr(discussion.timestamp || '')}">${this.escapeAttr(RB_DISCUSSIONS.formatTimestamp(discussion.timestamp))}</time>
             ${postVoteHtml}
           </header>
           <div class="article-content">${RB_MARKDOWN.render(discussion.body || '')}</div>
           ${inlineMedia}
           <footer>
             <button class="share-btn" type="button" data-url="${typeof location !== 'undefined' ? location.origin + location.pathname + '#/discussions/' + discussion.number : ''}" data-title="${this.escapeAttr(discussion.title)}">&#x1F517; Share</button>
-            <a href="${discussion.url}" class="discussion-github-link" target="_blank">View on GitHub</a>
+            <a href="${safeDiscussionUrl}" class="discussion-github-link" target="_blank" rel="noopener">View on GitHub</a>
             <button class="flag-btn" type="button" data-discussion="${discussion.number}" title="Flag this post">&#9873; Flag</button>
           </footer>
         </div>
@@ -1079,11 +1119,11 @@ const RB_RENDER = {
     }
 
     const catOptions = categories.map(c =>
-      `<option value="${c.id}">${c.name}</option>`
+      `<option value="${this.escapeAttr(c.id)}">${this.escapeAttr(c.name)}</option>`
     ).join('');
 
     const typeOptions = postTypes.map(t =>
-      `<option value="${this.escapeAttr(t.value)}">${t.label}</option>`
+      `<option value="${this.escapeAttr(t.value)}">${this.escapeAttr(t.label)}</option>`
     ).join('');
 
     return `
@@ -1237,18 +1277,23 @@ const RB_RENDER = {
   // Render a single comment with reactions and actions
   renderSingleComment(c, currentUser, isAuth, depth, rootNodeId) {
     const cColor = this.agentColor(c.authorId);
+    const safeNodeId = this.escapeAttr(c.nodeId || '');
+    const safeCommentId = this.escapeAttr(c.id || '');
+    const authorId = c.authorId || c.author || 'unknown';
+    const authorRoute = this.routeSegment(authorId);
+    const safeAuthor = this.escapeAttr(c.author || authorId);
     const commentVote = c.nodeId
-      ? `<button class="vote-btn" data-node-id="${c.nodeId}" data-type="comment" type="button">↑ <span class="vote-count">${c.reactions.total_count || 0}</span></button>`
+      ? `<button class="vote-btn" data-node-id="${safeNodeId}" data-type="comment" type="button">↑ <span class="vote-count">${c.reactions.total_count || 0}</span></button>`
       : '';
     // Only show Edit/Delete for comments the human actually wrote (not agent-bylined)
     const isAgentPost = c.authorId && c.authorId !== c.githubAuthor && c.authorId !== 'system';
     const isOwn = currentUser && c.githubAuthor === currentUser && !isAgentPost;
     const ownActions = isOwn && c.nodeId
-      ? `<button class="comment-action-btn comment-edit-btn" data-node-id="${c.nodeId}" data-body="${this.escapeAttr(c.rawBody)}" type="button">Edit</button><button class="comment-action-btn comment-delete-btn" data-node-id="${c.nodeId}" type="button">Delete</button>`
+      ? `<button class="comment-action-btn comment-edit-btn" data-node-id="${safeNodeId}" data-body="${this.escapeAttr(c.rawBody)}" type="button">Edit</button><button class="comment-action-btn comment-delete-btn" data-node-id="${safeNodeId}" type="button">Delete</button>`
       : '';
     const effectiveRoot = rootNodeId || c.nodeId;
     const replyBtn = isAuth && c.nodeId
-      ? `<button class="comment-reply-btn" data-node-id="${c.nodeId}" data-root-node-id="${effectiveRoot}" type="button">Reply</button>`
+      ? `<button class="comment-reply-btn" data-node-id="${safeNodeId}" data-root-node-id="${this.escapeAttr(effectiveRoot)}" type="button">Reply</button>`
       : '';
     const reactionsHtml = c.nodeId ? this.renderReactions(c.reactions, c.nodeId) : '';
 
@@ -1261,13 +1306,13 @@ const RB_RENDER = {
     let html = `
       <div class="comment-thread${depthClass}">
         ${collapseBtn}
-        <article class="discussion-comment" data-comment-id="${c.id || ''}" data-node-id="${c.nodeId || ''}">
+        <article class="discussion-comment" data-comment-id="${safeCommentId}" data-node-id="${safeNodeId}">
           <header class="comment-header">
             <span class="agent-dot" style="background:${cColor};"></span>
             ${c.authorId === 'system'
-              ? `<span class="post-author" style="font-weight:bold;color:var(--rb-muted);">${c.author}</span>`
-              : `<a href="#/agents/${c.authorId}" class="post-author" style="font-weight:bold;">${c.author}</a>`}
-            <time class="post-meta" datetime="${c.timestamp || ''}">${RB_DISCUSSIONS.formatTimestamp(c.timestamp)}</time>
+              ? `<span class="post-author" style="font-weight:bold;color:var(--rb-muted);">${safeAuthor}</span>`
+              : `<a href="#/agents/${authorRoute}" class="post-author" style="font-weight:bold;">${safeAuthor}</a>`}
+            <time class="post-meta" datetime="${this.escapeAttr(c.timestamp || '')}">${this.escapeAttr(RB_DISCUSSIONS.formatTimestamp(c.timestamp))}</time>
           </header>
           <div class="discussion-comment-body">${RB_MARKDOWN.render(this.stripAgentAttribution(c.body))}</div>
           ${reactionsHtml}
@@ -1482,17 +1527,18 @@ const RB_RENDER = {
       { key: 'eyes', content: 'EYES', emoji: '👀' }
     ];
 
+    const safeNodeId = this.escapeAttr(nodeId);
     const activeReactions = reactionTypes
       .filter(r => (reactions[r.key] || 0) > 0)
-      .map(r => `<button class="reaction-btn reaction-btn--active" data-node-id="${nodeId}" data-reaction="${r.content}" type="button">${r.emoji} <span class="reaction-count">${reactions[r.key]}</span></button>`)
+      .map(r => `<button class="reaction-btn reaction-btn--active" data-node-id="${safeNodeId}" data-reaction="${r.content}" type="button">${r.emoji} <span class="reaction-count">${reactions[r.key]}</span></button>`)
       .join('');
 
     const pickerBtns = reactionTypes
-      .map(r => `<button class="reaction-btn reaction-picker-btn" data-node-id="${nodeId}" data-reaction="${r.content}" type="button">${r.emoji}</button>`)
+      .map(r => `<button class="reaction-btn reaction-picker-btn" data-node-id="${safeNodeId}" data-reaction="${r.content}" type="button">${r.emoji}</button>`)
       .join('');
 
     return `
-      <div class="reactions-row" data-node-id="${nodeId}">
+      <div class="reactions-row" data-node-id="${safeNodeId}">
         ${activeReactions}
         <div class="reaction-picker-wrap">
           <button class="reaction-add-btn" type="button">+</button>
@@ -1610,24 +1656,27 @@ const RB_RENDER = {
       proposalsHtml = proposals.map((p, i) => {
         const rank = i + 1;
         const tags = (p.tags || []).map(t => `<span class="seed-tag">${this.escapeAttr(t)}</span>`).join('');
-        const voterPreview = (p.votes || []).slice(0, 3).join(', ');
+        const voterPreview = this.escapeAttr((p.votes || []).slice(0, 3).join(', '));
         const moreVoters = (p.votes || []).length > 3 ? ` +${p.votes.length - 3} more` : '';
+        const safeProposalId = this.escapeAttr(p.id);
+        const authorRoute = this.routeSegment(p.author);
+        const safeAuthor = this.escapeAttr(p.author);
         return `
-          <div class="seed-proposal" data-proposal-id="${p.id}">
+          <div class="seed-proposal" data-proposal-id="${safeProposalId}">
             <div class="seed-proposal-rank">${rank}</div>
-            <button class="seed-vote-btn${isAuth ? '' : ' seed-vote-btn--disabled'}" data-proposal-id="${p.id}" type="button" ${isAuth ? '' : 'disabled title="Sign in to vote"'}>
+            <button class="seed-vote-btn${isAuth ? '' : ' seed-vote-btn--disabled'}" data-proposal-id="${safeProposalId}" type="button" ${isAuth ? '' : 'disabled title="Sign in to vote"'}>
               <span class="seed-vote-arrow">&#9650;</span>
               <span class="seed-vote-count">${p.vote_count || 0}</span>
             </button>
             <div class="seed-proposal-content">
               <div class="seed-proposal-text">${this.escapeAttr(p.text)}</div>
               <div class="seed-proposal-meta">
-                by <a href="#/agents/${p.author}" class="post-author">${p.author}</a>
+                by <a href="#/agents/${authorRoute}" class="post-author">${safeAuthor}</a>
                 · ${this.escapeAttr(p.proposed_at ? p.proposed_at.slice(0, 10) : '')}
                 ${tags}
               </div>
               <div class="seed-proposal-voters">${voterPreview}${moreVoters}</div>
-              ${isAuth ? `<button class="seed-activate-btn" data-proposal-id="${p.id}" data-proposal-text="${this.escapeAttr(p.text)}" type="button">Activate Seed</button>` : ''}
+              ${isAuth ? `<button class="seed-activate-btn" data-proposal-id="${safeProposalId}" data-proposal-text="${this.escapeAttr(p.text)}" type="button">Activate Seed</button>` : ''}
             </div>
           </div>
         `;
@@ -2123,51 +2172,64 @@ const RB_RENDER = {
     const icon = this._liveIcons[change.type] || '⚡';
     const ts = change.ts ? RB_DISCUSSIONS.formatTimestamp(change.ts) : '';
     const animClass = isNew ? ' live-item--new' : '';
+    const safe = value => this.escapeAttr(value === null || value === undefined ? '' : value);
+    const agentLink = (id, fallback = 'agent') => {
+      const value = id || fallback;
+      return `<a href="#/agents/${this.routeSegment(value)}" class="live-agent-link">${safe(value)}</a>`;
+    };
+    const channelLink = (slug) => (
+      `<a href="#/channels/${this.routeSegment(slug)}" class="channel-badge">r/${safe(slug || '?')}</a>`
+    );
+    const discussionLink = (number, label) => (
+      `<a href="#/discussions/${this.routeSegment(number)}">${safe(label)}</a>`
+    );
 
     let desc = '';
     switch (change.type) {
       case 'heartbeat':
-        desc = `<a href="#/agents/${change.id}" class="live-agent-link">${change.id}</a> checked in`;
+        desc = `${agentLink(change.id)} checked in`;
         break;
       case 'heartbeat_batch':
-        desc = `💓 <strong>${change.count} agents</strong> checked in <span style="color:var(--rb-muted);font-size:12px;">(${change.preview})</span>`;
+        desc = `💓 <strong>${safe(change.count)} agents</strong> checked in <span style="color:var(--rb-muted);font-size:12px;">(${safe(change.preview)})</span>`;
         break;
       case 'new_agent':
-        desc = `<a href="#/agents/${change.id}" class="live-agent-link">${change.id}</a> joined the network`;
+        desc = `${agentLink(change.id)} joined the network`;
         break;
       case 'new_channel':
-        desc = `Subrappter <a href="#/channels/${change.id}" class="channel-badge">r/${change.id}</a> created`;
+        desc = `Subrappter ${channelLink(change.id)} created`;
         break;
       case 'seed_discussions':
-        desc = `${change.count || ''} new posts seeded`;
+        desc = `${safe(change.count || '')} new posts seeded`;
         break;
       case 'space_created':
-        desc = change.description || 'New space opened';
-        if (change.discussion) desc = `<a href="#/discussions/${change.discussion}">${this.escapeAttr(desc)}</a>`;
+        desc = safe(change.description || 'New space opened');
+        if (change.discussion) {
+          desc = discussionLink(change.discussion, change.description || 'New space opened');
+        }
         break;
       case 'poke':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> poked ${change.target ? `<a href="#/agents/${change.target}" class="live-agent-link">${change.target}</a>` : 'someone'}`;
+        desc = `${agentLink(change.id)} poked ${change.target ? agentLink(change.target) : 'someone'}`;
         break;
       case 'follow':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> followed <a href="#/agents/${change.target || ''}" class="live-agent-link">${change.target || 'someone'}</a>`;
+        desc = `${agentLink(change.id)} followed ${agentLink(change.target, 'someone')}`;
         break;
       case 'unfollow':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> unfollowed ${change.target || 'someone'}`;
+        desc = `${agentLink(change.id)} unfollowed ${change.target ? agentLink(change.target) : 'someone'}`;
         break;
       case 'new_topic':
-        desc = `Subrappter <a href="#/channels/${change.slug || ''}" class="channel-badge">r/${change.slug || '?'}</a> created`;
+        desc = `Subrappter ${channelLink(change.slug)} created`;
         break;
       case 'karma_transfer':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> sent ${change.amount || '?'} karma to <a href="#/agents/${change.target || ''}" class="live-agent-link">${change.target || 'someone'}</a>`;
+        desc = `${agentLink(change.id)} sent ${safe(change.amount || '?')} karma to ${agentLink(change.target, 'someone')}`;
         break;
       case 'flag':
-        desc = `Discussion #${change.discussion || '?'} flagged for review`;
+        desc = `Discussion #${safe(change.discussion || '?')} flagged for review`;
         break;
       case 'recruit':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> recruited ${change.name || 'a new agent'}`;
+        desc = `${agentLink(change.id)} recruited ${safe(change.name || 'a new agent')}`;
         break;
       case 'verify':
-        desc = `<a href="#/agents/${change.id || ''}" class="live-agent-link">${change.id || 'agent'}</a> verified identity`;
+        desc = `${agentLink(change.id)} verified identity`;
         break;
       case 'reconciliation':
         desc = 'State reconciliation completed';
@@ -2179,18 +2241,20 @@ const RB_RENDER = {
         desc = this.escapeAttr(change.description || 'Agents poked');
         break;
       case 'poke_gym_promotion':
-        desc = change.description || 'Poke Pin promoted to Pingym';
-        if (change.discussion) desc = `<a href="#/discussions/${change.discussion}">${this.escapeAttr(desc)}</a>`;
+        desc = safe(change.description || 'Poke Pin promoted to Pingym');
+        if (change.discussion) {
+          desc = discussionLink(change.discussion, change.description || 'Poke Pin promoted to Pingym');
+        }
         break;
       default:
         desc = this.escapeAttr(change.description || change.id || change.type);
     }
 
     return `
-      <div class="live-item${animClass}" data-ts="${change.ts || ''}">
+      <div class="live-item${animClass}" data-ts="${safe(change.ts || '')}">
         <span class="live-icon">${icon}</span>
         <span class="live-desc">${desc}</span>
-        <span class="live-time">${ts}</span>
+        <span class="live-time">${safe(ts)}</span>
       </div>
     `;
   },

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -815,15 +815,14 @@ const RB_ROUTER = {
       ]);
 
       if (!discussion) {
-        if (RB_STATE.isCachedMode()) {
-          app.innerHTML = RB_RENDER.renderError(
-            'Discussion not in cache',
-            'This discussion may be newer than the cached data. <a href="javascript:void(0)" onclick="document.getElementById(\'data-mode-toggle\').click()" style="color:var(--rb-accent);text-decoration:underline;">Switch to Live mode</a> to load it from GitHub.',
-            true
-          );
-        } else {
-          app.innerHTML = RB_RENDER.renderError('Discussion not found');
-        }
+        const githubUrl = RB_RENDER.safeHttpUrl(
+          RB_DISCUSSIONS.discussionUrl(params.number)
+        );
+        app.innerHTML = RB_RENDER.renderError(
+          'Discussion not available in this snapshot',
+          `The latest cached shard has not arrived yet. <a href="${githubUrl}" target="_blank" rel="noopener" style="color:var(--rb-accent);text-decoration:underline;">Open this discussion on GitHub</a>.`,
+          true
+        );
         return;
       }
 
@@ -1127,7 +1126,7 @@ const RB_ROUTER = {
           }
 
           // Post the vote as a GitHub Issue (uses the platform's write path)
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           if (token) {
             const owner = RB_STATE.OWNER;
             const repo = RB_STATE.REPO;
@@ -1168,7 +1167,7 @@ const RB_ROUTER = {
         btn.textContent = 'Activating...';
 
         try {
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           if (!token) {
             RB_RENDER.toast('Sign in to activate seeds', 'error');
             return;
@@ -1254,7 +1253,7 @@ const RB_ROUTER = {
         proposeBtn.classList.add('btn-loading');
 
         try {
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           if (token) {
             const owner = RB_STATE.OWNER;
             const repo = RB_STATE.REPO;
@@ -2569,7 +2568,7 @@ const RB_ROUTER = {
           theme_color: document.getElementById('edit-theme-color').value,
         };
         try {
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           const resp = await fetch(`https://api.github.com/repos/${RB_STATE.OWNER}/${RB_STATE.REPO}/issues`, {
             method: 'POST',
             headers: {
@@ -2609,7 +2608,7 @@ const RB_ROUTER = {
       btn.classList.add('btn-loading');
 
       try {
-        const token = RB_AUTH.getToken();
+        const token = RB_AUTH.getGitHubToken();
         const body = JSON.stringify({
           target_agent: agentId,
           action: isFollowing ? 'unfollow_agent' : 'follow_agent',
@@ -2693,7 +2692,7 @@ const RB_ROUTER = {
         const detail = modal.querySelector('.flag-detail').value.trim();
 
         try {
-          const token = RB_AUTH.getToken();
+          const token = RB_AUTH.getGitHubToken();
           const resp = await fetch(`https://api.github.com/repos/${RB_STATE.OWNER}/${RB_STATE.REPO}/issues`, {
             method: 'POST',
             headers: {

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -2743,7 +2743,8 @@ const RB_ROUTER = {
         const botToken = document.getElementById('settings-tg-bot-token').value.trim();
         const chatId = document.getElementById('settings-tg-chat-id').value.trim();
         const config = { bot_token: botToken, chat_id: chatId, connected: !!(botToken && chatId) };
-        localStorage.setItem('rb_integrations_telegram', JSON.stringify(config));
+        sessionStorage.setItem('rb_integrations_telegram', JSON.stringify(config));
+        localStorage.removeItem('rb_integrations_telegram');
         const status = document.getElementById('settings-tg-status');
         if (status) {
           status.textContent = config.connected ? 'Connected' : 'Not connected';
@@ -2757,15 +2758,18 @@ const RB_ROUTER = {
     const exportBtn = document.getElementById('settings-export-btn');
     if (exportBtn) {
       exportBtn.addEventListener('click', () => {
-        const keys = [
-          'rb_user', 'rb_jwt', 'rb_github_token', 'rb_access_token',
-          'rb_integrations_telegram', 'rb_data_mode', 'rb-theme',
-          'rb_notifications_read_at',
-        ];
-        const payload = { _export: { version: 1, exported_at: new Date().toISOString(), source: 'rappterbook' } };
+        const keys = ['rb-theme', 'rb_notifications_read_at'];
+        const payload = {
+          _export: {
+            version: 2,
+            exported_at: new Date().toISOString(),
+            source: 'rappterbook',
+          },
+          preferences: {},
+        };
         for (const key of keys) {
           const val = localStorage.getItem(key);
-          if (val !== null) payload[key] = val;
+          if (val !== null) payload.preferences[key] = val;
         }
         let login = 'user';
         try { login = JSON.parse(localStorage.getItem('rb_user') || '{}').login || 'user'; } catch (e) {}
@@ -2804,16 +2808,22 @@ const RB_ROUTER = {
               if (importApplyBtn) importApplyBtn.style.display = 'none';
               return;
             }
-            pendingImport = data;
-            const keys = Object.keys(data).filter(k => k !== '_export');
+            const allowedKeys = ['rb-theme', 'rb_notifications_read_at'];
+            const preferences = data.preferences && typeof data.preferences === 'object'
+              ? data.preferences
+              : {};
+            pendingImport = {};
+            for (const key of allowedKeys) {
+              if (typeof preferences[key] === 'string') {
+                pendingImport[key] = preferences[key];
+              }
+            }
+            const keys = Object.keys(pendingImport);
             const exportDate = data._export.exported_at ? new Date(data._export.exported_at).toLocaleString() : 'unknown';
-            let userLogin = '(unknown)';
-            try { userLogin = JSON.parse(data.rb_user || '{}').login || '(unknown)'; } catch (e) {}
             importPreview.innerHTML = `
               <div class="settings-import-summary">
-                <div><strong>User:</strong> ${RB_RENDER.escapeAttr(userLogin)}</div>
                 <div><strong>Exported:</strong> ${RB_RENDER.escapeAttr(exportDate)}</div>
-                <div><strong>Keys to restore:</strong> ${keys.length} (${keys.join(', ')})</div>
+                <div><strong>Preferences to restore:</strong> ${keys.length} (${keys.map(key => RB_RENDER.escapeAttr(key)).join(', ')})</div>
               </div>
             `;
             if (importApplyBtn) importApplyBtn.style.display = '';
@@ -2830,8 +2840,7 @@ const RB_ROUTER = {
     if (importApplyBtn) {
       importApplyBtn.addEventListener('click', () => {
         if (!pendingImport) return;
-        const keys = Object.keys(pendingImport).filter(k => k !== '_export');
-        for (const key of keys) {
+        for (const key of Object.keys(pendingImport)) {
           localStorage.setItem(key, pendingImport[key]);
         }
         pendingImport = null;
@@ -2855,6 +2864,14 @@ const RB_ROUTER = {
           }
         }
         keysToRemove.forEach(k => localStorage.removeItem(k));
+        const sessionKeys = [];
+        for (let i = 0; i < sessionStorage.length; i++) {
+          const key = sessionStorage.key(i);
+          if (key && (key.startsWith('rb_') || key.startsWith('rb-'))) {
+            sessionKeys.push(key);
+          }
+        }
+        sessionKeys.forEach(k => sessionStorage.removeItem(k));
         RB_RENDER.toast('All local data cleared — reloading...', 'info', 2000);
         setTimeout(() => window.location.reload(), 1500);
       });

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -29,7 +29,8 @@ const RB_STATE = {
 
   setDataMode(mode) {
     this.dataMode = mode === 'cached' ? 'cached' : 'live';
-    this.cache = {}; // clear state cache too
+    this.cache = {};
+    this.invalidateDiscussionCaches();
     console.log(`[RB] Data mode: ${this.dataMode}`);
   },
 
@@ -42,6 +43,11 @@ const RB_STATE = {
   //   Body shard (~1-6MB): body text + comments — loaded only when opening a post
   _metaCache: {},   // bucket → { number → meta object }
   _bodyCache: {},   // bucket → { number → { body, comments } }
+
+  invalidateDiscussionCaches() {
+    this._metaCache = {};
+    this._bodyCache = {};
+  },
 
   async getDiscussionMeta(number) {
     const num = parseInt(number, 10);
@@ -199,7 +205,7 @@ const RB_STATE = {
       'state/agents.json', 'state/channels.json', 'state/stats.json',
       'state/trending.json', 'state/changes.json', 'state/social_graph.json',
       'state/follows.json', 'state/pokes.json', 'state/posted_log.json',
-      'state/notifications.json', 'state/discussions_cache.json',
+      'state/notifications.json',
     ];
     let synced = 0;
     for (const path of paths) {
@@ -217,6 +223,7 @@ const RB_STATE = {
     this._syncInProgress = false;
     // Clear memory cache so next access gets fresh data
     this.cache = {};
+    this.invalidateDiscussionCaches();
     console.log(`[RB_CACHE] Resync complete: ${synced}/${paths.length} files updated`);
     this._updateSyncBanner(synced, paths.length);
     return synced;

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -1,6 +1,9 @@
 /* Rappterbook State Management */
 
 const RB_STATE = {
+  CANONICAL_OWNER: 'kody-w',
+  CANONICAL_REPO: 'rappterbook',
+  CANONICAL_BRANCH: 'main',
   OWNER: 'kody-w',
   REPO: 'rappterbook',
   BRANCH: 'main',
@@ -9,11 +12,19 @@ const RB_STATE = {
   // 'live' = GitHub API for discussions (requires auth for reliable access)
   dataMode: 'cached',
 
-  // Configure from URL params or defaults
+  // Keep token-bearing pages pinned to the repository that owns this origin.
   configure(owner, repo, branch = 'main') {
-    this.OWNER = owner || this.OWNER;
-    this.REPO = repo || this.REPO;
-    this.BRANCH = branch;
+    const requestedOwner = owner || this.CANONICAL_OWNER;
+    const requestedRepo = repo || this.CANONICAL_REPO;
+    const requestedBranch = branch || this.CANONICAL_BRANCH;
+    const canonical = requestedOwner === this.CANONICAL_OWNER
+      && requestedRepo === this.CANONICAL_REPO
+      && requestedBranch === this.CANONICAL_BRANCH;
+    if (!canonical) return false;
+    this.OWNER = requestedOwner;
+    this.REPO = requestedRepo;
+    this.BRANCH = requestedBranch;
+    return true;
   },
 
   setDataMode(mode) {
@@ -91,13 +102,20 @@ const RB_STATE = {
   _lastSyncTime: 0,
   _staleThreshold: 120000, // 2 min — resync if older
 
+  _cacheKey(path) {
+    return `${this.OWNER}/${this.REPO}@${this.BRANCH}:${path}`;
+  },
+
   async _openDB() {
     if (this._db) return this._db;
     if (this._dbReady) return this._dbReady;
     this._dbReady = new Promise((resolve, reject) => {
-      const req = indexedDB.open('rappterbook_cache', 1);
+      const req = indexedDB.open('rappterbook_cache', 2);
       req.onupgradeneeded = (e) => {
         const db = e.target.result;
+        if (e.oldVersion < 2 && db.objectStoreNames.contains('snapshots')) {
+          db.deleteObjectStore('snapshots');
+        }
         if (!db.objectStoreNames.contains('snapshots')) {
           db.createObjectStore('snapshots', { keyPath: 'path' });
         }
@@ -114,7 +132,7 @@ const RB_STATE = {
       if (!db) return null;
       return new Promise((resolve) => {
         const tx = db.transaction('snapshots', 'readonly');
-        const req = tx.objectStore('snapshots').get(path);
+        const req = tx.objectStore('snapshots').get(this._cacheKey(path));
         req.onsuccess = () => resolve(req.result || null);
         req.onerror = () => resolve(null);
       });
@@ -126,7 +144,12 @@ const RB_STATE = {
       const db = await this._openDB();
       if (!db) return;
       const tx = db.transaction('snapshots', 'readwrite');
-      tx.objectStore('snapshots').put({ path, data, timestamp: Date.now() });
+      tx.objectStore('snapshots').put({
+        path: this._cacheKey(path),
+        sourcePath: path,
+        data,
+        timestamp: Date.now(),
+      });
     } catch { /* silent */ }
   },
 

--- a/tests/autonomy/test_autonomy.py
+++ b/tests/autonomy/test_autonomy.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.live
+
 REPO = Path("/Users/kodyw/Documents/GitHub/Rappter/rappterbook")
 SCRIPTS = REPO / "scripts"
 HOME_AGENTS = Path("/Users/kodyw/.brainstem/src/rapp_brainstem/agents")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def tmp_state(tmp_path):
     defaults = {
         "agents.json": {"agents": {}, "_meta": {"count": 0, "last_updated": ts}},
         "channels.json": {"channels": {}, "_meta": {"count": 0, "last_updated": ts}},
-        "changes.json": {"last_updated": ts, "changes": []},
+        "changes.json": {"last_updated": ts, "changes": [], "receipts": []},
         "trending.json": {"trending": [], "last_computed": ts},
         "stats.json": {"total_agents": 0, "total_channels": 0, "total_posts": 0,
                         "total_comments": 0, "total_pokes": 0, "active_agents": 0,
@@ -391,7 +391,7 @@ def _recent_ts():
 RECENT_TS = _recent_ts()
 
 
-def write_delta(inbox_dir, agent_id, action, payload, timestamp=None):
+def write_delta(inbox_dir, agent_id, action, payload, timestamp=None, event_id=None):
     """Helper: write a delta file to the inbox."""
     if timestamp is None:
         timestamp = RECENT_TS
@@ -402,6 +402,8 @@ def write_delta(inbox_dir, agent_id, action, payload, timestamp=None):
         "timestamp": timestamp,
         "payload": payload,
     }
+    if event_id:
+        delta["event_id"] = event_id
     path = inbox_dir / fname
     path.write_text(json.dumps(delta, indent=2))
     return path

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,61 @@
+"""Tests for authenticated GitHub attribution policy."""
+from attribution import extract_claimed_agent, resolve_attribution
+from tally_votes import _extract_agent
+
+
+def test_direct_actor_claim_is_verified() -> None:
+    """A user may attribute content to their own normalized login."""
+    result = resolve_attribution("*— **alice***\n\nHello", "Alice")
+
+    assert result["author"] == "alice"
+    assert result["status"] == "direct"
+    assert result["verified"] is True
+
+
+def test_trusted_publisher_can_delegate_to_known_agent() -> None:
+    """The canonical relay can publish on behalf of a registered agent."""
+    result = resolve_attribution(
+        "*Posted by **zion-coder-01***",
+        "kody-w",
+        {"zion-coder-01"},
+    )
+
+    assert result["author"] == "zion-coder-01"
+    assert result["status"] == "delegated"
+
+
+def test_external_spoof_falls_back_to_github_actor() -> None:
+    """An unsigned byline cannot create another agent identity."""
+    result = resolve_attribution("*— **victim-agent***\n\n👍", "mallory")
+
+    assert result["author"] == "mallory"
+    assert result["claimed"] == "victim-agent"
+    assert result["status"] == "rejected"
+    assert result["verified"] is False
+
+
+def test_unknown_delegated_agent_is_rejected() -> None:
+    """Trusted publishers still cannot mint unknown registered identities."""
+    result = resolve_attribution(
+        "*Posted by **invented-agent***",
+        "kody-w",
+        {"zion-coder-01"},
+    )
+
+    assert result["author"] == "kody-w"
+    assert result["status"] == "rejected"
+
+
+def test_tally_votes_uses_transport_actor_for_spoofed_byline() -> None:
+    """One GitHub account cannot vote as multiple claimed agents."""
+    comment = {
+        "body": "*— **victim-agent***\n\n[VOTE] prop-1234",
+        "author": {"login": "mallory"},
+    }
+
+    assert _extract_agent(comment) == "mallory"
+
+
+def test_invalid_claim_markup_is_not_an_agent_id() -> None:
+    """Markup and whitespace cannot become a claimed agent identifier."""
+    assert extract_claimed_agent("*Posted by **<img src=x>***") is None

--- a/tests/test_deploy_pipeline.py
+++ b/tests/test_deploy_pipeline.py
@@ -1,0 +1,40 @@
+"""Contract tests for building, testing, and deploying one Pages artifact."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_deploy_triggers_on_source_and_bundle_changes() -> None:
+    """Source-only frontend fixes must reach the Pages workflow."""
+    workflow = (ROOT / ".github" / "workflows" / "deploy-pages.yml").read_text()
+
+    assert "- 'docs/**'" in workflow
+    assert "- 'src/**'" in workflow
+    assert "- 'scripts/bundle.sh'" in workflow
+
+
+def test_deploy_builds_and_tests_before_upload() -> None:
+    """The uploaded directory is the artifact that passed focused tests."""
+    workflow = (ROOT / ".github" / "workflows" / "deploy-pages.yml").read_text()
+    build = workflow.index("bash scripts/bundle.sh")
+    parity = workflow.index("git diff --exit-code -- docs/index.html")
+    tests = workflow.index("tests/test_frontend_bundle.py")
+    upload = workflow.index("actions/upload-pages-artifact")
+
+    assert build < parity < tests < upload
+    assert "docs/.build-sha" in workflow
+
+
+def test_ci_checks_generated_bundle_parity() -> None:
+    """Regular CI rejects stale committed frontend output."""
+    workflow = (ROOT / ".github" / "workflows" / "run-tests.yml").read_text()
+
+    assert "bash scripts/bundle.sh" in workflow
+    assert "git diff --exit-code -- docs/index.html" in workflow
+
+
+def test_host_autonomy_suite_is_live_only() -> None:
+    """Ubuntu CI skips tests tied to one Mac and its LaunchAgents."""
+    source = (ROOT / "tests" / "autonomy" / "test_autonomy.py").read_text()
+
+    assert "pytestmark = pytest.mark.live" in source

--- a/tests/test_file_locking.py
+++ b/tests/test_file_locking.py
@@ -54,11 +54,11 @@ class TestConcurrentSaveJson:
         assert len(data["data"]) == 100
 
 
-class TestLockTimeoutFallback:
-    """Verify save_json still works even if the lock can't be acquired."""
+class TestLockTimeout:
+    """Verify state writes fail closed when the lock can't be acquired."""
 
-    def test_lock_timeout_fallback(self, tmp_path):
-        """save_json succeeds even when the lock file is held by another process."""
+    def test_lock_timeout_blocks_write(self, tmp_path):
+        """save_json raises instead of writing without its lock."""
         target = tmp_path / "fallback.json"
         lock_path = target.with_suffix(".json.lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -69,8 +69,6 @@ class TestLockTimeoutFallback:
         fcntl.flock(held_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
         try:
-            # save_json should fall through after timeout (we use a short timeout)
-            # Patch the timeout to be very short so the test is fast
             original_file_lock = state_io._file_lock
 
             from contextlib import contextmanager
@@ -81,12 +79,10 @@ class TestLockTimeoutFallback:
                     yield
 
             with patch.object(state_io, "_file_lock", fast_lock):
-                state_io.save_json(target, {"fallback": True})
+                with pytest.raises(TimeoutError, match="Timed out acquiring state lock"):
+                    state_io.save_json(target, {"fallback": True})
 
-            # File should still be valid JSON
-            with open(target) as f:
-                data = json.load(f)
-            assert data == {"fallback": True}
+            assert not target.exists()
         finally:
             fcntl.flock(held_fd, fcntl.LOCK_UN)
             held_fd.close()

--- a/tests/test_frontend_live_data.py
+++ b/tests/test_frontend_live_data.py
@@ -1,0 +1,204 @@
+"""Behavioral tests for feed freshness and GitHub auth/live data paths."""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required")
+
+
+def _run_async_javascript(path: Path, body: str, prelude: str):
+    """Evaluate a source file and one async test body."""
+    script = (
+        f"{prelude}\n"
+        f"{path.read_text(encoding='utf-8')}\n"
+        "(async () => {\n"
+        f"{body}\n"
+        "})().catch(error => { console.error(error); process.exit(1); });\n"
+    )
+    result = subprocess.run(
+        [NODE, "-e", script],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_recent_posts_survive_shard_lag_without_monolith_fetch() -> None:
+    """A current logged post remains visible as an external GitHub link."""
+    discussions = ROOT / "src" / "js" / "discussions.js"
+    prelude = """
+      const requests = [];
+      const RB_STATE = {
+        OWNER: 'kody-w', REPO: 'rappterbook',
+        fetchJSON: async path => {
+          requests.push(path);
+          return { posts: [{
+            number: 20659, title: '[IDEA] Fresh', author: 'alice',
+            channel: 'general', timestamp: '2026-07-11T00:00:00Z'
+          }] };
+        },
+        getDiscussionMeta: async () => null,
+        getDiscussionBody: async () => { throw new Error('body shard should not load'); }
+      };
+      const RB_AUTH = { hasGitHubCapability: () => false };
+    """
+    body = """
+      const posts = await RB_DISCUSSIONS.fetchRecent(null, 10);
+      console.log(JSON.stringify({ posts, requests }));
+    """
+
+    result = _run_async_javascript(discussions, body, prelude)
+
+    assert len(result["posts"]) == 1
+    assert result["posts"][0]["cacheAvailable"] is False
+    assert result["posts"][0]["url"].endswith("/discussions/20659")
+    assert result["requests"] == ["state/posted_log.json"]
+
+
+def test_graphql_uses_only_github_token() -> None:
+    """A platform JWT is never sent to api.github.com."""
+    discussions = ROOT / "src" / "js" / "discussions.js"
+    prelude = """
+      let authorization = null;
+      const RB_AUTH = {
+        getGitHubToken: () => 'github-token',
+        getToken: () => 'platform-jwt'
+      };
+      const RB_STATE = { OWNER: 'kody-w', REPO: 'rappterbook' };
+      const fetch = async (url, options) => {
+        authorization = options.headers.Authorization;
+        return { ok: true, json: async () => ({ data: { viewer: { login: 'alice' } } }) };
+      };
+    """
+    body = """
+      await RB_DISCUSSIONS.graphql('query { viewer { login } }');
+      console.log(JSON.stringify({ authorization }));
+    """
+
+    result = _run_async_javascript(discussions, body, prelude)
+
+    assert result["authorization"] == "bearer github-token"
+
+
+def test_live_comments_accept_empty_authoritative_response() -> None:
+    """A successful empty live response does not fall back to stale comments."""
+    discussions = ROOT / "src" / "js" / "discussions.js"
+    prelude = """
+      const RB_AUTH = { getGitHubToken: () => 'github-token' };
+      const RB_STATE = { OWNER: 'kody-w', REPO: 'rappterbook' };
+    """
+    body = """
+      RB_DISCUSSIONS.graphql = async () => ({
+        repository: { discussion: { comments: { nodes: [] } } }
+      });
+      const result = await RB_DISCUSSIONS._fetchCommentsLive(42);
+      console.log(JSON.stringify(result));
+    """
+
+    result = _run_async_javascript(discussions, body, prelude)
+
+    assert result == {"comments": [], "voteCount": 0, "voters": []}
+
+
+def test_oauth_callback_uses_code_then_github_token_routes() -> None:
+    """Redirect OAuth exchanges code before validating the GitHub token."""
+    auth = ROOT / "src" / "js" / "auth.js"
+    prelude = """
+      const values = new Map();
+      const localStorage = {
+        getItem: key => values.has(key) ? values.get(key) : null,
+        setItem: (key, value) => values.set(key, String(value)),
+        removeItem: key => values.delete(key)
+      };
+      const calls = [];
+      const fetch = async (url, options) => {
+        calls.push({ url, body: JSON.parse(options.body) });
+        if (url.endsWith('/api/auth/token')) {
+          return { ok: true, json: async () => ({ access_token: 'github-token' }) };
+        }
+        return {
+          ok: true,
+          json: async () => ({ token: 'github-token', user: { login: 'alice' } })
+        };
+      };
+      const window = {
+        location: {
+          search: '?code=oauth-code', origin: 'https://kody-w.github.io',
+          pathname: '/rappterbook/', hash: ''
+        },
+        history: { replaceState: () => {} }
+      };
+    """
+    body = """
+      RB_AUTH._updateUI = () => {};
+      const success = await RB_AUTH.handleCallback();
+      console.log(JSON.stringify({
+        success,
+        routes: calls.map(call => call.url.split('/api')[1]),
+        firstBody: calls[0].body,
+        githubToken: localStorage.getItem('rb_github_token'),
+        platformToken: localStorage.getItem('rb_jwt')
+      }));
+    """
+
+    result = _run_async_javascript(auth, body, prelude)
+
+    assert result == {
+        "success": True,
+        "routes": ["/auth/token", "/auth/github"],
+        "firstBody": {"code": "oauth-code"},
+        "githubToken": "github-token",
+        "platformToken": None,
+    }
+
+
+def test_platform_jwt_does_not_unlock_github_write_controls() -> None:
+    """A non-GitHub session is not presented as Discussion-write capable."""
+    auth = ROOT / "src" / "js" / "auth.js"
+    prelude = """
+      const values = new Map([['rb_jwt', 'platform-only']]);
+      const localStorage = {
+        getItem: key => values.has(key) ? values.get(key) : null,
+        setItem: (key, value) => values.set(key, String(value)),
+        removeItem: key => values.delete(key)
+      };
+    """
+    body = """
+      console.log(JSON.stringify({
+        authenticated: RB_AUTH.isAuthenticated(),
+        githubCapable: RB_AUTH.hasGitHubCapability()
+      }));
+    """
+
+    result = _run_async_javascript(auth, body, prelude)
+
+    assert result == {"authenticated": False, "githubCapable": False}
+
+
+def test_frontend_has_no_monolithic_discussion_cache_fallback() -> None:
+    """List and detail reads remain shard-bounded."""
+    source = (
+        (ROOT / "src" / "js" / "discussions.js").read_text()
+        + (ROOT / "src" / "js" / "state.js").read_text()
+    )
+
+    assert "state/discussions_cache.json" not in source
+
+
+def test_misleading_live_mode_toggle_is_removed() -> None:
+    """Fresh detail fallback is automatic instead of exposing an inert toggle."""
+    source = (
+        (ROOT / "src" / "js" / "app.js").read_text()
+        + (ROOT / "src" / "js" / "router.js").read_text()
+        + (ROOT / "src" / "html" / "index.html").read_text()
+    )
+
+    assert "data-mode-toggle" not in source

--- a/tests/test_frontend_live_data.py
+++ b/tests/test_frontend_live_data.py
@@ -118,6 +118,12 @@ def test_oauth_callback_uses_code_then_github_token_routes() -> None:
         setItem: (key, value) => values.set(key, String(value)),
         removeItem: key => values.delete(key)
       };
+      const sessionValues = new Map();
+      const sessionStorage = {
+        getItem: key => sessionValues.has(key) ? sessionValues.get(key) : null,
+        setItem: (key, value) => sessionValues.set(key, String(value)),
+        removeItem: key => sessionValues.delete(key)
+      };
       const calls = [];
       const fetch = async (url, options) => {
         calls.push({ url, body: JSON.parse(options.body) });
@@ -144,8 +150,8 @@ def test_oauth_callback_uses_code_then_github_token_routes() -> None:
         success,
         routes: calls.map(call => call.url.split('/api')[1]),
         firstBody: calls[0].body,
-        githubToken: localStorage.getItem('rb_github_token'),
-        platformToken: localStorage.getItem('rb_jwt')
+        githubToken: sessionStorage.getItem('rb_github_token'),
+        platformToken: sessionStorage.getItem('rb_jwt')
       }));
     """
 
@@ -164,11 +170,17 @@ def test_platform_jwt_does_not_unlock_github_write_controls() -> None:
     """A non-GitHub session is not presented as Discussion-write capable."""
     auth = ROOT / "src" / "js" / "auth.js"
     prelude = """
-      const values = new Map([['rb_jwt', 'platform-only']]);
+      const values = new Map();
       const localStorage = {
         getItem: key => values.has(key) ? values.get(key) : null,
         setItem: (key, value) => values.set(key, String(value)),
         removeItem: key => values.delete(key)
+      };
+      const sessionValues = new Map([['rb_jwt', 'platform-only']]);
+      const sessionStorage = {
+        getItem: key => sessionValues.has(key) ? sessionValues.get(key) : null,
+        setItem: (key, value) => sessionValues.set(key, String(value)),
+        removeItem: key => sessionValues.delete(key)
       };
     """
     body = """
@@ -181,6 +193,41 @@ def test_platform_jwt_does_not_unlock_github_write_controls() -> None:
     result = _run_async_javascript(auth, body, prelude)
 
     assert result == {"authenticated": False, "githubCapable": False}
+
+
+def test_legacy_persistent_token_migrates_to_session_storage() -> None:
+    """Existing users are signed out persistently without losing the current tab."""
+    auth = ROOT / "src" / "js" / "auth.js"
+    prelude = """
+      const values = new Map([['rb_github_token', 'legacy-token']]);
+      const localStorage = {
+        getItem: key => values.has(key) ? values.get(key) : null,
+        setItem: (key, value) => values.set(key, String(value)),
+        removeItem: key => values.delete(key)
+      };
+      const sessionValues = new Map();
+      const sessionStorage = {
+        getItem: key => sessionValues.has(key) ? sessionValues.get(key) : null,
+        setItem: (key, value) => sessionValues.set(key, String(value)),
+        removeItem: key => sessionValues.delete(key)
+      };
+    """
+    body = """
+      const token = RB_AUTH.getGitHubToken();
+      console.log(JSON.stringify({
+        token,
+        persistent: localStorage.getItem('rb_github_token'),
+        session: sessionStorage.getItem('rb_github_token')
+      }));
+    """
+
+    result = _run_async_javascript(auth, body, prelude)
+
+    assert result == {
+        "token": "legacy-token",
+        "persistent": None,
+        "session": "legacy-token",
+    }
 
 
 def test_frontend_has_no_monolithic_discussion_cache_fallback() -> None:

--- a/tests/test_frontend_security.py
+++ b/tests/test_frontend_security.py
@@ -101,3 +101,23 @@ def test_app_routes_all_source_overrides_through_state_guard() -> None:
 
     assert "if (owner || repo || branch)" in app_source
     assert "RB_STATE.configure(owner, repo, branch)" in app_source
+
+
+def test_reaction_count_is_not_viewer_ownership() -> None:
+    """Aggregate reactions are active only when GitHub says the viewer reacted."""
+    render_path = ROOT / "src" / "js" / "render.js"
+    result = _run_javascript(
+        render_path,
+        """({
+          aggregateOnly: RB_RENDER.renderReactions({ '+1': 3 }, 'node-1'),
+          viewerOwned: RB_RENDER.renderReactions({
+            '+1': 3, viewer_has_reacted: { '+1': true }
+          }, 'node-1')
+        })""",
+        prelude=(
+            "const RB_DISCUSSIONS = { formatTimestamp: value => String(value || '') };"
+        ),
+    )
+
+    assert "reaction-btn--active" not in result["aggregateOnly"]
+    assert "reaction-btn--active" in result["viewerOwned"]

--- a/tests/test_frontend_security.py
+++ b/tests/test_frontend_security.py
@@ -59,15 +59,26 @@ def test_byline_parser_rejects_markup_but_keeps_agent_ids() -> None:
         discussions_path,
         """({
           malicious: RB_DISCUSSIONS.extractAuthor(
-            '*Posted by **<img src=x onerror=alert(1)>***'
+            '*Posted by **<img src=x onerror=alert(1)>***', 'mallory'
           ),
           valid: RB_DISCUSSIONS.extractAuthor(
-            '*Posted by **zion-coder-01***'
-          )
+            '*Posted by **zion-coder-01***', 'kody-w'
+          ),
+          spoofed: RB_DISCUSSIONS.extractAuthor(
+            '*Posted by **zion-coder-01***', 'mallory'
+          ),
+          direct: RB_DISCUSSIONS.extractAuthor(
+            '*Posted by **mallory***', 'mallory'
+          ),
         })""",
     )
 
-    assert result == {"malicious": None, "valid": "zion-coder-01"}
+    assert result == {
+        "malicious": None,
+        "valid": "zion-coder-01",
+        "spoofed": None,
+        "direct": "mallory",
+    }
 
 
 def test_live_feed_escapes_identity_fields_and_unsafe_urls() -> None:

--- a/tests/test_frontend_security.py
+++ b/tests/test_frontend_security.py
@@ -1,0 +1,103 @@
+"""Behavioral security tests for the static frontend trust boundary."""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required")
+
+
+def _run_javascript(path: Path, expression: str, prelude: str = ""):
+    """Evaluate one source file and return a JSON-serializable expression."""
+    script = (
+        f"{prelude}\n"
+        f"{path.read_text(encoding='utf-8')}\n"
+        f"console.log(JSON.stringify({expression}));\n"
+    )
+    result = subprocess.run(
+        [NODE, "-e", script],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_state_rejects_alternate_repository_and_namespaces_cache() -> None:
+    """A crafted query cannot retarget reads or reuse canonical cache entries."""
+    state_path = ROOT / "src" / "js" / "state.js"
+    result = _run_javascript(
+        state_path,
+        """({
+          accepted: RB_STATE.configure('attacker', 'poison', 'main'),
+          owner: RB_STATE.OWNER,
+          repo: RB_STATE.REPO,
+          branch: RB_STATE.BRANCH,
+          cacheKey: RB_STATE._cacheKey('state/stats.json')
+        })""",
+    )
+
+    assert result == {
+        "accepted": False,
+        "owner": "kody-w",
+        "repo": "rappterbook",
+        "branch": "main",
+        "cacheKey": "kody-w/rappterbook@main:state/stats.json",
+    }
+
+
+def test_byline_parser_rejects_markup_but_keeps_agent_ids() -> None:
+    """Bylines can identify agents but cannot carry HTML into renderers."""
+    discussions_path = ROOT / "src" / "js" / "discussions.js"
+    result = _run_javascript(
+        discussions_path,
+        """({
+          malicious: RB_DISCUSSIONS.extractAuthor(
+            '*Posted by **<img src=x onerror=alert(1)>***'
+          ),
+          valid: RB_DISCUSSIONS.extractAuthor(
+            '*Posted by **zion-coder-01***'
+          )
+        })""",
+    )
+
+    assert result == {"malicious": None, "valid": "zion-coder-01"}
+
+
+def test_live_feed_escapes_identity_fields_and_unsafe_urls() -> None:
+    """State-backed activity data is inert when inserted with innerHTML."""
+    render_path = ROOT / "src" / "js" / "render.js"
+    result = _run_javascript(
+        render_path,
+        """({
+          html: RB_RENDER.renderLiveItem({
+            type: 'new_agent',
+            id: '<img src=x onerror=alert(1)>',
+            ts: '" onmouseover="alert(2)'
+          }, false),
+          unsafeUrl: RB_RENDER.safeHttpUrl('javascript:alert(3)')
+        })""",
+        prelude=(
+            "const RB_DISCUSSIONS = { formatTimestamp: value => String(value || '') };"
+        ),
+    )
+
+    assert "<img" not in result["html"]
+    assert "&lt;img" in result["html"]
+    assert "%3Cimg" in result["html"]
+    assert "onmouseover=&quot;" in result["html"]
+    assert result["unsafeUrl"] == "#"
+
+
+def test_app_routes_all_source_overrides_through_state_guard() -> None:
+    """Owner, repo, and branch query parameters cannot bypass RB_STATE."""
+    app_source = (ROOT / "src" / "js" / "app.js").read_text()
+
+    assert "if (owner || repo || branch)" in app_source
+    assert "RB_STATE.configure(owner, repo, branch)" in app_source

--- a/tests/test_media_download_security.py
+++ b/tests/test_media_download_security.py
@@ -1,0 +1,80 @@
+"""Security tests for verified media redirect handling."""
+from email.message import Message
+from unittest.mock import patch
+import urllib.error
+
+import pytest
+
+from actions.media import _download_media_bytes, _validated_source_url
+
+
+class _Response:
+    """Minimal context-managed urllib response."""
+
+    def __init__(self, payload: bytes = b"image", content_type: str = "image/png"):
+        self.payload = payload
+        self.headers = {
+            "Content-Length": str(len(payload)),
+            "Content-Type": content_type,
+        }
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self, limit: int) -> bytes:
+        return self.payload[:limit]
+
+
+class _RedirectOpener:
+    """Return one redirect followed by one successful response."""
+
+    def __init__(self, location: str):
+        self.location = location
+        self.calls = []
+
+    def open(self, request, timeout: int):
+        self.calls.append(request.full_url)
+        if len(self.calls) == 1:
+            headers = Message()
+            headers["Location"] = self.location
+            raise urllib.error.HTTPError(
+                request.full_url, 302, "Found", headers, None
+            )
+        return _Response()
+
+
+def test_source_url_rejects_credentials_and_nonstandard_ports() -> None:
+    """Allowlisted hosts cannot be reached through credential or port tricks."""
+    assert _validated_source_url("https://user@github.com/file") is None
+    assert _validated_source_url("https://github.com:444/file") is None
+    assert _validated_source_url("http://github.com/file") is None
+
+
+def test_allowed_redirect_chain_is_revalidated() -> None:
+    """Each redirect may continue only to another allowlisted HTTPS host."""
+    opener = _RedirectOpener(
+        "https://private-user-images.githubusercontent.com/assets/image.png"
+    )
+    with patch("urllib.request.build_opener", return_value=opener):
+        payload, content_type = _download_media_bytes(
+            "https://github.com/user-attachments/assets/image"
+        )
+
+    assert payload == b"image"
+    assert content_type == "image/png"
+    assert len(opener.calls) == 2
+
+
+def test_redirect_to_untrusted_host_is_rejected_before_request() -> None:
+    """An allowlisted source cannot bounce the publisher to an arbitrary host."""
+    opener = _RedirectOpener("https://example.com/private")
+    with patch("urllib.request.build_opener", return_value=opener):
+        with pytest.raises(ValueError, match="redirect target is not allowed"):
+            _download_media_bytes(
+                "https://github.com/user-attachments/assets/image"
+            )
+
+    assert len(opener.calls) == 1

--- a/tests/test_parse_seed_event.py
+++ b/tests/test_parse_seed_event.py
@@ -1,0 +1,64 @@
+"""Tests for treating GitHub seed event fields strictly as data."""
+from pathlib import Path
+
+from parse_seed_event import (
+    parse_discussion_event,
+    parse_issue_event,
+    write_github_outputs,
+)
+
+
+def test_discussion_event_preserves_adversarial_text() -> None:
+    """Shell syntax and multiline bodies remain literal output values."""
+    event = {
+        "discussion": {
+            "number": 42,
+            "title": "[BUILD] $(touch /tmp/not-executed) `echo nope`",
+            "body": "line one\nBODYEOF\n${{ secrets.GITHUB_TOKEN }}",
+            "user": {"login": "external-agent"},
+        }
+    }
+
+    values = parse_discussion_event(event)
+
+    assert values["seed_text"] == "$(touch /tmp/not-executed) `echo nope`"
+    assert "BODYEOF" in values["context"]
+    assert "${{ secrets.GITHUB_TOKEN }}" in values["context"]
+    assert values["source"] == "discussion-42"
+
+
+def test_issue_event_filters_only_seed_label() -> None:
+    """Issue labels become comma-separated data without shell tokenization."""
+    event = {
+        "issue": {
+            "number": 7,
+            "title": "SEED: Harden event parsing",
+            "body": "context with 'quotes' and\nnewlines",
+            "labels": [
+                {"name": "seed"},
+                {"name": "artifact build"},
+                {"name": "$(echo literal)"},
+            ],
+        }
+    }
+
+    values = parse_issue_event(event)
+
+    assert values["seed_text"] == "Harden event parsing"
+    assert values["context"] == "context with 'quotes' and\nnewlines"
+    assert values["tags"] == "artifact build,$(echo literal)"
+    assert values["source"] == "github-issue-7"
+
+
+def test_github_outputs_use_multiline_delimiters(tmp_path: Path) -> None:
+    """Every value is emitted with a delimiter instead of shell assignment."""
+    output_path = tmp_path / "github-output"
+    values = {"seed_text": "a=b\n$(echo literal)", "context": "EOF\nBODYEOF"}
+
+    write_github_outputs(values, output_path)
+
+    output = output_path.read_text()
+    assert "seed_text=" not in output
+    assert "context=" not in output
+    assert "a=b\n$(echo literal)" in output
+    assert "EOF\nBODYEOF" in output

--- a/tests/test_process_inbox.py
+++ b/tests/test_process_inbox.py
@@ -183,9 +183,33 @@ class TestInboxCleanup:
 
         result = run_inbox(tmp_state)
 
-        assert result.returncode == 1
-        assert "retaining" in result.stderr
+        assert result.returncode == 0
+        assert "Retry 1/3" in result.stderr
         assert delta_path.exists()
+        delta = json.loads(delta_path.read_text())
+        assert delta["_retry"]["attempts"] == 1
+
+    def test_handler_error_dead_letters_after_retry_limit(self, tmp_state):
+        """A poison event cannot block the queue forever."""
+        delta_path = write_delta(
+            tmp_state / "inbox",
+            "missing-agent",
+            "update_profile",
+            {"bio": "never valid"},
+            event_id="event-poison",
+        )
+
+        for _ in range(3):
+            assert run_inbox(tmp_state).returncode == 0
+
+        rejected = tmp_state / "inbox" / "rejected"
+        rejected_delta = rejected / delta_path.name
+        assert not delta_path.exists()
+        assert rejected_delta.exists()
+        assert json.loads(rejected_delta.read_text())["_retry"]["attempts"] == 3
+        assert "Retry limit exceeded" in (
+            rejected / f"{delta_path.name}.reason"
+        ).read_text()
 
     def test_handler_error_rolls_back_partial_mutation(self, tmp_state, monkeypatch):
         """A failed handler cannot leak partial state into another saved action."""

--- a/tests/test_process_inbox.py
+++ b/tests/test_process_inbox.py
@@ -280,6 +280,32 @@ class TestInboxCleanup:
         assert agents["_meta"]["count"] == 1
         assert [r["event_id"] for r in changes["receipts"]] == ["event-once"]
 
+    def test_mixed_success_and_retry_commits_progress(self, tmp_state):
+        """A retryable sibling cannot replay already-saved successful work."""
+        success_path = write_delta(
+            tmp_state / "inbox",
+            "agent-a",
+            "register_agent",
+            {"name": "Agent A", "framework": "test", "bio": "Test."},
+            event_id="event-success",
+        )
+        retry_path = write_delta(
+            tmp_state / "inbox",
+            "missing-agent",
+            "update_profile",
+            {"bio": "retry"},
+            event_id="event-retry",
+        )
+
+        result = run_inbox(tmp_state)
+
+        agents = json.loads((tmp_state / "agents.json").read_text())
+        assert result.returncode == 0
+        assert "agent-a" in agents["agents"]
+        assert not success_path.exists()
+        assert retry_path.exists()
+        assert "Retained retryable deltas" in result.stderr
+
 
 class TestMultipleDeltas:
     def test_processed_in_order(self, tmp_state):

--- a/tests/test_process_inbox.py
+++ b/tests/test_process_inbox.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-from conftest import write_delta
+from conftest import RECENT_TS, write_delta
 
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = ROOT / "scripts" / "process_inbox.py"
@@ -171,6 +171,115 @@ class TestInboxCleanup:
         after = (tmp_state / "agents.json").read_text()
         assert before == after
 
+    def test_handler_error_retains_delta_for_retry(self, tmp_state):
+        """A potentially transient handler failure is not discarded."""
+        delta_path = write_delta(
+            tmp_state / "inbox",
+            "missing-agent",
+            "update_profile",
+            {"bio": "retry me"},
+            event_id="event-retry",
+        )
+
+        result = run_inbox(tmp_state)
+
+        assert result.returncode == 1
+        assert "retaining" in result.stderr
+        assert delta_path.exists()
+
+    def test_handler_error_rolls_back_partial_mutation(self, tmp_state, monkeypatch):
+        """A failed handler cannot leak partial state into another saved action."""
+        import process_inbox
+
+        delta_path = write_delta(
+            tmp_state / "inbox",
+            "agent-1",
+            "heartbeat",
+            {},
+            event_id="event-partial",
+        )
+        state = process_inbox.load_state(tmp_state)
+
+        def mutate_then_fail(delta, agents, stats, channels):
+            agents["agents"]["partial"] = {"name": "must roll back"}
+            stats["total_agents"] = 999
+            return "injected handler failure"
+
+        monkeypatch.setitem(
+            process_inbox.HANDLERS, "heartbeat", mutate_then_fail
+        )
+        outcome, _ = process_inbox._process_delta(
+            delta_path, state, {}, set()
+        )
+
+        assert outcome == "retry"
+        assert state["agents"]["agents"] == {}
+        assert state["stats"]["total_agents"] == 0
+
+    def test_invalid_json_moves_to_rejected_queue(self, tmp_state):
+        """Permanently malformed input gets a durable rejection reason."""
+        delta_path = tmp_state / "inbox" / "broken.json"
+        delta_path.write_text("{")
+
+        result = run_inbox(tmp_state)
+
+        rejected = tmp_state / "inbox" / "rejected"
+        assert result.returncode == 0
+        assert not delta_path.exists()
+        assert (rejected / "broken.json").exists()
+        assert "Invalid JSON" in (rejected / "broken.json.reason").read_text()
+
+    def test_save_failure_retains_successful_delta(
+        self, tmp_state, docs_dir, monkeypatch
+    ):
+        """Acknowledgement happens only after every state save succeeds."""
+        import process_inbox
+
+        delta_path = write_delta(
+            tmp_state / "inbox",
+            "agent-1",
+            "register_agent",
+            {"name": "Agent", "framework": "test", "bio": "Test."},
+            event_id="event-save-failure",
+        )
+
+        def fail_save(*args, **kwargs):
+            raise RuntimeError("injected save failure")
+
+        monkeypatch.setattr(process_inbox, "save_state", fail_save)
+        with pytest.raises(RuntimeError, match="injected save failure"):
+            process_inbox._process_inbox(tmp_state, docs_dir)
+
+        assert delta_path.exists()
+
+    def test_success_receipt_prevents_replay(self, tmp_state):
+        """A duplicate event ID is acknowledged without applying twice."""
+        payload = {"name": "Agent", "framework": "test", "bio": "Test."}
+        write_delta(
+            tmp_state / "inbox",
+            "agent-1",
+            "register_agent",
+            payload,
+            timestamp="2026-02-12T10:00:00Z",
+            event_id="event-once",
+        )
+        assert run_inbox(tmp_state).returncode == 0
+
+        write_delta(
+            tmp_state / "inbox",
+            "agent-1",
+            "register_agent",
+            payload,
+            timestamp="2026-02-12T11:00:00Z",
+            event_id="event-once",
+        )
+        assert run_inbox(tmp_state).returncode == 0
+
+        agents = json.loads((tmp_state / "agents.json").read_text())
+        changes = json.loads((tmp_state / "changes.json").read_text())
+        assert agents["_meta"]["count"] == 1
+        assert [r["event_id"] for r in changes["receipts"]] == ["event-once"]
+
 
 class TestMultipleDeltas:
     def test_processed_in_order(self, tmp_state):
@@ -289,7 +398,7 @@ class TestMediaPipeline:
             "media_type": "image",
             "source_url": sample_file.as_uri(),
             "filename": "breadcrumb.png",
-        }, timestamp="2026-03-08T01:00:00Z")
+        }, timestamp=RECENT_TS)
         run_inbox(tmp_state, docs_dir=docs_dir, extra_env=extra_env)
 
         flags = json.loads((tmp_state / "flags.json").read_text())
@@ -299,7 +408,7 @@ class TestMediaPipeline:
             "submission_id": submission_id,
             "decision": "approve",
             "note": "Looks safe to publish.",
-        }, timestamp="2026-03-08T02:00:00Z")
+        }, timestamp=RECENT_TS)
         run_inbox(tmp_state, docs_dir=docs_dir, extra_env=extra_env)
 
         flags = json.loads((tmp_state / "flags.json").read_text())

--- a/tests/test_process_issues.py
+++ b/tests/test_process_issues.py
@@ -50,6 +50,7 @@ class TestValidIssues:
         assert len(inbox_files) == 1
         delta = json.loads(inbox_files[0].read_text())
         assert delta["action"] == "register_agent"
+        assert delta["source"]["issue_number"] == 1
 
     def test_heartbeat_creates_delta(self, tmp_state):
         event = make_issue_event("heartbeat", {})

--- a/tests/test_process_issues.py
+++ b/tests/test_process_issues.py
@@ -66,6 +66,33 @@ class TestValidIssues:
         result = run_issues(event, tmp_state)
         assert result.returncode == 0
 
+    def test_duplicate_delivery_keeps_one_stable_delta(self, tmp_state):
+        """Re-delivering one GitHub event cannot overwrite or duplicate work."""
+        event = make_issue_event("heartbeat", {})
+
+        first = run_issues(event, tmp_state)
+        second = run_issues(event, tmp_state)
+
+        assert first.returncode == 0
+        assert second.returncode == 0
+        assert "already queued" in second.stdout
+        inbox_files = list((tmp_state / "inbox").glob("*.json"))
+        assert len(inbox_files) == 1
+        delta = json.loads(inbox_files[0].read_text())
+        assert delta["event_id"].startswith("github-issue-")
+
+    def test_distinct_issues_get_distinct_files(self, tmp_state):
+        """Two same-actor events never collide on wall-clock seconds."""
+        first_event = make_issue_event("heartbeat", {})
+        second_event = make_issue_event("heartbeat", {})
+        second_event["issue"]["number"] = 2
+
+        run_issues(first_event, tmp_state)
+        run_issues(second_event, tmp_state)
+
+        inbox_files = list((tmp_state / "inbox").glob("*.json"))
+        assert len(inbox_files) == 2
+
 
 class TestInvalidIssues:
     def test_invalid_json_exits_1(self, tmp_state):

--- a/tests/test_profile_export_security.py
+++ b/tests/test_profile_export_security.py
@@ -1,0 +1,51 @@
+"""Static guards for browser credential and profile-export boundaries."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_auth_tokens_are_not_persisted_in_local_storage() -> None:
+    """Auth may migrate legacy keys but never writes new persistent tokens."""
+    source = (ROOT / "src" / "js" / "auth.js").read_text()
+
+    for key in ("rb_jwt", "rb_access_token", "rb_github_token"):
+        assert f"localStorage.setItem('{key}'" not in source
+        assert f"sessionStorage.setItem('{key}'" in source
+
+
+def test_profile_export_and_import_use_preference_allowlist() -> None:
+    """Profile files cannot contain or restore credentials and arbitrary keys."""
+    source = (ROOT / "src" / "js" / "router.js").read_text()
+    export_block = source.split("// Export profile", 1)[1].split("// Import profile", 1)[0]
+    import_block = source.split("// Import profile", 1)[1].split("// Danger zone", 1)[0]
+
+    for secret_key in (
+        "rb_jwt",
+        "rb_github_token",
+        "rb_access_token",
+        "rb_integrations_telegram",
+    ):
+        assert secret_key not in export_block
+        assert secret_key not in import_block
+    assert "const keys = ['rb-theme', 'rb_notifications_read_at']" in export_block
+    assert "const allowedKeys = ['rb-theme', 'rb_notifications_read_at']" in import_block
+
+
+def test_telegram_secret_is_session_scoped() -> None:
+    """The optional Telegram bot token does not survive the browser session."""
+    router = (ROOT / "src" / "js" / "router.js").read_text()
+    render = (ROOT / "src" / "js" / "render.js").read_text()
+
+    assert "sessionStorage.setItem('rb_integrations_telegram'" in router
+    assert "sessionStorage.getItem('rb_integrations_telegram'" in render
+    assert "localStorage.setItem('rb_integrations_telegram'" not in router
+
+
+def test_leaflet_has_subresource_integrity() -> None:
+    """Token-bearing pages pin third-party executable assets."""
+    html = (ROOT / "src" / "html" / "index.html").read_text()
+
+    leaflet_lines = [line for line in html.splitlines() if "leaflet@1.9.4" in line]
+    assert len(leaflet_lines) == 2
+    assert all("integrity=\"sha256-" in line for line in leaflet_lines)
+    assert all('crossorigin="anonymous"' in line for line in leaflet_lines)

--- a/tests/test_public_authorization.py
+++ b/tests/test_public_authorization.py
@@ -1,0 +1,84 @@
+"""Authorization tests for actor-owned governance fields."""
+from actions.agent import process_verify_agent
+from actions.seed import (
+    process_propose_seed,
+    process_unvote_seed,
+    process_vote_seed,
+)
+
+
+def _delta(action: str, agent_id: str, payload: dict) -> dict:
+    """Build an authenticated action delta."""
+    return {
+        "action": action,
+        "agent_id": agent_id,
+        "timestamp": "2026-07-11T00:00:00Z",
+        "payload": payload,
+    }
+
+
+def test_proposal_author_comes_from_transport_identity() -> None:
+    """A proposal cannot claim another author."""
+    seeds = {"proposals": []}
+    forged = _delta("propose_seed", "alice", {"text": "Build it", "author": "bob"})
+
+    error = process_propose_seed(forged, seeds)
+
+    assert error == "payload.author must match authenticated agent_id"
+    assert seeds["proposals"] == []
+
+
+def test_seed_vote_and_unvote_reject_forged_voter() -> None:
+    """Vote mutations cannot use a payload-controlled principal."""
+    seeds = {
+        "proposals": [{
+            "id": "prop-1",
+            "text": "Build it",
+            "author": "alice",
+            "votes": ["alice"],
+            "vote_count": 1,
+        }]
+    }
+
+    vote_error = process_vote_seed(
+        _delta("vote_seed", "bob", {"proposal_id": "prop-1", "voter": "carol"}),
+        seeds,
+    )
+    unvote_error = process_unvote_seed(
+        _delta("unvote_seed", "alice", {"proposal_id": "prop-1", "voter": "bob"}),
+        seeds,
+    )
+
+    assert vote_error == "payload.voter must match authenticated agent_id"
+    assert unvote_error == "payload.voter must match authenticated agent_id"
+    assert seeds["proposals"][0]["votes"] == ["alice"]
+
+
+def test_matching_redundant_identity_remains_compatible() -> None:
+    """Clients may send a matching identity during migration."""
+    seeds = {"proposals": []}
+    delta = _delta("propose_seed", "Alice", {"text": "Build it", "author": "alice"})
+
+    error = process_propose_seed(delta, seeds)
+
+    assert error is None
+    assert seeds["proposals"][0]["author"] == "Alice"
+
+
+def test_verify_identity_must_be_unique() -> None:
+    """One GitHub identity cannot verify multiple agents."""
+    agents = {
+        "agents": {
+            "alice": {"verified": True, "verified_github": "alice"},
+            "Alice": {"verified": False},
+        },
+        "_meta": {},
+    }
+
+    error = process_verify_agent(
+        _delta("verify_agent", "Alice", {"github_username": "Alice"}),
+        agents,
+    )
+
+    assert error == "GitHub identity Alice is already bound to another agent"
+    assert agents["agents"]["Alice"]["verified"] is False

--- a/tests/test_reconcile_channels.py
+++ b/tests/test_reconcile_channels.py
@@ -29,6 +29,7 @@ def test_infer_post_channel_and_topic_keeps_verified_category_and_topic():
         "createdAt": "2026-03-08T01:00:00Z",
         "url": "https://github.com/kody-w/rappterbook/discussions/4455",
         "body": "*Posted by **zion-guide-01***\n\n---\n\nThread body",
+        "author_login": "kody-w",
         "category": {"slug": "general"},
         "reactions": {"totalCount": 3},
         "comments": {"totalCount": 7},
@@ -54,6 +55,7 @@ def test_discussion_to_posted_log_entry_uses_topic_for_community_routed_posts():
         "createdAt": "2026-03-08T01:00:00Z",
         "url": "https://github.com/kody-w/rappterbook/discussions/4455",
         "body": "*Posted by **zion-guide-01***\n\n---\n\nThread body",
+        "author_login": "kody-w",
         "category": {"slug": "community"},
         "reactions": {"totalCount": 3},
         "comments": {"totalCount": 7},
@@ -97,6 +99,7 @@ def test_build_channel_counts_tracks_verified_categories_and_topics():
         discussions,
         channels_data,
         {"show-and-tell", "community"},
+        {"posts": []},
     )
 
     # Each discussion counted exactly once: by topic if unverified, by category otherwise
@@ -120,7 +123,9 @@ def test_build_channel_counts_no_tag_falls_through_to_category():
         {"title": "Just a normal post", "category": {"slug": "general"}},
         {"title": "[SPACE] A space post", "category": {"slug": "general"}},
     ]
-    counts = build_channel_counts(discussions, channels_data, {"general"})
+    counts = build_channel_counts(
+        discussions, channels_data, {"general"}, {"posts": []}
+    )
     assert counts["general"] == 1   # only the untagged post
     assert counts["space"] == 1     # the tagged post
     assert sum(counts.values()) == 2
@@ -174,6 +179,7 @@ def test_sync_posted_log_from_discussions_backfills_only_missing_numbers():
             "createdAt": "2026-03-08T00:00:00Z",
             "url": "https://github.com/kody-w/rappterbook/discussions/4400",
             "body": "*Posted by **agent-a***",
+            "author_login": "agent-a",
             "category": {"slug": "general"},
             "reactions": {"totalCount": 0},
             "comments": {"totalCount": 1},
@@ -184,6 +190,7 @@ def test_sync_posted_log_from_discussions_backfills_only_missing_numbers():
             "createdAt": "2026-03-08T01:10:00Z",
             "url": "https://github.com/kody-w/rappterbook/discussions/4458",
             "body": "*Posted by **zion-curator-03***",
+            "author_login": "kody-w",
             "category": {"slug": "show-and-tell"},
             "reactions": {"totalCount": 4},
             "comments": {"totalCount": 2},
@@ -225,6 +232,7 @@ def test_sync_posted_log_normalizes_existing_community_posts():
             "createdAt": "2026-03-08T00:00:00Z",
             "url": "https://github.com/kody-w/rappterbook/discussions/4401",
             "body": "*Posted by **agent-a***",
+            "author_login": "agent-a",
             "category": {"slug": "community"},
             "reactions": {"totalCount": 0},
             "comments": {"totalCount": 1},

--- a/tests/test_run_python.py
+++ b/tests/test_run_python.py
@@ -1,4 +1,4 @@
-"""Tests for the run_python action handler."""
+"""Tests for internal Python execution and its disabled public surface."""
 from __future__ import annotations
 
 import json
@@ -204,14 +204,14 @@ class TestHandleRunPythonUnit:
 
 
 # ---------------------------------------------------------------------------
-# Integration: run_python flows through process_inbox
+# Public action surface: host execution must remain unreachable
 # ---------------------------------------------------------------------------
 
-class TestRunPythonIntegration:
-    """End-to-end: delta file → process_inbox → compute_log.json updated."""
+class TestRunPythonPublicSurface:
+    """The internal brainstem helper must not be reachable from public actions."""
 
-    def test_inbox_dispatch_updates_compute_log(self, tmp_state):
-        """A run_python delta processed by process_inbox writes to compute_log.json."""
+    def test_inbox_delta_is_rejected_without_execution(self, tmp_state):
+        """A forged legacy delta cannot dispatch the internal execution helper."""
         from state_io import load_json
 
         inbox_dir = tmp_state / "inbox"
@@ -229,16 +229,13 @@ class TestRunPythonIntegration:
             text=True,
         )
         assert result.returncode == 0, result.stderr
+        assert "Unknown action: run_python" in result.stderr
 
         compute_log = load_json(tmp_state / "compute_log.json")
-        assert len(compute_log.get("runs", [])) == 1
-        run = compute_log["runs"][0]
-        assert run["agent_id"] == "agent-1"
-        assert "integration test" in run["stdout"]
-        assert run["exit_code"] == 0
+        assert compute_log.get("runs", []) == []
 
-    def test_process_issues_accepts_run_python(self, tmp_state):
-        """process_issues.py validates run_python and writes a delta."""
+    def test_process_issues_rejects_run_python(self, tmp_state):
+        """Public issue intake rejects run_python as an unknown action."""
         import subprocess, os
         env = os.environ.copy()
         env["STATE_DIR"] = str(tmp_state)
@@ -261,33 +258,20 @@ class TestRunPythonIntegration:
             capture_output=True,
             text=True,
         )
-        assert result.returncode == 0, result.stderr
+        assert result.returncode == 1
+        assert "Unknown action: run_python" in result.stderr
 
         delta_files = list((tmp_state / "inbox").glob("*.json"))
-        assert len(delta_files) == 1
-        delta = json.loads(delta_files[0].read_text())
-        assert delta["action"] == "run_python"
-        assert delta["payload"]["code"] == "print(42)"
+        assert delta_files == []
 
-    def test_missing_code_rejected_by_process_issues(self, tmp_state):
-        """process_issues.py rejects run_python with missing code field."""
-        import subprocess, os
-        env = os.environ.copy()
-        env["STATE_DIR"] = str(tmp_state)
+    def test_public_registries_do_not_expose_run_python(self):
+        """All public dispatch registries exclude the internal helper."""
+        from actions import HANDLERS
+        from actions.shared import ACTION_TYPE_MAP
+        from process_inbox import ACTION_STATE_MAP
+        from process_issues import VALID_ACTIONS
 
-        issue_event = {
-            "issue": {
-                "user": {"login": "agent-1"},
-                "body": '{"action": "run_python", "payload": {}}',
-            }
-        }
-
-        result = subprocess.run(
-            [sys.executable, str(Path(__file__).resolve().parent.parent / "scripts" / "process_issues.py")],
-            input=json.dumps(issue_event),
-            env=env,
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 1
-        assert "code" in result.stderr.lower()
+        assert "run_python" not in HANDLERS
+        assert "run_python" not in ACTION_TYPE_MAP
+        assert "run_python" not in ACTION_STATE_MAP
+        assert "run_python" not in VALID_ACTIONS

--- a/tests/test_safe_commit.sh
+++ b/tests/test_safe_commit.sh
@@ -82,7 +82,7 @@ else
   fail "all entries survive conflict — got: $RESULT"
 fi
 
-# ─── Test 3: Competing change on the SAME file ───────────────────────────────
+# ─── Test 3: Competing change on the SAME file fails closed ──────────────────
 cd "$WORK2"
 git pull origin main 2>/dev/null
 echo '{"posts": [{"number": 1, "commentCount": 0}]}' > state/posted_log.json
@@ -90,26 +90,49 @@ git add . && git commit -m "overwrite with stale data" 2>/dev/null && git push o
 
 cd "$WORK1"
 echo '{"posts": [{"number": 1, "commentCount": 100}]}' > state/posted_log.json
+set +e
 OUTPUT=$(bash "$SCRIPT_PATH" "test: same file conflict" state/posted_log.json 2>&1)
+STATUS=$?
+set -e
 
-cd "$WORK1"
-git pull origin main 2>/dev/null
-RESULT=$(cat state/posted_log.json)
-if echo "$RESULT" | grep -q '"commentCount": 100'; then
-  pass "our computed data wins same-file conflict"
+if [ "$STATUS" -ne 0 ] && echo "$OUTPUT" | grep -q "refusing to overwrite remote state"; then
+  pass "same-file conflict fails closed"
 else
-  fail "our computed data wins same-file conflict — got: $RESULT"
+  fail "same-file conflict fails closed — status=$STATUS output=$OUTPUT"
 fi
+
+git fetch origin main 2>/dev/null
+RESULT=$(git show origin/main:state/posted_log.json)
+echo "$RESULT" | grep -q '"commentCount": 0' \
+  && pass "remote same-file update preserved" \
+  || fail "remote same-file update preserved — got: $RESULT"
+
+# Return clone 1 to the remote winner before continuing.
+git reset --hard origin/main >/dev/null
 
 # ─── Test 4: No changes = no commit ──────────────────────────────────────────
 cd "$WORK1"
 OUTPUT=$(bash "$SCRIPT_PATH" "test: no changes" state/posted_log.json 2>&1)
 echo "$OUTPUT" | grep -q "No state changes" && pass "no-op detected" || fail "no-op detected"
 
-# ─── Test 5: Multiple files preserved ─────────────────────────────────────────
+# ─── Test 5: Invalid staged JSON is rejected before commit ────────────────────
+cd "$WORK1"
+echo '{"trending": ' > state/trending.json
+set +e
+OUTPUT=$(bash "$SCRIPT_PATH" "test: reject malformed json" state/trending.json 2>&1)
+STATUS=$?
+set -e
+if [ "$STATUS" -ne 0 ] && echo "$OUTPUT" | grep -q "invalid JSON"; then
+  pass "malformed JSON rejected before commit"
+else
+  fail "malformed JSON rejected — status=$STATUS output=$OUTPUT"
+fi
+git reset --hard HEAD >/dev/null
+
+# ─── Test 6: Multiple files survive a disjoint remote change ─────────────────
 cd "$WORK2"
 git pull origin main 2>/dev/null
-echo '{"feeds": "updated"}' > state/trending.json
+echo '{"remote": "updated"}' > state/remote-only.json
 git add . && git commit -m "competing trending" 2>/dev/null && git push origin main 2>/dev/null
 
 cd "$WORK1"
@@ -123,6 +146,7 @@ GOT_LOG=$(cat state/posted_log.json)
 GOT_TREND=$(cat state/trending.json)
 echo "$GOT_LOG" | grep -q '"commentCount": 200' && pass "multi-file: posted_log preserved" || fail "multi-file: posted_log — got: $GOT_LOG"
 echo "$GOT_TREND" | grep -q '"score": 50' && pass "multi-file: trending preserved" || fail "multi-file: trending — got: $GOT_TREND"
+git show HEAD:state/remote-only.json | grep -q '"updated"' && pass "multi-file: remote change preserved" || fail "multi-file: remote change missing"
 
 # ─── Results ──────────────────────────────────────────────────────────────────
 echo ""

--- a/tests/test_safe_commit_callers.py
+++ b/tests/test_safe_commit_callers.py
@@ -40,3 +40,14 @@ def test_safe_commit_never_overwrites_or_rewrites_history() -> None:
     assert "git checkout \"$OUR_COMMIT\"" not in script
     assert "--force-with-lease" not in script
     assert "git commit --amend" not in script
+
+
+def test_issue_ingress_is_serialized_and_uses_safe_commit() -> None:
+    """Concurrent issue events cannot race raw pushes to main."""
+    workflow = (
+        ROOT / ".github" / "workflows" / "process-issues.yml"
+    ).read_text()
+
+    assert "group: state-ingress" in workflow
+    assert "scripts/safe_commit.sh" in workflow
+    assert "git push" not in workflow

--- a/tests/test_safe_commit_callers.py
+++ b/tests/test_safe_commit_callers.py
@@ -1,0 +1,42 @@
+"""Regression tests for workflows that previously called safe_commit incorrectly."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = (
+    ROOT / ".github" / "workflows" / "twin-driver.yml",
+    ROOT / ".github" / "workflows" / "twin-author.yml",
+    ROOT / ".github" / "workflows" / "generate-twitter-data.yml",
+    ROOT / ".github" / "workflows" / "precompute-fleet.yml",
+)
+
+
+def test_safe_commit_callers_supply_message_and_paths() -> None:
+    """Every repaired caller passes explicit files after its message."""
+    expected_paths = {
+        "twin-driver.yml": "state/twin_runs/",
+        "twin-author.yml": "state/twin_content/",
+        "generate-twitter-data.yml": "docs/api/twitter/",
+        "precompute-fleet.yml": "docs/pretrained_*.json",
+    }
+    for workflow in WORKFLOWS:
+        text = workflow.read_text()
+        assert "safe_commit.sh" in text
+        assert expected_paths[workflow.name] in text
+
+
+def test_safe_commit_callers_have_no_plain_push_fallback() -> None:
+    """Validation or conflict failures must remain visible workflow failures."""
+    for workflow in WORKFLOWS:
+        text = workflow.read_text()
+        assert "safe_commit.sh || git push" not in text
+        assert "changes might be discarded" not in text
+
+
+def test_safe_commit_never_overwrites_or_rewrites_history() -> None:
+    """Conflict recovery must abort rather than replacing state snapshots."""
+    script = (ROOT / "scripts" / "safe_commit.sh").read_text()
+
+    assert "git reset --hard" not in script
+    assert "git checkout \"$OUR_COMMIT\"" not in script
+    assert "--force-with-lease" not in script
+    assert "git commit --amend" not in script

--- a/tests/test_shard_cache.py
+++ b/tests/test_shard_cache.py
@@ -1,0 +1,27 @@
+"""Tests for explicit shard byte budgets."""
+from pathlib import Path
+
+import pytest
+
+from shard_cache import MAX_BODY_SHARD_BYTES, write_bounded_json
+
+
+def test_write_bounded_json_uses_encoded_byte_length(tmp_path: Path) -> None:
+    """The reported size matches the compact UTF-8 payload on disk."""
+    path = tmp_path / "body.json"
+
+    size = write_bounded_json(path, {"42": {"body": "hello 🌎"}}, 1024)
+
+    assert size == path.stat().st_size
+    assert path.read_bytes().startswith(b'{"42":')
+
+
+def test_write_bounded_json_rejects_oversized_shard(tmp_path: Path) -> None:
+    """A body shard cannot silently grow beyond the browser budget."""
+    path = tmp_path / "body.json"
+    data = {"42": {"body": "x" * MAX_BODY_SHARD_BYTES}}
+
+    with pytest.raises(RuntimeError, match="shard limit"):
+        write_bounded_json(path, data, MAX_BODY_SHARD_BYTES)
+
+    assert not path.exists()

--- a/tests/test_skill_schema.py
+++ b/tests/test_skill_schema.py
@@ -13,7 +13,6 @@ EXPECTED_ACTIONS = {
     "recruit_agent", "transfer_karma", "create_topic", "verify_agent",
     "submit_media", "verify_media",
     "propose_seed", "vote_seed", "unvote_seed",
-    "run_python",
 }
 EXPECTED_ENDPOINTS = {"agents", "channels", "changes", "trending", "stats", "pokes", "follows", "notifications"}
 

--- a/tests/test_state_bundle.py
+++ b/tests/test_state_bundle.py
@@ -1,0 +1,103 @@
+"""Failure-injection tests for recoverable multi-file JSON bundles."""
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import state_io
+
+
+def _write(path: Path, value: int) -> None:
+    """Write one small JSON fixture."""
+    path.write_text(json.dumps({"value": value}) + "\n")
+
+
+def test_bundle_promotes_every_file(tmp_path: Path) -> None:
+    """A successful bundle makes every new projection visible."""
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write(first, 1)
+    _write(second, 1)
+
+    state_io.save_json_bundle({
+        first: {"value": 2},
+        second: {"value": 2},
+    })
+
+    assert json.loads(first.read_text())["value"] == 2
+    assert json.loads(second.read_text())["value"] == 2
+    assert not (tmp_path / ".state-transaction.json").exists()
+
+
+def test_bundle_rolls_back_partial_promotion(tmp_path: Path) -> None:
+    """Failure on the second replacement restores the complete old bundle."""
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write(first, 1)
+    _write(second, 1)
+    real_replace = os.replace
+    failed = False
+
+    def fail_second_prepared(source, target):
+        nonlocal failed
+        if (
+            Path(target) == second
+            and Path(source).name.endswith(".new")
+            and not failed
+        ):
+            failed = True
+            raise OSError("injected second-file failure")
+        return real_replace(source, target)
+
+    with patch("state_io.os.replace", side_effect=fail_second_prepared):
+        with pytest.raises(OSError, match="injected second-file failure"):
+            state_io.save_json_bundle({
+                first: {"value": 2},
+                second: {"value": 2},
+            })
+
+    assert json.loads(first.read_text())["value"] == 1
+    assert json.loads(second.read_text())["value"] == 1
+    assert not (tmp_path / ".state-transaction.json").exists()
+    assert not list(tmp_path.glob(".state-tx-*"))
+
+
+def test_recovery_rolls_back_interrupted_bundle(tmp_path: Path) -> None:
+    """A durable journal repairs split state on the next startup."""
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write(first, 2)
+    _write(second, 1)
+    transaction = tmp_path / ".state-tx-interrupted"
+    transaction.mkdir()
+    first_backup = transaction / "0.bak"
+    second_backup = transaction / "1.bak"
+    _write(first_backup, 1)
+    _write(second_backup, 1)
+    journal = {
+        "transaction_dir": str(transaction),
+        "entries": [
+            {
+                "target": str(first),
+                "prepared": str(transaction / "0.new"),
+                "backup": str(first_backup),
+                "existed": True,
+            },
+            {
+                "target": str(second),
+                "prepared": str(transaction / "1.new"),
+                "backup": str(second_backup),
+                "existed": True,
+            },
+        ],
+    }
+    (tmp_path / ".state-transaction.json").write_text(json.dumps(journal))
+
+    assert state_io.recover_json_bundle(tmp_path) is True
+
+    assert json.loads(first.read_text())["value"] == 1
+    assert json.loads(second.read_text())["value"] == 1
+    assert not transaction.exists()
+    assert not (tmp_path / ".state-transaction.json").exists()

--- a/tests/test_state_io.py
+++ b/tests/test_state_io.py
@@ -3,6 +3,7 @@ import json
 import sys
 import tempfile
 import shutil
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -184,13 +185,80 @@ class TestRecordPost:
             cleanup(tmp)
 
     def test_dedup_by_number(self):
-        """Duplicate discussion number is not logged twice."""
+        """A duplicate discussion is a complete no-op across all counters."""
         tmp = make_temp_state()
         try:
-            state_io.record_post(tmp, "zion-philosopher-01", "general",
-                                 "New Post", 1, "http://x/1")  # number 1 already exists
+            before = {
+                name: (tmp / name).read_text()
+                for name in ("stats.json", "channels.json", "agents.json", "posted_log.json")
+            }
+            created = state_io.record_post(
+                tmp, "zion-philosopher-01", "general",
+                "Post 1", 1, "http://x/1"
+            )
+
+            assert created is False
+            for name, content in before.items():
+                assert (tmp / name).read_text() == content
             log = json.loads((tmp / "posted_log.json").read_text())
-            assert len(log["posts"]) == 3  # unchanged
+            assert len(log["posts"]) == 3
+            assert not (tmp / "event_log.jsonl").exists()
+        finally:
+            cleanup(tmp)
+
+    def test_retry_after_new_post_is_idempotent(self):
+        """Recording one fresh post twice applies exactly once."""
+        tmp = make_temp_state()
+        try:
+            assert state_io.record_post(
+                tmp, "zion-philosopher-01", "general",
+                "New Post", 42, "http://x/42"
+            ) is True
+            first = {
+                name: (tmp / name).read_text()
+                for name in ("stats.json", "channels.json", "agents.json", "posted_log.json")
+            }
+
+            assert state_io.record_post(
+                tmp, "zion-philosopher-01", "general",
+                "New Post", 42, "http://x/42"
+            ) is False
+
+            for name, content in first.items():
+                assert (tmp / name).read_text() == content
+            assert len((tmp / "event_log.jsonl").read_text().splitlines()) == 1
+        finally:
+            cleanup(tmp)
+
+    def test_conflicting_post_number_rejected(self):
+        """One GitHub discussion number cannot identify two posts."""
+        tmp = make_temp_state()
+        try:
+            with pytest.raises(ValueError, match="different title"):
+                state_io.record_post(
+                    tmp, "zion-philosopher-01", "general",
+                    "Conflicting title", 1, "http://x/1"
+                )
+        finally:
+            cleanup(tmp)
+
+    def test_concurrent_post_retry_applies_once(self):
+        """The activity lock serializes concurrent retries of one post."""
+        tmp = make_temp_state()
+        try:
+            def record():
+                return state_io.record_post(
+                    tmp, "zion-philosopher-01", "general",
+                    "Concurrent Post", 88, "http://x/88"
+                )
+
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                results = list(executor.map(lambda _: record(), range(8)))
+
+            assert results.count(True) == 1
+            assert results.count(False) == 7
+            log = json.loads((tmp / "posted_log.json").read_text())
+            assert sum(post.get("number") == 88 for post in log["posts"]) == 1
         finally:
             cleanup(tmp)
 
@@ -262,6 +330,42 @@ class TestRecordComment:
             state_io.record_comment(tmp, "zion-coder-01", 1, "Post 1")
             log = json.loads((tmp / "posted_log.json").read_text())
             assert len(log["comments"]) == 5  # was 4
+        finally:
+            cleanup(tmp)
+
+    def test_comment_id_deduplicates_all_side_effects(self):
+        """A retried GitHub comment ID increments counters only once."""
+        tmp = make_temp_state()
+        try:
+            assert state_io.record_comment(
+                tmp, "zion-coder-01", 1, "Post 1", comment_id="comment-42"
+            ) is True
+            first = {
+                name: (tmp / name).read_text()
+                for name in ("stats.json", "agents.json", "posted_log.json")
+            }
+
+            assert state_io.record_comment(
+                tmp, "zion-coder-01", 1, "Post 1", comment_id="comment-42"
+            ) is False
+
+            for name, content in first.items():
+                assert (tmp / name).read_text() == content
+            assert len((tmp / "event_log.jsonl").read_text().splitlines()) == 1
+        finally:
+            cleanup(tmp)
+
+    def test_comment_id_conflict_rejected(self):
+        """A comment ID cannot be replayed under another author."""
+        tmp = make_temp_state()
+        try:
+            state_io.record_comment(
+                tmp, "zion-coder-01", 1, "Post 1", comment_id="comment-42"
+            )
+            with pytest.raises(ValueError, match="different metadata"):
+                state_io.record_comment(
+                    tmp, "someone-else", 1, "Post 1", comment_id="comment-42"
+                )
         finally:
             cleanup(tmp)
 

--- a/tests/test_v1_architecture.py
+++ b/tests/test_v1_architecture.py
@@ -40,9 +40,9 @@ class TestV1Dispatcher:
     """Test the v1 dict-based dispatcher replaces if/elif correctly."""
 
     def test_handler_registry_has_expected_actions(self):
-        """v1 should have exactly 21 action handlers (includes run_python)."""
+        """v1 should have exactly 20 public action handlers."""
         from actions import HANDLERS
-        assert len(HANDLERS) == 21
+        assert len(HANDLERS) == 20
 
     def test_all_handlers_are_callable(self):
         """Every registered handler must be callable."""
@@ -69,6 +69,7 @@ class TestV1Dispatcher:
             "create_quest", "complete_quest", "stake_prediction", "resolve_prediction",
             "fuse_creatures", "forge_artifact", "equip_artifact",
             "form_alliance", "join_alliance", "leave_alliance", "enter_tournament",
+            "run_python",
         }
         for action in dead_actions:
             assert action not in HANDLERS, f"Dead action {action} still in HANDLERS"
@@ -267,9 +268,9 @@ class TestStateFileCount:
         assert len(STATE_DEFAULTS) == 14
 
     def test_action_type_map_only_v1_actions(self):
-        """ACTION_TYPE_MAP should only contain v1 action types (includes run_python)."""
+        """ACTION_TYPE_MAP should only contain public v1 action types."""
         from actions.shared import ACTION_TYPE_MAP
-        assert len(ACTION_TYPE_MAP) == 18
+        assert len(ACTION_TYPE_MAP) == 17
         dead_types = {"pin", "unpin", "delete_post", "upvote", "downvote",
                       "tier_upgrade", "new_listing", "purchase",
                       "token_claim", "token_transfer", "token_list", "token_delist",

--- a/tests/test_verify_agent.py
+++ b/tests/test_verify_agent.py
@@ -111,7 +111,9 @@ class TestVerifyAgent:
 
         result = run_inbox(tmp_state)
 
-        assert result.returncode == 1
+        assert result.returncode == 0
         assert "must match authenticated agent_id" in result.stderr
+        rejected = tmp_state / "inbox" / "rejected"
+        assert list(rejected.glob("*.json"))
         agents = json.loads((tmp_state / "agents.json").read_text())
         assert agents["agents"]["test-agent-01"].get("verified") is not True

--- a/tests/test_verify_agent.py
+++ b/tests/test_verify_agent.py
@@ -34,14 +34,14 @@ class TestVerifyAgent:
         run_inbox(tmp_state)
 
         write_delta(tmp_state / "inbox", "test-agent-01", "verify_agent", {
-            "github_username": "testuser123"
+            "github_username": "test-agent-01"
         }, timestamp="2026-02-12T13:00:00Z")
         run_inbox(tmp_state)
 
         agents = json.loads((tmp_state / "agents.json").read_text())
         agent = agents["agents"]["test-agent-01"]
         assert agent["verified"] is True
-        assert agent["verified_github"] == "testuser123"
+        assert agent["verified_github"] == "test-agent-01"
         assert agent["verified_at"] == "2026-02-12T13:00:00Z"
 
     def test_verify_already_verified(self, tmp_state):
@@ -52,7 +52,7 @@ class TestVerifyAgent:
         run_inbox(tmp_state)
 
         write_delta(tmp_state / "inbox", "test-agent-01", "verify_agent", {
-            "github_username": "testuser123"
+            "github_username": "test-agent-01"
         }, timestamp="2026-02-12T13:00:00Z")
         run_inbox(tmp_state)
 
@@ -91,10 +91,27 @@ class TestVerifyAgent:
         run_inbox(tmp_state)
 
         write_delta(tmp_state / "inbox", "test-agent-01", "verify_agent", {
-            "github_username": "testuser123"
+            "github_username": "test-agent-01"
         }, timestamp="2026-02-12T13:00:00Z")
         run_inbox(tmp_state)
 
         changes = json.loads((tmp_state / "changes.json").read_text())
         verify_changes = [c for c in changes["changes"] if c.get("type") == "verify"]
         assert len(verify_changes) >= 1
+
+    def test_verify_rejects_different_github_identity(self, tmp_state):
+        """An issue author cannot claim another GitHub identity."""
+        write_delta(tmp_state / "inbox", "test-agent-01", "register_agent", {
+            "name": "Test Agent", "framework": "pytest", "bio": "A test agent."
+        })
+        run_inbox(tmp_state)
+        write_delta(tmp_state / "inbox", "test-agent-01", "verify_agent", {
+            "github_username": "someone-else"
+        }, timestamp="2026-02-12T13:00:00Z")
+
+        result = run_inbox(tmp_state)
+
+        assert result.returncode == 1
+        assert "must match authenticated agent_id" in result.stderr
+        agents = json.loads((tmp_state / "agents.json").read_text())
+        assert agents["agents"]["test-agent-01"].get("verified") is not True

--- a/tests/test_workflow_input_safety.py
+++ b/tests/test_workflow_input_safety.py
@@ -1,0 +1,53 @@
+"""Static guardrails for untrusted GitHub event data in workflow scripts."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = (
+    ROOT / ".github" / "workflows" / "build-seed.yml",
+    ROOT / ".github" / "workflows" / "inject-seed.yml",
+)
+
+
+def _literal_blocks(text: str) -> list[str]:
+    """Extract YAML run/script literal blocks using indentation."""
+    lines = text.splitlines()
+    blocks = []
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped not in {"run: |", "script: |"}:
+            continue
+        indent = len(line) - len(line.lstrip())
+        body = []
+        for candidate in lines[index + 1:]:
+            if candidate.strip() and len(candidate) - len(candidate.lstrip()) <= indent:
+                break
+            body.append(candidate)
+        blocks.append("\n".join(body))
+    return blocks
+
+
+def test_seed_workflows_never_interpolate_event_text_in_scripts() -> None:
+    """Issue and Discussion title/body values never become executable source."""
+    forbidden = (
+        "github.event.discussion.title",
+        "github.event.discussion.body",
+        "github.event.issue.title",
+        "github.event.issue.body",
+    )
+    for workflow in WORKFLOWS:
+        blocks = _literal_blocks(workflow.read_text())
+        assert blocks, f"No script blocks found in {workflow.name}"
+        for block in blocks:
+            for expression in forbidden:
+                assert expression not in block, (
+                    f"{workflow.name} interpolates {expression} inside executable source"
+                )
+
+
+def test_seed_workflows_parse_the_event_file() -> None:
+    """Both public triggers use the tested parser and explicit permissions."""
+    for workflow in WORKFLOWS:
+        text = workflow.read_text()
+        assert "scripts/parse_seed_event.py" in text
+        assert "permissions:" in text
+        assert "contents: write" in text


### PR DESCRIPTION
## 24-hour autonomous evolution

This persistent draft PR receives one validated commit set per evolution round. It will not auto-merge while main CI is red.

### Round 1 — security boundaries
Eight independent strategy agents voted B (23 points), C (12), A (8).

1. Removed `run_python` from public Issue ingestion, action dispatch, and `skill.json`; the internal brainstem helper remains available locally.
2. Replaced direct GitHub event interpolation in seed workflows with a tested stdlib event parser and environment-bound arguments.
3. Pinned the frontend to canonical state, versioned and source-qualified IndexedDB cache keys, validated byline IDs, escaped identity/event fields, and rejected unsafe URLs.

### Validation
- 71 focused tests passed
- all frontend JavaScript passed `node --check`
- workflow YAML parsed successfully
- `skill.json` parsed successfully
- frontend bundle rebuilt successfully
- `git diff --check` passed

A broader pre-existing production-state test remains red because channel `lispy` references missing topic `sandbox`; round 1 did not modify that state.
### Round 2 — durable, actor-bound state writes
Eight strategy agents converged on E/I (fail-closed publication), D (durable inbox outcomes), and L (transport-bound governance identity).

1. Added baseline-aware staged JSON/count/blob validation; same-file push conflicts now abort instead of overwriting remote state.
2. Added stable GitHub event IDs, source-qualified delta filenames, a global inbox lock, replay receipts, rejected-event records, retry retention, rollback of partial handler mutations, and acknowledge-after-save deletion.
3. Bound verification, proposal authorship, votes, and unvotes to the authenticated GitHub issue actor with uniqueness checks.
4. Repaired four broken `safe_commit.sh` workflow callers and added the shell concurrency suite to CI.

### Round 2 validation
- 139 focused Python tests passed, 1 skipped
- 12 bare-remote concurrency/push scenarios passed
- changed workflow YAML parsed successfully
- staged-state validator and `git diff --check` passed
### Round 3 — fresh feeds, honest GitHub auth, idempotent activity
Eight strategy agents converged on F (coherent shard-bounded feeds), G (GitHub auth/live correctness), and J (idempotent recording).

1. Current posted-log entries survive shard lag as safe external GitHub cards; agent feeds do the same. The frontend no longer downloads the 99 MB monolith, shard misses refresh, and generated shards have explicit byte caps.
2. OAuth redirect now performs code exchange then GitHub validation; every GitHub API call uses only the GitHub token. Static misses can load live details, empty live comments remain authoritative, reaction ownership uses `viewerHasReacted`, and the inert Live toggle is gone.
3. `record_post` and `record_comment` now serialize activity, deduplicate by GitHub IDs across active/archive logs, reject conflicting replay metadata, emit one event, and return whether insertion occurred. The broken Zion downvote recorder call now passes the real comment ID.

### Round 3 validation
- 162 focused Python/Node-backed tests passed, 1 skipped
- all frontend JavaScript passed `node --check`
- frontend bundle rebuilt successfully
- 12 bare-remote safe-commit scenarios passed
- staged-state validator and `git diff --check` passed
### Round 4 — credential containment, trusted attribution, safe ingress
Eight strategy agents converged on P (credential/media boundaries), M (authenticated attribution), and R (serialized truthful ingress).

1. GitHub/platform credentials now migrate from persistent storage into tab-scoped session storage; profile import/export uses a two-key preference allowlist; Telegram secrets are session-only; Leaflet assets have SRI.
2. Media publication manually validates every bounded redirect hop, HTTPS host, credentials, and port before downloading.
3. One attribution policy now accepts direct claims or delegated claims from configured service publishers. Frontend, feeds, reconciliation, and vote tallying fall back to the authenticated GitHub actor on spoof attempts.
4. Issue ingress is serialized, uses `safe_commit.sh`, carries source provenance, and reports safely queued work. Mixed success/retry inbox batches now commit completed work while retaining retries.

### Round 4 validation
- 189 focused Python/Node-backed tests passed, 1 skipped
- all frontend JavaScript passed `node --check`
- frontend bundle rebuilt successfully
- 12 bare-remote safe-commit scenarios passed
- staged-state validator and `git diff --check` passed
### Round 5 — tested deployment, terminal retries, atomic state bundles
Eight strategy agents converged on N/V (exact build/test/deploy), X (bounded terminal outcomes), and T (failure-atomic multi-file state).

1. CI now covers docs/SDKs/projects/Worker/Action changes, skips host-only Mac autonomy tests by default, rebuilds the frontend, and rejects bundle drift.
2. Pages now triggers on source/bundler changes, rebuilds and parity-checks the artifact, runs focused frontend/security tests, embeds the source SHA, and uploads that exact tested directory.
3. Retryable deltas persist attempt/error metadata, semantic/quota failures reject immediately, and poison events dead-letter after three attempts.
4. `save_json_bundle` prepares, journals, fsyncs, promotes, validates, rolls back, and recovers multi-file state generations under one global state lock. Inbox and activity projections now use it.

### Round 5 validation
- 197 focused Python/Node-backed tests passed, 1 skipped
- 12 bare-remote safe-commit scenarios passed
- changed workflow YAML parsed successfully
- bundle parity, staged-state validation, and `git diff --check` passed