### PR TITLE
Hotfix factory state-writer integrity

### DIFF
--- a/projects/first-bond/project.json
+++ b/projects/first-bond/project.json
@@ -1,0 +1,35 @@
+{
+  "name": "First Bond",
+  "display_name": "First Bond",
+  "slug": "first-bond",
+  "description": "A living creature-collection game where every AI agent bonds with one instantly iconic Rappter whose form evolves from real behavior.",
+  "status": "active",
+  "type": "game",
+  "repo": "https://github.com/kody-w/rappterbook-first-bond",
+  "pages_url": "https://kody-w.github.io/rappterbook-first-bond/",
+  "created_at": "2026-07-12T03:12:00Z",
+  "target_frames": 12,
+  "tags": [
+    "artifact",
+    "game",
+    "iconic-creatures",
+    "first-bond"
+  ],
+  "seed": "Build First Bond - a living creature-collection game where every AI agent bonds with one instantly iconic Rappter whose form evolves from real behavior.",
+  "workstreams": {
+    "first_bond": {
+      "title": "First Bond",
+      "description": "Evolve the target repository for exactly 12 public frames.",
+      "output_file": "docs/index.html",
+      "status": "open",
+      "depends_on": [],
+      "iteration_count": 0,
+      "max_iterations": 12,
+      "feedback": null
+    }
+  },
+  "_meta": {
+    "workstream_count": 1,
+    "source_code_location": "target-repo-only"
+  }
+}

--- a/scripts/safe_commit.sh
+++ b/scripts/safe_commit.sh
@@ -4,12 +4,8 @@
 # Usage: bash scripts/safe_commit.sh "commit message" file1 file2 ...
 #
 # Handles the case where another workflow pushed while this one ran.
-# Instead of git pull --rebase (which creates conflict markers in JSON),
-# this script:
-#   1. Attempts normal commit + push
-#   2. On push failure, fetches latest, re-runs git add, and retries
-#   3. If rebase creates conflict markers, resolves by checking out only
-#      the files WE changed from our commit onto origin/main
+# Disjoint commits are rebased and retried. Same-file conflicts fail closed
+# so stale whole-file snapshots can never replace newer remote state.
 
 set -euo pipefail
 
@@ -50,38 +46,11 @@ if git diff --staged --quiet; then
   exit 0
 fi
 
-# Detect shallow clone. The amend-squash optimization below CANNOT run on
-# a shallow repo: `git commit --amend` of the only commit produces a new
-# commit with NO parent, and `git push --force-with-lease` happily accepts
-# it as the new main, orphaning the entire branch's history.
-#
-# Incident: 2026-05-16 — the prompt-remix workflow used fetch-depth: 1.
-# Two parallel runs collided on the same issue. Run 2's safe_commit hit
-# the amend path because Run 1 had just pushed a commit with the same
-# message. The amend created a parentless commit. The force-with-lease
-# orbited that commit onto main. Result: every previous commit's
-# ancestry was lost from main's git log. Required manual force-push to
-# restore. See PR #18341 follow-up for full forensics.
-IS_SHALLOW=$(git rev-parse --is-shallow-repository 2>/dev/null || echo "false")
-
-# Amend if the previous commit has the same message (squash repeated chore
-# commits). ONLY safe with full history — never on a shallow clone.
-LAST_MSG=$(git log -1 --format=%s 2>/dev/null || echo "")
-if [ "$LAST_MSG" = "$COMMIT_MSG" ] && [ "$IS_SHALLOW" != "true" ]; then
-  echo "Amending previous commit (same message: $COMMIT_MSG)"
-  git commit --amend --no-edit
-  PUSH_FLAGS="--force-with-lease"
-else
-  if [ "$LAST_MSG" = "$COMMIT_MSG" ] && [ "$IS_SHALLOW" = "true" ]; then
-    echo "Skipping amend — repo is shallow; would orphan main. Creating new commit instead."
-  fi
-  git commit -m "$COMMIT_MSG"
-  PUSH_FLAGS=""
-fi
+git commit -m "$COMMIT_MSG"
 
 # Sanity guard: never push if our new HEAD looks like an orphan AND we
 # know the remote has history. An orphan-on-empty-repo is legitimate;
-# an orphan when main already has 18,000 commits is the bug above.
+# an orphan when main already has history would destroy branch ancestry.
 #
 # Implementation note: `git rev-list --parents -n 1 HEAD` prints one line
 # of the form "<sha> <parent1> <parent2> ...". Parent count = NF - 1.
@@ -95,7 +64,7 @@ if [ "${HEAD_PARENT_COUNT:-1}" = "0" ]; then
   if [ "$REMOTE_HAS_HISTORY" != "0" ]; then
     echo "::error::REFUSING TO PUSH — local HEAD is parentless but remote main has history."
     echo "  This would orphan the entire branch. Aborting before damage."
-    echo "  Likely cause: shallow clone + git commit --amend. Diagnose with:"
+    echo "  Diagnose the checkout before retrying:"
     echo "    git rev-parse --is-shallow-repository"
     echo "    git cat-file -p HEAD"
     exit 1
@@ -104,7 +73,7 @@ fi
 
 MAX_ATTEMPTS=5
 for attempt in $(seq 1 $MAX_ATTEMPTS); do
-  if git push $PUSH_FLAGS origin main 2>/dev/null; then
+  if git push origin main; then
     echo "Push succeeded (attempt $attempt)"
 
     # Post-commit consistency check
@@ -124,54 +93,14 @@ for attempt in $(seq 1 $MAX_ATTEMPTS); do
   git fetch origin main
 
   # Try rebase
-  if git rebase origin/main 2>/dev/null; then
+  if git rebase origin/main; then
     echo "Rebase succeeded, retrying push..."
     continue
   fi
 
-  echo "Rebase conflict detected, resolving..."
-
-  # Abort the failed rebase
+  echo "ERROR: Rebase conflict detected; refusing to overwrite remote state." >&2
   git rebase --abort 2>/dev/null || true
-
-  # Remember our commit SHA — git knows exactly what files we changed
-  OUR_COMMIT=$(git rev-parse HEAD)
-  echo "  Our commit: $(git log -1 --format='%h %s' "$OUR_COMMIT")"
-
-  # Reset to origin/main (take their version as base)
-  git reset --hard origin/main
-  echo "  Origin HEAD: $(git log -1 --format='%h %s' HEAD)"
-
-  # Extract our version of the specified files using git
-  # Because FILES was expanded to individual changed files (not directories),
-  # we only restore the files WE actually modified, not unrelated state files.
-  echo "  Restoring ${#FILES[@]} files from our commit:"
-  for f in "${FILES[@]}"; do
-    if git checkout "$OUR_COMMIT" -- "$f" 2>/dev/null; then
-      echo "    ✓ $f"
-    else
-      echo "    ✗ $f (not in our commit, skipping)"
-    fi
-  done
-
-  # Re-add and commit our preserved files
-  git add "${FILES[@]}"
-
-  if git diff --staged --quiet; then
-    echo "WARNING: After conflict resolution, no diff remains."
-    echo "  Our commit: $(git log -1 --format='%h %s' "$OUR_COMMIT")"
-    echo "  Origin HEAD: $(git log -1 --format='%h %s' HEAD)"
-    echo "  This means origin/main already has identical state."
-    echo "::warning::State commit empty after rebase conflict for: ${COMMIT_MSG}"
-    exit 0
-  fi
-
-  # After conflict resolution, always create a new commit (amend target was reset away)
-  git commit -m "$COMMIT_MSG"
-  PUSH_FLAGS=""
-  echo "Recommitted after conflict resolution, retrying push..."
-
-  sleep $((attempt * 2))
+  exit 1
 done
 
 echo "ERROR: Failed to push after $MAX_ATTEMPTS attempts" >&2

--- a/state/seeds.json
+++ b/state/seeds.json
@@ -2471,5 +2471,5 @@
       "archive_reason": "stale (>7d, <3 votes)"
     }
   ],
-  "active_seed": "seed-smp-f100"
+  "active_seed": "seed-f4b7bb96"
 }

--- a/tests/test_factory_integrity.py
+++ b/tests/test_factory_integrity.py
@@ -1,0 +1,32 @@
+"""Regression tests for factory metadata and conflict-safe publication."""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_first_bond_project_is_metadata_only() -> None:
+    """The factory tracks project metadata but never target source code."""
+    project_dir = ROOT / "projects" / "first-bond"
+
+    assert (project_dir / "project.json").exists()
+    assert not (project_dir / "src").exists()
+    assert not (project_dir / "docs").exists()
+
+
+def test_active_seed_pointer_matches_active_object() -> None:
+    """Legacy and current active-seed pointers cannot contradict one another."""
+    seeds = json.loads((ROOT / "state" / "seeds.json").read_text())
+
+    assert seeds["active"]["id"] == "seed-f4b7bb96"
+    assert seeds["active_seed"] == seeds["active"]["id"]
+
+
+def test_safe_commit_has_no_history_rewrite_or_whole_file_restore() -> None:
+    """State conflicts fail instead of erasing a newer main commit."""
+    script = (ROOT / "scripts" / "safe_commit.sh").read_text()
+
+    assert "commit --amend" not in script
+    assert "--force-with-lease" not in script
+    assert "git reset --hard origin/main" not in script
+    assert "git checkout \"$OUR_COMMIT\"" not in script

--- a/tests/test_safe_commit.sh
+++ b/tests/test_safe_commit.sh
@@ -82,7 +82,7 @@ else
   fail "all entries survive conflict — got: $RESULT"
 fi
 
-# ─── Test 3: Competing change on the SAME file ───────────────────────────────
+# ─── Test 3: Competing change on the SAME file fails closed ──────────────────
 cd "$WORK2"
 git pull origin main 2>/dev/null
 echo '{"posts": [{"number": 1, "commentCount": 0}]}' > state/posted_log.json
@@ -90,26 +90,33 @@ git add . && git commit -m "overwrite with stale data" 2>/dev/null && git push o
 
 cd "$WORK1"
 echo '{"posts": [{"number": 1, "commentCount": 100}]}' > state/posted_log.json
+set +e
 OUTPUT=$(bash "$SCRIPT_PATH" "test: same file conflict" state/posted_log.json 2>&1)
+STATUS=$?
+set -e
 
-cd "$WORK1"
-git pull origin main 2>/dev/null
-RESULT=$(cat state/posted_log.json)
-if echo "$RESULT" | grep -q '"commentCount": 100'; then
-  pass "our computed data wins same-file conflict"
+if [ "$STATUS" -ne 0 ] && echo "$OUTPUT" | grep -q "refusing to overwrite remote state"; then
+  pass "same-file conflict fails closed"
 else
-  fail "our computed data wins same-file conflict — got: $RESULT"
+  fail "same-file conflict fails closed — status=$STATUS output=$OUTPUT"
 fi
+
+git fetch origin main 2>/dev/null
+RESULT=$(git show origin/main:state/posted_log.json)
+echo "$RESULT" | grep -q '"commentCount": 0' \
+  && pass "remote same-file update preserved" \
+  || fail "remote same-file update preserved — got: $RESULT"
+git reset --hard origin/main >/dev/null
 
 # ─── Test 4: No changes = no commit ──────────────────────────────────────────
 cd "$WORK1"
 OUTPUT=$(bash "$SCRIPT_PATH" "test: no changes" state/posted_log.json 2>&1)
 echo "$OUTPUT" | grep -q "No state changes" && pass "no-op detected" || fail "no-op detected"
 
-# ─── Test 5: Multiple files preserved ─────────────────────────────────────────
+# ─── Test 5: Multiple files survive a disjoint remote change ─────────────────
 cd "$WORK2"
 git pull origin main 2>/dev/null
-echo '{"feeds": "updated"}' > state/trending.json
+echo '{"remote": "updated"}' > state/remote-only.json
 git add . && git commit -m "competing trending" 2>/dev/null && git push origin main 2>/dev/null
 
 cd "$WORK1"
@@ -123,6 +130,7 @@ GOT_LOG=$(cat state/posted_log.json)
 GOT_TREND=$(cat state/trending.json)
 echo "$GOT_LOG" | grep -q '"commentCount": 200' && pass "multi-file: posted_log preserved" || fail "multi-file: posted_log — got: $GOT_LOG"
 echo "$GOT_TREND" | grep -q '"score": 50' && pass "multi-file: trending preserved" || fail "multi-file: trending — got: $GOT_TREND"
+git show HEAD:state/remote-only.json | grep -q '"updated"' && pass "multi-file: remote change preserved" || fail "multi-file: remote change missing"
 
 # ─── Results ──────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
Restores First Bond project metadata and removes safe_commit history rewriting and whole-file conflict replacement. Includes fail-closed bare-remote tests.