### PR TITLE
Rebuild D365 twin as Customer Service Hub

### DIFF
--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -34,10 +34,10 @@ that can be **projected into any platform's native shape** on demand.
 Each "twin" is a **native-API sandbox** — same data, different shape. A Twitter
 client (tweepy, postman, curl) pointed at `api/twitter/2/` doesn't know it's
 talking to Rappterbook. The D365 projection at `api/data/v9.2/` is an immutable,
-OData-shaped JSON seed; `docs/d365/` layers a deterministic browser-local
-Service Hub over it for CRUD, faults, retries, concurrency, and virtual time.
-Its UI explicitly labels simulated writes as local rather than implying a
-Dataverse server accepted them.
+OData-shaped JSON seed; `docs/d365/` presents a clean Customer Service Hub over
+it for ordinary service work. Deterministic CRUD, faults, retries, concurrency,
+and virtual time remain available only in the visually separate Service
+Management area, where the in-memory simulation boundary is disclosed.
 
 ## What This Unlocks
 

--- a/docs/d365/app-helpers.mjs
+++ b/docs/d365/app-helpers.mjs
@@ -1,3 +1,265 @@
+export const PAGE_SIZE = 50;
+export const RELATED_EMAIL_LIMIT = 25;
+
+const DASHBOARD_FOCUS_TARGETS = Object.freeze({
+  selector: "dashboard-selector",
+  refresh: "dashboard-refresh",
+});
+
+export function replaceDialogState(activeDialog, incomingDialog) {
+  return {
+    activeDialog: incomingDialog,
+    replacement: activeDialog
+      ? { dialog: activeDialog, value: activeDialog.cancelValue }
+      : null,
+  };
+}
+
+export function dashboardRenderCompletion(focusTarget = null) {
+  return {
+    busy: false,
+    focusTargetId: DASHBOARD_FOCUS_TARGETS[focusTarget] || null,
+  };
+}
+
+export function savedFormRenderTarget(activeForm, savedRecord, selectedTab = "summary") {
+  if (!activeForm?.entity || !savedRecord) return null;
+  const initialTab = ["summary", "details", "related"].includes(selectedTab)
+    ? selectedTab
+    : "summary";
+  return {
+    entity: activeForm.entity,
+    record: savedRecord,
+    initialTab,
+  };
+}
+
+export function createNavigationHistory(currentIndex = 0) {
+  return {
+    currentIndex: Number.isInteger(currentIndex) ? currentIndex : 0,
+    pending: null,
+  };
+}
+
+export function pushNavigationHistory(history) {
+  return {
+    currentIndex: history.currentIndex + 1,
+    pending: null,
+  };
+}
+
+export function transitionHistoryPop(history, targetIndex, dirty) {
+  const pending = history.pending;
+  if (!Number.isInteger(targetIndex)) {
+    return {
+      state: history,
+      effect: { type: pending ? "stay" : "unknown" },
+    };
+  }
+  if (pending) {
+    const anchorIndex = pending.phase === "proceeding"
+      ? pending.targetIndex
+      : pending.originIndex;
+    if (targetIndex !== anchorIndex) {
+      return {
+        state: history,
+        effect: { type: "traverse", delta: anchorIndex - targetIndex },
+      };
+    }
+    if (pending.phase === "restoring") {
+      return {
+        state: { ...history, pending: { ...pending, phase: "prompting" } },
+        effect: { type: "prompt" },
+      };
+    }
+    if (pending.phase === "prompting") {
+      return { state: history, effect: { type: "stay" } };
+    }
+    if (pending.phase === "proceeding") {
+      return {
+        state: { currentIndex: targetIndex, pending: null },
+        effect: { type: "navigate" },
+      };
+    }
+    return { state: history, effect: { type: "stay" } };
+  }
+  if (targetIndex === history.currentIndex) {
+    return { state: history, effect: { type: "stay" } };
+  }
+  if (!dirty) {
+    return {
+      state: { currentIndex: targetIndex, pending: null },
+      effect: { type: "navigate" },
+    };
+  }
+  return {
+    state: {
+      ...history,
+      pending: {
+        originIndex: history.currentIndex,
+        targetIndex,
+        phase: "restoring",
+      },
+    },
+    effect: {
+      type: "traverse",
+      delta: history.currentIndex - targetIndex,
+    },
+  };
+}
+
+export function transitionHistoryPrompt(history, proceed) {
+  const pending = history.pending;
+  if (pending?.phase !== "prompting") {
+    return { state: history, effect: { type: "stay" } };
+  }
+  if (!proceed) {
+    return {
+      state: { currentIndex: pending.originIndex, pending: null },
+      effect: { type: "stay" },
+    };
+  }
+  return {
+    state: { ...history, pending: { ...pending, phase: "proceeding" } },
+    effect: {
+      type: "traverse",
+      delta: pending.targetIndex - pending.originIndex,
+    },
+  };
+}
+
+export function nextRovingTabIndex(tabs, currentIndex, key) {
+  const enabled = tabs
+    .map((tab, index) => ({ tab, index }))
+    .filter(({ tab }) => !tab.disabled)
+    .map(({ index }) => index);
+  if (!enabled.length) return -1;
+  if (key === "Home") return enabled[0];
+  if (key === "End") return enabled.at(-1);
+  if (key !== "ArrowLeft" && key !== "ArrowRight") return currentIndex;
+  const position = enabled.indexOf(currentIndex);
+  const offset = key === "ArrowRight" ? 1 : -1;
+  const nextPosition = position < 0
+    ? (offset > 0 ? 0 : enabled.length - 1)
+    : (position + offset + enabled.length) % enabled.length;
+  return enabled[nextPosition];
+}
+
+function normalizeSnapshotValue(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return null;
+    return Object.is(value, -0) ? 0 : value;
+  }
+  if (typeof value === "string") return value.replace(/\r\n?/g, "\n");
+  return value;
+}
+
+export function normalizeEditableSnapshot(values = {}) {
+  return Object.fromEntries(
+    Object.keys(values).sort().map((key) => [key, normalizeSnapshotValue(values[key])]),
+  );
+}
+
+export function editableSnapshotsEqual(left, right) {
+  return JSON.stringify(normalizeEditableSnapshot(left))
+    === JSON.stringify(normalizeEditableSnapshot(right));
+}
+
+export function isRecordEditable(entity, record, entityEditable = true) {
+  if (!entityEditable) return false;
+  if (!record) return true;
+  if (!["contacts", "accounts", "tasks", "incidents"].includes(entity)) return true;
+  return Number(record.statecode ?? 0) === 0;
+}
+
+export function recordCommandActions(entity, record, options = {}) {
+  const entityEditable = options.editable ?? true;
+  const deletable = options.deletable ?? true;
+  const creating = !record;
+  const active = Number(record?.statecode ?? 0) === 0;
+  const actions = [];
+  if (isRecordEditable(entity, record, entityEditable)) actions.push("save", "save-close");
+  if (!creating && (entity === "contacts" || entity === "accounts")) {
+    actions.push(active ? "deactivate" : "activate");
+  } else if (!creating && entity === "tasks" && active) {
+    actions.push("complete", "cancel");
+  } else if (!creating && entity === "incidents") {
+    actions.push(...(active ? ["resolve", "cancel"] : ["reopen"]));
+  }
+  if (!creating && entity === "emails" && options.hasSafeSource) actions.push("open-source");
+  if (!creating && deletable) actions.push("delete");
+  if (!creating) actions.push("refresh");
+  actions.push("back");
+  return actions;
+}
+
+export const NAV_GROUPS = Object.freeze([
+  Object.freeze({
+    label: "My Work",
+    items: Object.freeze([
+      Object.freeze({ key: "dashboard", label: "Dashboards" }),
+      Object.freeze({ key: "activities", label: "Activities" }),
+    ]),
+  }),
+  Object.freeze({
+    label: "Customers",
+    items: Object.freeze([
+      Object.freeze({ key: "accounts", label: "Accounts" }),
+      Object.freeze({ key: "contacts", label: "Contacts" }),
+    ]),
+  }),
+  Object.freeze({
+    label: "Service",
+    items: Object.freeze([
+      Object.freeze({ key: "cases", label: "Cases" }),
+      Object.freeze({ key: "queues", label: "Queues" }),
+    ]),
+  }),
+  Object.freeze({
+    label: "Knowledge",
+    items: Object.freeze([
+      Object.freeze({ key: "knowledge-articles", label: "Knowledge Articles" }),
+      Object.freeze({ key: "knowledge-search", label: "Knowledge Search" }),
+    ]),
+  }),
+  Object.freeze({
+    label: "Service Management",
+    items: Object.freeze([
+      Object.freeze({ key: "simulation-settings", label: "Simulation settings" }),
+      Object.freeze({ key: "api-simulation", label: "API & simulation" }),
+    ]),
+  }),
+]);
+
+export const SYSTEM_VIEWS = Object.freeze({
+  contacts: Object.freeze([
+    Object.freeze({ id: "active", label: "Active Contacts" }),
+    Object.freeze({ id: "inactive", label: "Inactive Contacts" }),
+    Object.freeze({ id: "all", label: "All Contacts" }),
+  ]),
+  accounts: Object.freeze([
+    Object.freeze({ id: "active", label: "Active Accounts" }),
+    Object.freeze({ id: "inactive", label: "Inactive Accounts" }),
+    Object.freeze({ id: "all", label: "All Accounts" }),
+  ]),
+  incidents: Object.freeze([
+    Object.freeze({ id: "active", label: "Active Cases" }),
+    Object.freeze({ id: "resolved", label: "Resolved Cases" }),
+    Object.freeze({ id: "all", label: "All Cases" }),
+  ]),
+  activities: Object.freeze([
+    Object.freeze({ id: "open", label: "Open Activities" }),
+    Object.freeze({ id: "closed", label: "Closed Activities" }),
+    Object.freeze({ id: "all", label: "All Activities" }),
+    Object.freeze({ id: "sent-email", label: "Sent Email" }),
+  ]),
+  connections: Object.freeze([
+    Object.freeze({ id: "active", label: "Active Connections" }),
+    Object.freeze({ id: "all", label: "All Connections" }),
+  ]),
+});
+
 const TASK_STATE_LABELS = Object.freeze({
   0: "Open",
   1: "Completed",
@@ -22,23 +284,25 @@ const INCIDENT_STATE_LABELS = Object.freeze({
   2: "Canceled",
 });
 
-function codeUnitCompare(left, right) {
+export function codeUnitCompare(left, right) {
   const first = String(left ?? "");
   const second = String(right ?? "");
   return first < second ? -1 : first > second ? 1 : 0;
 }
 
-function parsedCreatedOn(value) {
+function parsedDate(value) {
   if (typeof value !== "string" || !value.trim()) return null;
   const timestamp = Date.parse(value);
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 
-export function newestRelatedEmails(emails, limit = 25) {
-  const maximum = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 25;
+export function newestRelatedEmails(emails, limit = RELATED_EMAIL_LIMIT) {
+  const maximum = Number.isFinite(limit)
+    ? Math.max(0, Math.floor(limit))
+    : RELATED_EMAIL_LIMIT;
   return [...emails].sort((left, right) => {
-    const leftTimestamp = parsedCreatedOn(left?.createdon);
-    const rightTimestamp = parsedCreatedOn(right?.createdon);
+    const leftTimestamp = parsedDate(left?.createdon);
+    const rightTimestamp = parsedDate(right?.createdon);
     if (leftTimestamp !== null && rightTimestamp !== null) {
       return leftTimestamp === rightTimestamp
         ? codeUnitCompare(left?.activityid, right?.activityid)
@@ -50,11 +314,196 @@ export function newestRelatedEmails(emails, limit = 25) {
   }).slice(0, maximum);
 }
 
-export function gridCodeLabel(entity, field, value) {
+export function relatedEmailsForAccount(emails, accountId) {
+  return newestRelatedEmails((emails || []).filter((email) =>
+    emailReferencesAccount(email, accountId)));
+}
+
+export function relatedEmailsForContact(emails, contact) {
+  const contactId = String(contact?.contactid || "").toLowerCase();
+  const sourceKey = String(contact?.new_agentid || "").toLowerCase();
+  return newestRelatedEmails(emails.filter((email) => {
+    const authorId = String(email?.new_authorid || "").toLowerCase();
+    const authorKey = String(email?.new_author || "").toLowerCase();
+    return (contactId && authorId === contactId) || (sourceKey && authorKey === sourceKey);
+  }));
+}
+
+function normalizedIdentifier(value) {
+  let normalized = String(value ?? "").trim().toLowerCase();
+  normalized = normalized.replace(/^['"]|['"]$/g, "").trim();
+  if (normalized.startsWith("{") && normalized.endsWith("}")) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+  return normalized;
+}
+
+function boundAccountIdentifier(value) {
+  const match = String(value ?? "").trim().match(
+    /(?:^|\/)accounts\s*\(\s*(\{?[^{}()/?#]+\}?)\s*\)(?:[?#].*)?$/i,
+  );
+  return normalizedIdentifier(match?.[1]);
+}
+
+export function emailReferencesAccount(email, accountId) {
+  const normalized = normalizedIdentifier(accountId);
+  if (!normalized) return false;
+  return normalizedIdentifier(email?._regardingobjectid_value) === normalized
+    || boundAccountIdentifier(email?.["regardingobjectid_account@odata.bind"]) === normalized;
+}
+
+function routeSignature(route) {
+  return JSON.stringify({
+    view: route?.view ?? null,
+    entity: route?.entity ?? null,
+    id: route?.id === undefined || route?.id === null
+      ? null
+      : normalizedIdentifier(route.id),
+    query: route?.query ?? null,
+    path: route?.path ?? null,
+    initialView: route?.initialView ?? null,
+    scenario: route?.scenario ?? null,
+  });
+}
+
+export function captureRouteGuard(navigationToken, route) {
+  return Object.freeze({
+    navigationToken,
+    routeSignature: routeSignature(route),
+  });
+}
+
+export function routeGuardMatches(guard, navigationToken, route) {
+  return Boolean(guard)
+    && guard.navigationToken === navigationToken
+    && guard.routeSignature === routeSignature(route);
+}
+
+export function preflightContactDeletion(contactIds, contacts, connections) {
+  const requested = new Map();
+  for (const contactId of contactIds || []) {
+    const normalized = normalizedIdentifier(contactId);
+    if (normalized && !requested.has(normalized)) requested.set(normalized, String(contactId));
+  }
+  const names = new Map((contacts || []).map((contact) => [
+    normalizedIdentifier(contact?.contactid),
+    contact?.fullname
+      || [contact?.firstname, contact?.lastname].filter(Boolean).join(" ")
+      || String(contact?.contactid || ""),
+  ]));
+  const blockers = [];
+  for (const [normalized, contactId] of requested) {
+    const connectionIds = (connections || []).filter((connection) =>
+      normalizedIdentifier(connection?._record1id_value) === normalized
+      || normalizedIdentifier(connection?._record2id_value) === normalized)
+      .map((connection) => String(connection?.connectionid || ""))
+      .sort(codeUnitCompare);
+    if (connectionIds.length) {
+      blockers.push({
+        contactId,
+        contactName: names.get(normalized) || contactId,
+        connectionIds,
+      });
+    }
+  }
+  return {
+    allowed: blockers.length === 0,
+    blockers,
+  };
+}
+
+export function preflightAccountDeletion(accountIds, accounts, emails) {
+  const requested = new Map();
+  for (const accountId of accountIds || []) {
+    const normalized = normalizedIdentifier(accountId);
+    if (normalized && !requested.has(normalized)) requested.set(normalized, String(accountId));
+  }
+  const names = new Map((accounts || []).map((account) => [
+    normalizedIdentifier(account?.accountid),
+    account?.name || String(account?.accountid || ""),
+  ]));
+  const blockers = [];
+  for (const [normalized, accountId] of requested) {
+    const emailIds = (emails || [])
+      .filter((email) => emailReferencesAccount(email, normalized))
+      .map((email) => String(email?.activityid || ""))
+      .sort(codeUnitCompare);
+    if (emailIds.length) {
+      blockers.push({
+        accountId,
+        accountName: names.get(normalized) || accountId,
+        emailIds,
+      });
+    }
+  }
+  return {
+    allowed: blockers.length === 0,
+    blockers,
+  };
+}
+
+export function shouldInterceptSpaNavigation(options = {}) {
+  const target = String(options.target || "").trim().toLowerCase();
+  return !options.defaultPrevented
+    && Number(options.button ?? 0) === 0
+    && !options.ctrlKey
+    && !options.metaKey
+    && !options.shiftKey
+    && !options.altKey
+    && !options.download
+    && (!target || target === "_self");
+}
+
+export function isTaskOverdue(task, now) {
+  if (Number(task?.statecode) !== 0) return false;
+  const due = parsedDate(task?.scheduledend);
+  const current = parsedDate(now);
+  return due !== null && current !== null && due < current;
+}
+
+export function taskStatusLabel(task, now) {
+  if (Number(task?.statecode) === 0 && isTaskOverdue(task, now)) return "Overdue";
+  return TASK_STATE_LABELS[Number(task?.statecode)] ?? String(task?.statecode ?? "");
+}
+
+export function emailStatusLabel(email) {
+  const state = Number(email?.statecode);
+  if (state === 1 && Number(email?.statuscode) === 3) return "Sent";
+  if (state === 0) return "Open";
+  if (state === 2) return "Canceled";
+  return state === 1 ? "Completed" : String(email?.statuscode ?? "");
+}
+
+export function combineActivities(emails = [], tasks = [], now = "") {
+  const normalizedEmails = emails.map((email) => ({
+    ...email,
+    _activityType: "Email",
+    _entity: "emails",
+    _id: email.activityid,
+    _status: emailStatusLabel(email),
+    _regarding: email.new_channel || email.torecipients || "",
+    _activityDate: email.actualend || email.createdon || "",
+    _dueOrSent: email.actualend || email.createdon || "",
+  }));
+  const normalizedTasks = tasks.map((task) => ({
+    ...task,
+    _activityType: "Task",
+    _entity: "tasks",
+    _id: task.activityid,
+    _status: taskStatusLabel(task, now),
+    _regarding: "",
+    _activityDate: task.modifiedon || task.createdon || task.scheduledend || "",
+    _dueOrSent: task.scheduledend || "",
+  }));
+  return [...normalizedEmails, ...normalizedTasks];
+}
+
+export function gridCodeLabel(entity, field, value, now = "", record = null) {
   if (value === undefined || value === null || value === "") return null;
   const code = Number(value);
   if (field === "statecode") {
-    if (entity === "tasks") return TASK_STATE_LABELS[code] ?? String(value);
+    if (entity === "tasks") return record ? taskStatusLabel(record, now) : TASK_STATE_LABELS[code] ?? String(value);
+    if (entity === "emails") return record ? emailStatusLabel(record) : code === 1 ? "Sent" : String(value);
     if (entity === "incidents") return INCIDENT_STATE_LABELS[code] ?? String(value);
     return code === 0 ? "Active" : "Inactive";
   }
@@ -65,8 +514,223 @@ export function gridCodeLabel(entity, field, value) {
   return null;
 }
 
-export function isActiveEntityRoute(currentToken, currentRoute, expectedToken, expectedEntity) {
-  return currentToken === expectedToken
-    && currentRoute?.view === "entity"
-    && currentRoute.entity === expectedEntity;
+export function contactStatusLabel(value) {
+  if (value === undefined || value === null || value === "") return "";
+  return String(value).toLowerCase() === "active" ? "Active" : "Inactive";
+}
+
+export function applySystemView(records, entity, viewId) {
+  if (viewId === "all") return [...records];
+  if (entity === "contacts" || entity === "accounts") {
+    return records.filter((record) => Number(record.statecode) === (viewId === "inactive" ? 1 : 0));
+  }
+  if (entity === "incidents") {
+    if (viewId === "resolved") return records.filter((record) => Number(record.statecode) === 1);
+    return records.filter((record) => Number(record.statecode) === 0);
+  }
+  if (entity === "connections") {
+    return records.filter((record) => Number(record.statecode) === 0);
+  }
+  if (entity === "activities") {
+    if (viewId === "sent-email") {
+      return records.filter((record) => record._entity === "emails" && record._status === "Sent");
+    }
+    if (viewId === "open") {
+      return records.filter((record) => record._status === "Open" || record._status === "Overdue");
+    }
+    if (viewId === "closed") {
+      return records.filter((record) => !["Open", "Overdue"].includes(record._status));
+    }
+  }
+  return [...records];
+}
+
+export function searchRows(records, fields, query, displayValue = null) {
+  const term = String(query ?? "").trim().toLowerCase();
+  if (!term) return [...records];
+  return records.filter((record) => fields.some((field) => {
+    const raw = String(record[field] ?? "").toLowerCase();
+    const displayed = displayValue
+      ? String(displayValue(record, field) ?? "").toLowerCase()
+      : "";
+    return raw.includes(term) || displayed.includes(term);
+  }));
+}
+
+function compareGridValues(left, right) {
+  if (typeof left === "number" && typeof right === "number") return left - right;
+  return codeUnitCompare(String(left).toLowerCase(), String(right).toLowerCase());
+}
+
+export function stableSortRows(records, key, direction = "asc", identityKey = null) {
+  const multiplier = direction === "desc" ? -1 : 1;
+  return records.map((record, index) => ({ record, index })).sort((left, right) => {
+    const leftValue = left.record[key];
+    const rightValue = right.record[key];
+    const leftEmpty = leftValue === undefined || leftValue === null || leftValue === "";
+    const rightEmpty = rightValue === undefined || rightValue === null || rightValue === "";
+    if (leftEmpty !== rightEmpty) return leftEmpty ? 1 : -1;
+    const compared = leftEmpty && rightEmpty ? 0 : compareGridValues(leftValue, rightValue);
+    if (compared) return compared * multiplier;
+    if (identityKey) {
+      const identity = codeUnitCompare(left.record[identityKey], right.record[identityKey]);
+      if (identity) return identity;
+    }
+    return left.index - right.index;
+  }).map(({ record }) => record);
+}
+
+export function paginateRows(records, requestedPage, pageSize = PAGE_SIZE) {
+  const size = Math.max(1, Math.floor(Number(pageSize) || PAGE_SIZE));
+  const pageCount = Math.max(1, Math.ceil(records.length / size));
+  const page = Math.min(pageCount, Math.max(1, Math.floor(Number(requestedPage) || 1)));
+  const startIndex = (page - 1) * size;
+  const rows = records.slice(startIndex, startIndex + size);
+  return {
+    rows,
+    page,
+    pageCount,
+    pageSize: size,
+    total: records.length,
+    start: rows.length ? startIndex + 1 : 0,
+    end: startIndex + rows.length,
+    hasPrevious: page > 1,
+    hasNext: page < pageCount,
+  };
+}
+
+export function updateSelection(currentSelection, keys, selected) {
+  const next = new Set(currentSelection || []);
+  for (const key of keys) {
+    if (selected) next.add(key);
+    else next.delete(key);
+  }
+  return next;
+}
+
+export function resolveConnectionRows(connections, contacts) {
+  const names = new Map(contacts.map((contact) => [
+    String(contact.contactid || "").toLowerCase(),
+    contact.fullname || [contact.firstname, contact.lastname].filter(Boolean).join(" "),
+  ]));
+  return connections.map((connection) => ({
+    ...connection,
+    _record1name: names.get(String(connection._record1id_value || "").toLowerCase()) || "",
+    _record2name: names.get(String(connection._record2id_value || "").toLowerCase()) || "",
+  }));
+}
+
+export function relatedConnectionsForContact(connections, contactId, contacts) {
+  const normalized = String(contactId || "").toLowerCase();
+  return resolveConnectionRows(connections, contacts).flatMap((connection) => {
+    const firstId = String(connection._record1id_value || "").toLowerCase();
+    const secondId = String(connection._record2id_value || "").toLowerCase();
+    if (firstId !== normalized && secondId !== normalized) return [];
+    const currentIsFirst = firstId === normalized;
+    return [{
+      ...connection,
+      _relatedId: currentIsFirst ? connection._record2id_value : connection._record1id_value,
+      _relatedName: currentIsFirst ? connection._record2name : connection._record1name,
+      _relationship: currentIsFirst ? "Follows" : "Followed by",
+    }];
+  });
+}
+
+function newestFirst(records, dateKey, identityKey) {
+  return [...records].sort((left, right) => {
+    const leftDate = parsedDate(left[dateKey]);
+    const rightDate = parsedDate(right[dateKey]);
+    if (leftDate !== null && rightDate !== null && leftDate !== rightDate) return rightDate - leftDate;
+    if (leftDate !== null && rightDate === null) return -1;
+    if (leftDate === null && rightDate !== null) return 1;
+    return codeUnitCompare(left[identityKey], right[identityKey]);
+  });
+}
+
+function countActivityValues(activities, key) {
+  const counts = new Map();
+  for (const activity of activities) {
+    const label = String(activity[key] ?? "").trim();
+    if (label) counts.set(label, (counts.get(label) || 0) + 1);
+  }
+  return [...counts].map(([label, value]) => ({ label, value }))
+    .sort((left, right) => codeUnitCompare(left.label, right.label));
+}
+
+export function deriveDashboardMetrics(data, now) {
+  const incidents = data.incidents || [];
+  const contacts = data.contacts || [];
+  const accounts = data.accounts || [];
+  const activities = combineActivities(data.emails || [], data.tasks || [], now);
+  const activeCases = newestFirst(
+    incidents.filter((record) => Number(record.statecode) === 0),
+    "createdon",
+    "incidentid",
+  );
+  const recentActivities = newestFirst(activities, "_activityDate", "_id").slice(0, 8);
+  const openActivities = newestFirst(
+    activities.filter((record) => record._status === "Open" || record._status === "Overdue"),
+    "_dueOrSent",
+    "_id",
+  );
+  const sentEmails = newestFirst(
+    activities.filter((record) => record._entity === "emails" && record._status === "Sent"),
+    "_dueOrSent",
+    "_id",
+  );
+  const taskActivities = newestFirst(
+    activities.filter((record) => record._entity === "tasks"),
+    "_activityDate",
+    "_id",
+  );
+  const casePriority = [1, 2, 3].map((value) => ({
+    label: INCIDENT_PRIORITY_LABELS[value],
+    value: incidents.filter((record) => Number(record.prioritycode) === value).length,
+  }));
+  const contactStatus = [
+    { label: "Active", value: contacts.filter((record) => Number(record.statecode) === 0).length },
+    { label: "Inactive", value: contacts.filter((record) => Number(record.statecode) !== 0).length },
+  ];
+  const accountActivity = accounts.map((account) => ({
+    id: account.accountid,
+    label: account.name || "",
+    value: Number(account.new_postcount || 0),
+  })).sort((left, right) => right.value - left.value || codeUnitCompare(left.id, right.id));
+  return {
+    activeCases,
+    recentActivities,
+    openActivities,
+    sentEmails,
+    taskActivities,
+    activitiesByType: countActivityValues(activities, "_activityType"),
+    activitiesByStatus: countActivityValues(activities, "_status"),
+    casePriority,
+    contactStatus,
+    accountActivity,
+  };
+}
+
+export function transitionPatch(entity, action, now) {
+  const transitions = {
+    tasks: {
+      complete: { statecode: 1, statuscode: 5, actualend: now },
+      cancel: { statecode: 2, statuscode: 6, actualend: now },
+    },
+    incidents: {
+      resolve: { statecode: 1, statuscode: 5 },
+      cancel: { statecode: 2, statuscode: 6 },
+      reopen: { statecode: 0, statuscode: 1 },
+    },
+    contacts: {
+      activate: { statecode: 0, statuscode: 1, new_status: "active" },
+      deactivate: { statecode: 1, statuscode: 2, new_status: "inactive" },
+    },
+    accounts: {
+      activate: { statecode: 0, statuscode: 1 },
+      deactivate: { statecode: 1, statuscode: 2 },
+    },
+  };
+  const patch = transitions[entity]?.[action];
+  if (!patch) throw new TypeError(`Unsupported ${entity} transition: ${action}`);
+  return { ...patch };
 }

--- a/docs/d365/app.mjs
+++ b/docs/d365/app.mjs
@@ -1,226 +1,412 @@
 import {
   BUILT_IN_SCENARIOS,
   ENTITY_DEFINITIONS,
-  TwinRetryExhaustedError,
-  TwinTransportError,
   createTwin,
   parsePath,
   runBuiltInScenario,
 } from "./twin-core.mjs";
 import {
+  PAGE_SIZE,
+  SYSTEM_VIEWS,
+  applySystemView,
+  captureRouteGuard,
+  combineActivities,
+  contactStatusLabel,
+  createNavigationHistory,
+  dashboardRenderCompletion,
+  deriveDashboardMetrics,
+  editableSnapshotsEqual,
   gridCodeLabel,
-  isActiveEntityRoute,
-  newestRelatedEmails,
+  isRecordEditable,
+  isTaskOverdue,
+  nextRovingTabIndex,
+  normalizeEditableSnapshot,
+  paginateRows,
+  preflightAccountDeletion,
+  preflightContactDeletion,
+  pushNavigationHistory,
+  relatedConnectionsForContact,
+  relatedEmailsForAccount,
+  relatedEmailsForContact,
+  recordCommandActions,
+  replaceDialogState,
+  routeGuardMatches,
+  savedFormRenderTarget,
+  searchRows,
+  shouldInterceptSpaNavigation,
+  stableSortRows,
+  transitionHistoryPop,
+  transitionHistoryPrompt,
+  transitionPatch,
+  updateSelection,
 } from "./app-helpers.mjs";
 
 const API_ROOT = new URL("../api/data/v9.2/", import.meta.url);
-const TWIN_EPOCH = "2026-07-01T09:00:00.000Z";
-const MAX_GRID_ROWS = 300;
+const RUNTIME_EPOCH = "2026-07-01T09:00:00.000Z";
+const DASHBOARD_ENTITIES = Object.freeze(["incidents", "emails", "tasks", "contacts", "accounts"]);
+const HISTORY_INDEX_KEY = "customerServiceHistoryIndex";
 
 const ui = {
   root: document.querySelector("#view-root"),
   commands: document.querySelector("#command-bar"),
-  breadcrumb: document.querySelector("#breadcrumb"),
-  clock: document.querySelector("#header-clock"),
+  main: document.querySelector("#main-content"),
   status: document.querySelector("#live-status"),
   errors: document.querySelector("#live-errors"),
   sitemap: document.querySelector("#sitemap"),
   scrim: document.querySelector("#sitemap-scrim"),
-  sitemapToggle: document.querySelector("#sitemap-toggle"),
+  navigationToggle: document.querySelector("#navigation-toggle"),
+  navigationClose: document.querySelector("#navigation-close"),
+  launcher: document.querySelector("#app-launcher"),
+  selector: document.querySelector("#app-selector"),
+  launcherMenu: document.querySelector("#app-launcher-menu"),
+  quickCreate: document.querySelector("#quick-create"),
+  quickCreateMenu: document.querySelector("#quick-create-menu"),
+  areaSwitcher: document.querySelector("#area-switcher"),
+  areaMenu: document.querySelector("#area-menu"),
+  globalSearch: document.querySelector("#global-search"),
+  globalSearchInput: document.querySelector("#global-search-input"),
+  dialog: document.querySelector("#app-dialog"),
+  dialogTitle: document.querySelector("#dialog-title"),
+  dialogContent: document.querySelector("#dialog-content"),
+  dialogActions: document.querySelector("#dialog-actions"),
+  dialogClose: document.querySelector("#dialog-close"),
 };
 
 const app = {
-  twin: createTwin({ epoch: TWIN_EPOCH, seedName: "rappterbook-pages-snapshot" }),
+  twin: createTwin({ epoch: RUNTIME_EPOCH, seedName: "customer-service-hub-data" }),
   metadata: null,
-  counts: new Map(),
   loadedEntities: new Set(),
   entityPromises: new Map(),
   seedInstallTail: Promise.resolve(),
   navigationToken: 0,
   requestCounter: 0,
-  grid: new Map(),
   currentRoute: null,
+  currentHash: "",
+  navigationHistory: createNavigationHistory(),
+  grid: new Map(),
+  associatedGrid: new Map(),
+  bpfStages: new Map(),
+  dashboardView: "customer-service",
+  dirty: false,
+  activeForm: null,
+  activeDialog: null,
+  historyPromptPromise: null,
   lastScenario: null,
   lastManualResponse: null,
+  activePopup: null,
+  shellListenersReady: false,
 };
 
-const recordTabSelectionTokens = new WeakMap();
+const ICON_PATHS = Object.freeze({
+  add: "M12 5v14M5 12h14",
+  back: "m14 6-6 6 6 6M8 12h11",
+  cancel: "m6 6 12 12M18 6 6 18",
+  check: "m5 12 4 4L19 6",
+  delete: "M6 7h12M9 7V4h6v3M8 7l1 13h6l1-13M11 10v7M14 10v7",
+  edit: "m5 16-1 4 4-1L18 9l-3-3zM13 8l3 3",
+  external: "M13 5h6v6M19 5l-8 8M17 13v6H5V7h6",
+  refresh: "M19 8V4l-2 2a8 8 0 1 0 2 9M19 4h-4",
+  reopen: "M8 8H4V4M4 8a8 8 0 1 1 1 9",
+  save: "M5 4h12l2 2v14H5zM8 4v6h8V4M8 20v-6h8v6",
+  search: "M10.5 5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11m4.5 10 5 5",
+  state: "M12 4v16M5 12h14",
+  time: "M12 4a8 8 0 1 0 8 8 8 8 0 0 0-8-8m0 4v5l3 2",
+});
 
-const ENTITY_UI = {
+const CHOICES = Object.freeze({
+  taskPriority: Object.freeze([[0, "Low"], [1, "Normal"], [2, "High"]]),
+  casePriority: Object.freeze([[1, "High"], [2, "Normal"], [3, "Low"]]),
+  caseOrigin: Object.freeze([[1, "Phone"], [2, "Email"], [3, "Web"]]),
+  caseType: Object.freeze([[1, "Question"], [2, "Problem"], [3, "Request"]]),
+});
+
+function field(key, label, options = {}) {
+  return { key, label, type: "text", ...options };
+}
+
+const ENTITY_UI = Object.freeze({
   contacts: {
     label: "Contacts",
     singular: "Contact",
-    icon: "♙",
+    route: "contacts",
     primaryKey: "contactid",
     nameField: "fullname",
     creatable: true,
     editable: true,
+    deletable: true,
+    defaultView: "active",
     columns: [
-      ["fullname", "Full name"], ["jobtitle", "Job title"], ["emailaddress1", "Email"],
-      ["new_karma", "Karma", "number"], ["new_status", "Status", "status"], ["modifiedon", "Modified", "date"],
+      field("fullname", "Full Name"),
+      field("emailaddress1", "Email"),
+      field("jobtitle", "Job Title"),
+      field("new_status", "Customer Status", { type: "contact-status" }),
+      field("new_karma", "Engagement Score", { type: "number" }),
+      field("modifiedon", "Modified On", { type: "date" }),
+    ],
+    headerFields: [
+      field("emailaddress1", "Email"),
+      field("jobtitle", "Job title"),
+      field("new_status", "Customer status", { type: "contact-status" }),
+      field("new_karma", "Engagement score", { type: "number" }),
     ],
     sections: [
-      ["General", [
-        field("firstname", "First name", true), field("lastname", "Last name", true),
-        field("emailaddress1", "Email", true, "email"), field("jobtitle", "Job title", true),
-        field("department", "Department", true), field("new_status", "Agent status", true, "select", ["active", "dormant"]),
-        field("description", "Description", true, "textarea", null, true),
-      ]],
-      ["Rappterbook", [
-        field("new_agentid", "Agent ID"), field("new_archetype", "Archetype"),
-        field("new_karma", "Karma"), field("new_postcount", "Posts"),
-        field("new_commentcount", "Comments"), field("new_subscribedchannels", "Subscribed channels", false, "text", null, true),
-      ]],
-      ["System", [
-        field("contactid", "Contact ID"), field("@odata.etag", "ETag"),
-        field("statecode", "State"), field("statuscode", "Status reason"),
-        field("createdon", "Created on"), field("modifiedon", "Modified on"),
-      ]],
+      {
+        tab: "summary", title: "Contact Information", fields: [
+          field("firstname", "First name", { editable: true, required: true }),
+          field("lastname", "Last name", { editable: true }),
+          field("emailaddress1", "Email", { editable: true, type: "email" }),
+          field("description", "Description", { editable: true, type: "textarea", full: true }),
+        ],
+      },
+      {
+        tab: "summary", title: "Professional Information", fields: [
+          field("jobtitle", "Job title", { editable: true }),
+          field("department", "Department", { editable: true }),
+          field("new_archetype", "Role category"),
+          field("new_status", "Customer status", { type: "contact-status" }),
+        ],
+      },
+      {
+        tab: "summary", title: "Engagement", fields: [
+          field("new_karma", "Engagement score", { type: "number" }),
+          field("new_karmabalance", "Engagement balance", { type: "number" }),
+          field("new_postcount", "Contributions", { type: "number" }),
+          field("new_commentcount", "Interactions", { type: "number" }),
+          field("new_subscribedchannels", "Topics of interest", { full: true }),
+        ],
+      },
+      {
+        tab: "details", title: "Administration", fields: [
+          field("statecode", "Status", { type: "state" }),
+          field("statuscode", "Status reason", { type: "status-reason" }),
+          field("createdon", "Created on", { type: "date" }),
+          field("modifiedon", "Modified on", { type: "date" }),
+        ],
+      },
     ],
   },
   accounts: {
     label: "Accounts",
     singular: "Account",
-    icon: "▤",
+    route: "accounts",
     primaryKey: "accountid",
     nameField: "name",
     creatable: true,
     editable: true,
+    deletable: true,
+    defaultView: "active",
     columns: [
-      ["name", "Account name"], ["description", "Description"], ["new_postcount", "Posts", "number"],
-      ["new_slug", "Slug"], ["createdon", "Created", "date"],
+      field("name", "Account Name"),
+      field("new_slug", "Topic"),
+      field("new_postcount", "Activity Volume", { type: "number" }),
+      field("statecode", "Status", { type: "state" }),
+      field("createdon", "Created On", { type: "date" }),
+    ],
+    headerFields: [
+      field("new_slug", "Topic"),
+      field("new_postcount", "Activity volume", { type: "number" }),
+      field("statecode", "Status", { type: "state" }),
+      field("createdon", "Created on", { type: "date" }),
     ],
     sections: [
-      ["General", [
-        field("name", "Account name", true), field("websiteurl", "Website", true, "url"),
-        field("description", "Description", true, "textarea", null, true),
-      ]],
-      ["Rappterbook", [
-        field("new_slug", "Channel slug"), field("new_postcount", "Post count"),
-        field("new_icon", "Icon", true), field("new_topicaffinity", "Topic affinity", true),
-        field("new_constitution", "Constitution", true, "textarea", null, true),
-      ]],
-      ["System", [
-        field("accountid", "Account ID"), field("@odata.etag", "ETag"),
-        field("statecode", "State"), field("statuscode", "Status reason"),
-        field("createdon", "Created on"), field("modifiedon", "Modified on"),
-      ]],
+      {
+        tab: "summary", title: "Account Information", fields: [
+          field("name", "Account name", { editable: true, required: true }),
+          field("websiteurl", "Website", { editable: true, type: "url" }),
+          field("description", "Description", { editable: true, type: "textarea", full: true }),
+        ],
+      },
+      {
+        tab: "summary", title: "Engagement Profile", fields: [
+          field("new_slug", "Topic"),
+          field("new_postcount", "Activity volume", { type: "number" }),
+          field("new_topicaffinity", "Topic affinity", { editable: true }),
+          field("new_constitution", "Service notes", { editable: true, type: "textarea", full: true }),
+        ],
+      },
+      {
+        tab: "details", title: "Administration", fields: [
+          field("statecode", "Status", { type: "state" }),
+          field("statuscode", "Status reason", { type: "status-reason" }),
+          field("createdon", "Created on", { type: "date" }),
+          field("modifiedon", "Modified on", { type: "date" }),
+        ],
+      },
     ],
   },
   emails: {
-    label: "Emails",
+    label: "Email Activities",
     singular: "Email",
-    icon: "✉",
+    route: "emails",
     primaryKey: "activityid",
     nameField: "subject",
     creatable: false,
     editable: false,
-    columns: [
-      ["subject", "Subject"], ["new_channel", "Channel"], ["new_author", "From"],
-      ["new_upvotes", "Upvotes", "number"], ["new_commentcount", "Replies", "number"], ["createdon", "Sent", "date"],
+    deletable: true,
+    columns: [],
+    headerFields: [
+      field("sender", "From"),
+      field("torecipients", "To"),
+      field("actualend", "Sent on", { type: "date" }),
+      field("new_channel", "Topic"),
     ],
     sections: [
-      ["Message", [
-        field("subject", "Subject"), field("sender", "From"), field("torecipients", "To"),
-        field("description", "Description", false, "text", null, true),
-      ]],
-      ["Rappterbook", [
-        field("new_discussionnumber", "Discussion number"), field("new_channel", "Channel"),
-        field("new_author", "Author"), field("new_upvotes", "Upvotes"),
-        field("new_downvotes", "Downvotes"), field("new_commentcount", "Replies"),
-        field("new_url", "Discussion URL", false, "url", null, true),
-      ]],
-      ["System", [
-        field("activityid", "Activity ID"), field("@odata.etag", "ETag"),
-        field("statecode", "State"), field("statuscode", "Status reason"),
-        field("createdon", "Created on"), field("actualend", "Sent on"),
-      ]],
+      {
+        tab: "summary", title: "Message", fields: [
+          field("subject", "Subject", { full: true }),
+          field("sender", "From"),
+          field("torecipients", "To"),
+          field("description", "Message", { type: "multiline", full: true }),
+        ],
+      },
+      {
+        tab: "summary", title: "Regarding", fields: [
+          field("new_channel", "Topic"),
+          field("new_posttopic", "Subject category"),
+          field("new_url", "Source", { type: "url", full: true }),
+        ],
+      },
+      {
+        tab: "summary", title: "Interaction Summary", fields: [
+          field("new_upvotes", "Positive responses", { type: "number" }),
+          field("new_downvotes", "Negative responses", { type: "number" }),
+          field("new_commentcount", "Responses", { type: "number" }),
+        ],
+      },
+      {
+        tab: "details", title: "Administration", fields: [
+          field("statecode", "Status", { type: "state" }),
+          field("statuscode", "Status reason", { type: "status-reason" }),
+          field("createdon", "Created on", { type: "date" }),
+          field("modifiedon", "Modified on", { type: "date" }),
+          field("actualend", "Sent on", { type: "date" }),
+        ],
+      },
     ],
   },
   tasks: {
-    label: "Activities",
+    label: "Tasks",
     singular: "Task",
-    icon: "✓",
+    route: "tasks",
     primaryKey: "activityid",
     nameField: "subject",
     creatable: true,
     editable: true,
-    columns: [
-      ["subject", "Subject"], ["description", "Description"], ["statecode", "State", "state"],
-      ["prioritycode", "Priority", "priority"], ["scheduledend", "Due", "date"],
+    deletable: true,
+    columns: [],
+    headerFields: [
+      field("statecode", "Status", { type: "task-state" }),
+      field("prioritycode", "Priority", { type: "priority" }),
+      field("scheduledend", "Due", { type: "date" }),
+      field("actualend", "Completed on", { type: "date" }),
     ],
     sections: [
-      ["Task", [
-        field("subject", "Subject", true), field("prioritycode", "Priority", true, "number"),
-        field("scheduledend", "Due", true, "datetime"), field("description", "Description", true, "textarea", null, true),
-      ]],
-      ["Poke mapping", [
-        field("new_fromid", "From agent"), field("new_toid", "To agent"), field("new_poketype", "Poke type"),
-      ]],
-      ["System", [
-        field("activityid", "Activity ID"), field("@odata.etag", "ETag"),
-        field("statecode", "State"), field("statuscode", "Status reason"),
-        field("createdon", "Created on"), field("modifiedon", "Modified on"), field("actualend", "Completed on"),
-      ]],
-    ],
-  },
-  connections: {
-    label: "Connections",
-    singular: "Connection",
-    icon: "⇄",
-    primaryKey: "connectionid",
-    nameField: "name",
-    creatable: false,
-    editable: false,
-    columns: [
-      ["name", "Relationship"], ["_record1id_value", "Record 1"], ["_record2id_value", "Record 2"],
-      ["statecode", "State", "state"],
-    ],
-    sections: [
-      ["Connection", [
-        field("name", "Name"), field("_record1id_value", "Record 1"),
-        field("_record2id_value", "Record 2"), field("record1objecttypecode", "Record 1 type"),
-        field("record2objecttypecode", "Record 2 type"),
-      ]],
-      ["System", [
-        field("connectionid", "Connection ID"), field("@odata.etag", "ETag"),
-        field("statecode", "State"), field("statuscode", "Status reason"),
-      ]],
+      {
+        tab: "summary", title: "Task Details", fields: [
+          field("subject", "Subject", { editable: true, required: true, full: true }),
+          field("prioritycode", "Priority", { editable: true, type: "choice", choices: CHOICES.taskPriority, defaultValue: 1 }),
+          field("description", "Description", { editable: true, type: "textarea", full: true }),
+        ],
+      },
+      {
+        tab: "summary", title: "Scheduling", fields: [
+          field("scheduledend", "Due", { editable: true, type: "datetime" }),
+          field("actualend", "Completed on", { type: "date" }),
+          field("new_poketype", "Interaction type"),
+        ],
+      },
+      {
+        tab: "details", title: "Administration", fields: [
+          field("statecode", "Status", { type: "task-state" }),
+          field("statuscode", "Status reason", { type: "status-reason" }),
+          field("createdon", "Created on", { type: "date" }),
+          field("modifiedon", "Modified on", { type: "date" }),
+        ],
+      },
     ],
   },
   incidents: {
     label: "Cases",
     singular: "Case",
-    icon: "◫",
+    route: "cases",
     primaryKey: "incidentid",
     nameField: "title",
     creatable: true,
     editable: true,
+    deletable: true,
+    defaultView: "active",
     columns: [
-      ["title", "Case title"], ["new_category", "Category"], ["prioritycode", "Priority", "priority"],
-      ["new_sla_status", "SLA", "status"], ["statecode", "State", "state"], ["createdon", "Created", "date"],
+      field("title", "Case Title"),
+      field("new_category", "Category"),
+      field("prioritycode", "Priority", { type: "priority" }),
+      field("new_sla_status", "SLA Status", { type: "service-status" }),
+      field("statecode", "Status", { type: "state" }),
+      field("createdon", "Created On", { type: "date" }),
+    ],
+    headerFields: [
+      field("statecode", "Status", { type: "state" }),
+      field("prioritycode", "Priority", { type: "priority" }),
+      field("new_category", "Category"),
+      field("new_sla_status", "SLA status", { type: "service-status" }),
     ],
     sections: [
-      ["Case details", [
-        field("title", "Title", true), field("prioritycode", "Priority", true, "number"),
-        field("new_category", "Category", true), field("new_sla_due", "SLA due", true, "datetime"),
-        field("new_sla_status", "SLA status", true), field("description", "Description", true, "textarea", null, true),
-      ]],
-      ["Diagnostics", [
-        field("new_score", "Score"), field("new_grade", "Grade"),
-        field("new_overallscore", "Overall score"), field("severitycode", "Severity"),
-      ]],
-      ["System", [
-        field("incidentid", "Case ID"), field("@odata.etag", "ETag"),
-        field("statecode", "State"), field("statuscode", "Status reason"), field("createdon", "Created on"),
-      ]],
+      {
+        tab: "summary", title: "Case Summary", fields: [
+          field("title", "Case title", { editable: true, required: true, full: true }),
+        ],
+      },
+      {
+        tab: "summary", title: "Classification", fields: [
+          field("prioritycode", "Priority", { editable: true, type: "choice", choices: CHOICES.casePriority, defaultValue: 2 }),
+          field("caseorigincode", "Origin", { editable: true, type: "choice", choices: CHOICES.caseOrigin, defaultValue: 3 }),
+          field("casetypecode", "Case type", { editable: true, type: "choice", choices: CHOICES.caseType, defaultValue: 2 }),
+          field("new_category", "Category", { editable: true }),
+          field("severitycode", "Severity", { type: "number" }),
+        ],
+      },
+      {
+        tab: "summary", title: "Service Level", fields: [
+          field("new_sla_status", "SLA status", { type: "service-status" }),
+          field("new_sla_due", "SLA due", { editable: true, type: "datetime" }),
+          field("new_score", "Service score", { type: "number" }),
+          field("new_overallscore", "Overall score", { type: "number" }),
+          field("new_grade", "Service grade"),
+        ],
+      },
+      {
+        tab: "details", title: "Description", fields: [
+          field("description", "Detailed description", { editable: true, type: "textarea", full: true }),
+        ],
+      },
+      {
+        tab: "details", title: "Administration", fields: [
+          field("statecode", "Status", { type: "state" }),
+          field("statuscode", "Status reason", { type: "status-reason" }),
+          field("createdon", "Created on", { type: "date" }),
+          field("modifiedon", "Modified on", { type: "date" }),
+        ],
+      },
     ],
   },
-};
+});
 
-function field(key, label, editable = false, type = "text", options = null, full = false) {
-  return { key, label, editable, type, options, full };
-}
+const ACTIVITIES_GRID = Object.freeze({
+  label: "Activities",
+  singular: "Activity",
+  primaryKey: "_key",
+  defaultView: "open",
+  creatable: true,
+  editable: true,
+  deletable: true,
+  columns: [
+    field("subject", "Subject"),
+    field("_activityType", "Activity Type"),
+    field("_status", "Status", { type: "activity-status" }),
+    field("_regarding", "Regarding"),
+    field("_dueOrSent", "Due or Sent", { type: "date" }),
+    field("prioritycode", "Priority", { type: "activity-priority" }),
+  ],
+});
 
 function node(tag, properties = {}, children = []) {
   const element = document.createElement(tag);
@@ -233,6 +419,8 @@ function node(tag, properties = {}, children = []) {
       for (const [eventName, handler] of Object.entries(value)) element.addEventListener(eventName, handler);
     } else if (key === "disabled") element.disabled = Boolean(value);
     else if (key === "checked") element.checked = Boolean(value);
+    else if (key === "selected") element.selected = Boolean(value);
+    else if (key === "hidden") element.hidden = Boolean(value);
     else if (key === "value") element.value = String(value);
     else element.setAttribute(key, String(value));
   }
@@ -244,45 +432,26 @@ function node(tag, properties = {}, children = []) {
   return element;
 }
 
+function svgElement(tag, attributes = {}, children = []) {
+  const element = document.createElementNS("http://www.w3.org/2000/svg", tag);
+  for (const [key, value] of Object.entries(attributes)) element.setAttribute(key, String(value));
+  for (const child of children) element.append(child);
+  return element;
+}
+
+function icon(name, className = "ui-icon") {
+  const svg = svgElement("svg", {
+    class: className,
+    viewBox: "0 0 24 24",
+    "aria-hidden": "true",
+    focusable: "false",
+  });
+  svg.append(svgElement("path", { d: ICON_PATHS[name] || ICON_PATHS.state }));
+  return svg;
+}
+
 function replace(target, ...children) {
   target.replaceChildren(...children.flat(Infinity).filter((child) => child !== null && child !== undefined));
-}
-
-function rawJson(value, className = "json-block") {
-  const pre = node("pre", { className });
-  pre.textContent = JSON.stringify(value, null, 2);
-  return pre;
-}
-
-function safeHttpUrl(value) {
-  try {
-    const parsed = new URL(String(value), window.location.href);
-    return ["http:", "https:"].includes(parsed.protocol) ? parsed.href : null;
-  } catch {
-    return null;
-  }
-}
-
-function externalLink(value, label = null) {
-  const safe = safeHttpUrl(value);
-  if (!safe) return node("span", { className: "read-value", text: value || "—" });
-  return node("a", {
-    className: "external-link",
-    href: safe,
-    target: "_blank",
-    rel: "noopener noreferrer",
-    text: label || value,
-  });
-}
-
-function openExternal(value) {
-  const safe = safeHttpUrl(value);
-  if (!safe) {
-    announceError("Only http and https links can be opened.");
-    return;
-  }
-  const opened = window.open(safe, "_blank", "noopener,noreferrer");
-  if (opened) opened.opener = null;
 }
 
 function announce(message) {
@@ -299,21 +468,54 @@ function setBusy(busy) {
   ui.root.setAttribute("aria-busy", String(Boolean(busy)));
 }
 
-function updateClock() {
-  ui.clock.textContent = app.twin.now().replace(".000Z", "Z");
-}
-
 function requestId(prefix) {
   app.requestCounter += 1;
-  return `ui-${prefix}-${String(app.requestCounter).padStart(4, "0")}`;
+  return `ui-${prefix}-${String(app.requestCounter).padStart(5, "0")}`;
 }
 
-function metadataCounts(metadata) {
-  const counts = new Map();
-  for (const entity of metadata.EntitySets || []) {
-    counts.set(entity.name, Number(entity.recordCount ?? 0));
+function currentRouteGuard() {
+  return captureRouteGuard(app.navigationToken, app.currentRoute);
+}
+
+function routeGuardIsCurrent(guard) {
+  return routeGuardMatches(guard, app.navigationToken, app.currentRoute);
+}
+
+function safeHttpUrl(value) {
+  try {
+    const parsed = new URL(String(value), window.location.href);
+    return ["http:", "https:"].includes(parsed.protocol) ? parsed.href : null;
+  } catch {
+    return null;
   }
-  return counts;
+}
+
+function externalLink(value, label = null) {
+  const safe = safeHttpUrl(value);
+  if (!safe) return node("span", { className: "field-value", text: value || "" });
+  return node("a", {
+    className: "external-link",
+    href: safe,
+    target: "_blank",
+    rel: "noopener noreferrer",
+    text: label || value,
+  });
+}
+
+function openExternal(value) {
+  const safe = safeHttpUrl(value);
+  if (!safe) {
+    showErrorDialog("Link could not be opened", "Only HTTP and HTTPS links can be opened.");
+    return;
+  }
+  const opened = window.open(safe, "_blank", "noopener,noreferrer");
+  if (opened) opened.opener = null;
+}
+
+function rawJson(value, className = "json-block") {
+  const output = node("pre", { className });
+  output.textContent = JSON.stringify(value, null, 2);
+  return output;
 }
 
 async function fetchSeedJson(filename) {
@@ -334,15 +536,8 @@ async function fetchSeedJson(filename) {
 
 async function loadMetadata() {
   const metadata = await fetchSeedJson("$metadata.json");
-  if (!Array.isArray(metadata.EntitySets)) {
-    throw new Error("Failed to load D365 metadata: EntitySets is missing.");
-  }
+  if (!Array.isArray(metadata.EntitySets)) throw new Error("Entity set metadata is unavailable.");
   app.metadata = metadata;
-  app.counts = metadataCounts(metadata);
-  for (const countNode of document.querySelectorAll("[data-count]")) {
-    const count = app.counts.get(countNode.dataset.count);
-    countNode.textContent = Number.isFinite(count) ? count.toLocaleString() : "—";
-  }
 }
 
 async function ensureEntity(entity) {
@@ -376,44 +571,87 @@ async function ensureEntities(entities) {
   await Promise.all([...new Set(entities)].map((entity) => ensureEntity(entity)));
 }
 
-async function ensureScenarioEntities(scenarioId) {
-  const scenario = BUILT_IN_SCENARIOS.find((item) => item.id === scenarioId);
-  if (!scenario) throw new TypeError(`Unknown scenario: ${scenarioId}`);
-  await ensureEntities(scenario.entities || []);
+function decodeSegment(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function parseRoute() {
-  const value = window.location.hash.replace(/^#\/?/, "").split("?")[0];
-  const segments = value.split("/").filter(Boolean).map(decodeURIComponent);
-  if (!segments.length) return { view: "dashboard" };
-  if (segments[0] === "dashboard" || segments[0] === "lab" || segments[0] === "about") {
-    return { view: segments[0] };
+  const hash = window.location.hash || "#/dashboard";
+  const [rawPath, rawQuery = ""] = hash.replace(/^#\/?/, "").split("?");
+  const segments = rawPath.split("/").filter(Boolean).map(decodeSegment);
+  const query = new URLSearchParams(rawQuery);
+  if (!segments.length || segments[0] === "dashboard") return { view: "dashboard" };
+  if (segments[0] === "activities") return { view: "grid", entity: "activities" };
+  if (segments[0] === "emails") {
+    return segments[1]
+      ? { view: "record", entity: "emails", id: segments[1] }
+      : { view: "grid", entity: "activities", initialView: "sent-email" };
   }
-  if (ENTITY_UI[segments[0]]) {
-    return { view: "entity", entity: segments[0], id: segments[1] || null };
+  if (segments[0] === "tasks") {
+    return segments[1]
+      ? { view: "record", entity: "tasks", id: segments[1] }
+      : { view: "grid", entity: "activities", initialView: "open" };
   }
-  return { view: "not-found", path: segments.join("/") };
+  if (segments[0] === "contacts" || segments[0] === "accounts") {
+    return segments[1]
+      ? { view: "record", entity: segments[0], id: segments[1], initialTab: segments[2] === "related" ? "related" : null }
+      : { view: "grid", entity: segments[0] };
+  }
+  if (segments[0] === "cases" || segments[0] === "incidents") {
+    return segments[1]
+      ? { view: "record", entity: "incidents", id: segments[1] }
+      : { view: "grid", entity: "incidents" };
+  }
+  if (segments[0] === "queues") return { view: "queues" };
+  if (segments[0] === "knowledge-articles") return { view: "knowledge-articles" };
+  if (segments[0] === "knowledge-search") return { view: "knowledge-search", query: query.get("q") || "" };
+  if (segments[0] === "search") return { view: "search", query: query.get("q") || "" };
+  if (segments[0] === "lab") return { view: "simulation-settings", scenario: query.get("scenario") };
+  if (segments[0] === "about") return { view: "api-simulation" };
+  if (segments[0] === "service-management" && segments[1] === "simulation-settings") {
+    return { view: "simulation-settings", scenario: query.get("scenario") };
+  }
+  if (segments[0] === "service-management" && segments[1] === "api-simulation") {
+    return { view: "api-simulation" };
+  }
+  return { view: "not-found", path: rawPath };
 }
 
 function routeHref(entity, id = null) {
-  return id ? `#/${entity}/${encodeURIComponent(id)}` : `#/${entity}`;
+  const route = entity === "incidents" ? "cases" : entity;
+  return id ? `#/${route}/${encodeURIComponent(id)}` : `#/${route}`;
 }
 
-function setActiveNav(key) {
-  for (const link of document.querySelectorAll("[data-nav]")) {
-    link.classList.toggle("active", link.dataset.nav === key);
+function routeNavKey(route) {
+  if (route.view === "record") {
+    if (route.entity === "emails" || route.entity === "tasks") return "activities";
+    return route.entity === "incidents" ? "cases" : route.entity;
   }
+  if (route.view === "grid") return route.entity === "incidents" ? "cases" : route.entity;
+  return route.view;
 }
 
-function closeSitemap() {
-  ui.sitemap.classList.remove("open");
-  ui.scrim.classList.remove("open");
-  ui.sitemapToggle.setAttribute("aria-expanded", "false");
+function setActiveNavigation(route) {
+  const active = routeNavKey(route);
+  for (const link of document.querySelectorAll("[data-nav]")) {
+    const selected = link.dataset.nav === active;
+    link.classList.toggle("active", selected);
+    if (selected) link.setAttribute("aria-current", "page");
+    else link.removeAttribute("aria-current");
+  }
+  const management = ["simulation-settings", "api-simulation"].includes(active);
+  ui.sitemap.classList.toggle("management-area", management);
+  ui.areaSwitcher.querySelector("span").textContent = management ? "Service Management" : "Customer Service";
 }
 
 function showLoading(message) {
   setBusy(true);
-  replace(ui.root, node("div", { className: "loading-card", role: "status" }, [
+  setCommands([]);
+  replace(ui.root, node("div", { className: "loading-state", role: "status" }, [
     node("span", { className: "spinner", "aria-hidden": "true" }),
     node("span", { text: message }),
   ]));
@@ -421,193 +659,278 @@ function showLoading(message) {
 
 function showLoadError(title, error, retry) {
   setBusy(false);
-  const card = node("section", { className: "error-card", role: "alert" }, [
-    node("h2", { text: title }),
-    node("p", {
-      text: `${error.message} The dataset could not be loaded; no empty fallback was substituted.`,
-    }),
-    node("button", { className: "retry-button", type: "button", text: "Retry", on: { click: retry } }),
-  ]);
-  replace(ui.root, card);
+  setCommands([]);
+  replace(ui.root, node("section", { className: "error-state", role: "alert" }, [
+    icon("cancel", "state-icon"),
+    node("h1", { text: title }),
+    node("p", { text: error.message }),
+    node("button", { className: "primary-button", type: "button", text: "Try again", on: { click: retry } }),
+  ]));
   announceError(`${title}: ${error.message}`);
 }
 
-function localNotice() {
-  return node("aside", { className: "local-notice" }, [
-    node("span", { "aria-hidden": "true", text: "⚠" }),
-    node("strong", { text: "Local simulation" }),
-    node("span", { text: "Creates, edits, deactivations, deletes, faults, and time travel stay in this browser tab. Generated JSON is immutable." }),
-  ]);
-}
-
-function pageHeader(title, subtitle) {
-  return node("header", { className: "page-header" }, [
+function pageHeading(title, subtitle = "") {
+  return node("header", { className: "page-heading" }, [
     node("div", {}, [
       node("h1", { text: title }),
-      node("p", { className: "page-subtitle", text: subtitle }),
+      subtitle ? node("p", { text: subtitle }) : null,
     ]),
   ]);
 }
 
-function command(label, icon, handler, options = {}) {
+function command(label, iconName, handler, options = {}) {
   return node("button", {
+    id: options.id,
     type: "button",
-    className: `command-button${options.primary ? " primary" : ""}${options.danger ? " danger" : ""}`,
-    text: `${icon} ${label}`,
+    className: `command${options.primary ? " primary" : ""}${options.danger ? " danger" : ""}`,
     disabled: options.disabled,
     title: options.title || label,
+    "aria-label": options.ariaLabel || label,
+    "data-action": options.action,
     on: { click: handler },
-  });
+  }, [icon(iconName), node("span", { text: label })]);
 }
 
 function setCommands(commands) {
   const children = [];
   for (const item of commands) {
     if (item === "separator") children.push(node("span", { className: "command-separator", "aria-hidden": "true" }));
-    else children.push(item);
+    else if (item) children.push(item);
   }
   replace(ui.commands, children);
+  ui.commands.hidden = children.length === 0;
 }
 
-function setBreadcrumb(items) {
-  const children = [];
-  items.forEach((item, index) => {
-    if (index) children.push(node("span", { "aria-hidden": "true", text: "›" }));
-    if (item.href) children.push(node("a", { href: item.href, text: item.label }));
-    else children.push(node("span", { text: item.label }));
-  });
-  replace(ui.breadcrumb, children);
+function closePopup(restoreFocus = false) {
+  if (!app.activePopup) return;
+  const { button, panel } = app.activePopup;
+  panel.hidden = true;
+  button.setAttribute("aria-expanded", "false");
+  app.activePopup = null;
+  if (restoreFocus) button.focus();
 }
 
-async function navigate() {
-  closeSitemap();
-  const route = parseRoute();
-  app.currentRoute = route;
-  const token = ++app.navigationToken;
-  setActiveNav(route.view === "entity" ? route.entity : route.view);
-  try {
-    if (route.view === "dashboard") renderDashboard();
-    else if (route.view === "lab") renderLab();
-    else if (route.view === "about") renderAbout();
-    else if (route.view === "entity") await renderEntityRoute(route, token);
-    else renderNotFound(route.path);
-  } catch (error) {
-    if (token !== app.navigationToken) return;
-    showLoadError("This Service Hub view could not be loaded", error, navigate);
-  } finally {
-    if (token === app.navigationToken) {
-      setBusy(false);
-      updateClock();
-      ui.mainContent?.focus?.();
+function togglePopup(button, panel) {
+  const alreadyOpen = app.activePopup?.panel === panel;
+  closePopup();
+  if (alreadyOpen) return;
+  panel.hidden = false;
+  button.setAttribute("aria-expanded", "true");
+  app.activePopup = { button, panel };
+  panel.querySelector("a, button")?.focus();
+}
+
+function openSitemap() {
+  closePopup();
+  ui.sitemap.classList.add("open");
+  ui.scrim.classList.add("open");
+  ui.navigationToggle.setAttribute("aria-expanded", "true");
+  ui.sitemap.querySelector("a[aria-current='page']")?.focus();
+}
+
+function closeSitemap(restoreFocus = false) {
+  const wasOpen = ui.sitemap.classList.contains("open");
+  ui.sitemap.classList.remove("open");
+  ui.scrim.classList.remove("open");
+  ui.navigationToggle.setAttribute("aria-expanded", "false");
+  if (wasOpen && restoreFocus) ui.navigationToggle.focus();
+}
+
+function focusableElements(container) {
+  return [...container.querySelectorAll(
+    "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+  )].filter((element) => !element.hidden && element.getAttribute("aria-hidden") !== "true");
+}
+
+function showDialog({ title, content, actions, cancelValue = "cancel" }) {
+  const dialog = { cancelValue, finish: null };
+  const replacement = replaceDialogState(app.activeDialog, dialog);
+  app.activeDialog = replacement.activeDialog;
+  if (replacement.replacement) {
+    replacement.replacement.dialog.finish(replacement.replacement.value);
+  }
+  const previousFocus = document.activeElement;
+  ui.dialogTitle.textContent = title;
+  replace(ui.dialogContent, ...(Array.isArray(content) ? content : [node("p", { text: content })]));
+  replace(ui.dialogActions);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      if (app.activeDialog === dialog) app.activeDialog = null;
+      ui.dialog.removeEventListener("cancel", handleCancel);
+      ui.dialog.removeEventListener("keydown", trapFocus);
+      ui.dialogClose.removeEventListener("click", handleClose);
+      if (ui.dialog.open) ui.dialog.close();
+      if (previousFocus instanceof HTMLElement && previousFocus.isConnected) previousFocus.focus();
+      resolve(value);
+    };
+    const handleCancel = (event) => {
+      event.preventDefault();
+      finish(cancelValue);
+    };
+    const handleClose = () => finish(cancelValue);
+    const trapFocus = (event) => {
+      if (event.key !== "Tab") return;
+      const focusable = focusableElements(ui.dialog);
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    for (const action of actions) {
+      ui.dialogActions.append(node("button", {
+        type: "button",
+        className: `${action.primary ? "primary-button" : "secondary-button"}${action.danger ? " danger" : ""}`,
+        text: action.label,
+        on: { click: () => finish(action.value) },
+      }));
     }
+    dialog.finish = finish;
+    ui.dialogClose.addEventListener("click", handleClose);
+    ui.dialog.addEventListener("cancel", handleCancel);
+    ui.dialog.addEventListener("keydown", trapFocus);
+    ui.dialog.showModal();
+    ui.dialogActions.querySelector(".primary-button")?.focus()
+      || ui.dialogActions.querySelector("button")?.focus();
+  });
+}
+
+function showErrorDialog(title, message) {
+  announceError(`${title}: ${message}`);
+  return showDialog({
+    title,
+    content: message,
+    actions: [{ label: "Close", value: "close", primary: true }],
+    cancelValue: "close",
+  });
+}
+
+function confirmAction(title, message, confirmLabel, danger = false) {
+  return showDialog({
+    title,
+    content: message,
+    actions: [
+      { label: "Cancel", value: false },
+      { label: confirmLabel, value: true, primary: true, danger },
+    ],
+    cancelValue: false,
+  });
+}
+
+function setDirty(dirty) {
+  app.dirty = Boolean(dirty);
+  document.body.classList.toggle("record-dirty", app.dirty);
+}
+
+async function resolveDirtyState() {
+  if (!app.dirty) return true;
+  const choice = await showDialog({
+    title: "Unsaved changes",
+    content: "Your changes have not been saved. What would you like to do?",
+    actions: [
+      { label: "Cancel", value: "cancel" },
+      { label: "Discard changes", value: "discard", danger: true },
+      { label: "Save", value: "save", primary: true },
+    ],
+  });
+  if (choice === "cancel") return false;
+  if (choice === "discard") {
+    setDirty(false);
+    return true;
+  }
+  const activeForm = app.activeForm;
+  if (!activeForm) return false;
+  const selectedTab = activeForm.form.closest(".record-shell")
+    ?.querySelector(".form-tab[aria-selected='true']")
+    ?.id.replace(/^tab-/, "") || "summary";
+  const savedRecord = await saveRecord(
+    activeForm.entity,
+    activeForm.record,
+    activeForm.form,
+    { render: false },
+  );
+  const renderTarget = savedFormRenderTarget(activeForm, savedRecord, selectedTab);
+  if (!renderTarget) return false;
+  renderRecordForm(renderTarget.entity, renderTarget.record, renderTarget.initialTab);
+  return true;
+}
+
+async function requestNavigation(href) {
+  const target = String(href || "#/dashboard");
+  if (!(await resolveDirtyState())) return;
+  closePopup();
+  closeSitemap();
+  if (window.location.hash === target) {
+    app.currentHash = target;
+    await navigate();
+  } else {
+    app.navigationHistory = pushNavigationHistory(app.navigationHistory);
+    window.history.pushState({
+      ...(window.history.state || {}),
+      [HISTORY_INDEX_KEY]: app.navigationHistory.currentIndex,
+    }, "", target);
+    app.currentHash = target;
+    await navigate();
   }
 }
 
-function renderDashboard() {
-  setBreadcrumb([{ label: "Service Hub" }, { label: "Dashboard" }]);
-  setCommands([
-    command("Refresh metadata", "↻", async () => {
-      showLoading("Refreshing deterministic metadata…");
-      try {
-        await loadMetadata();
-        renderDashboard();
-        announce("Dashboard metadata refreshed.");
-      } catch (error) {
-        showLoadError("Failed to load dashboard metadata", error, renderDashboard);
-      }
-    }),
-    command("Open Twin Lab", "⚗", () => { window.location.hash = "#/lab"; }, { primary: true }),
-  ]);
-  const cards = [
-    ["incidents", "Active cases", "Review service diagnostics"],
-    ["tasks", "Activities", "Tasks and virtual-time work"],
-    ["contacts", "Contacts", "AI agents as customers"],
-    ["accounts", "Accounts", "Channels as organizations"],
-    ["emails", "Email activities", "Posts as sent email"],
-    ["connections", "Connections", "Lazy-loaded relationship graph"],
-  ].map(([entity, label, detail]) => node("a", { className: "metric-card", href: `#/${entity}` }, [
-    node("span", { className: "metric-label", text: label }),
-    node("strong", { className: "metric-value", text: (app.counts.get(entity) ?? 0).toLocaleString() }),
-    node("span", { className: "metric-detail", text: detail }),
-  ]));
-  const traceItems = app.twin.getTrace().slice(-6).reverse();
-  const recent = traceItems.length
-    ? traceItems.map((event) => node("li", {}, [
-      node("span", { className: "quick-icon", text: event.type.startsWith("commit") ? "✓" : "↯" }),
-      node("span", { className: "quick-copy" }, [
-        node("strong", { text: event.type }),
-        node("small", { text: `${event.at} · ${event.requestId || event.entity || "system"}` }),
-      ]),
-    ]))
-    : [node("li", {}, [
-      node("span", { className: "quick-icon", text: "○" }),
-      node("span", { className: "quick-copy" }, [
-        node("strong", { text: "No local requests yet" }),
-        node("small", { text: "Open a record or run a Twin Lab scenario." }),
-      ]),
-    ])];
-  const scenarioItems = BUILT_IN_SCENARIOS.slice(0, 4).map((scenario) => node("li", {}, [
-    node("span", { className: "quick-icon", text: "⚗" }),
-    node("span", { className: "quick-copy" }, [
-      node("a", { href: `#/lab?scenario=${scenario.id}`, text: scenario.label }),
-      node("small", { text: scenario.description }),
-    ]),
-  ]));
-  replace(ui.root,
-    pageHeader("Customer Service dashboard", `Rappterbook Service Hub · snapshot ${String(app.metadata?._snapshot || "unavailable").slice(0, 24)}…`),
-    localNotice(),
-    node("section", { className: "dashboard-grid", "aria-label": "Entity counts" }, cards),
-    node("section", { className: "dashboard-columns" }, [
-      node("article", { className: "panel" }, [
-        node("header", { className: "panel-header" }, [node("h2", { text: "Recent twin activity" })]),
-        node("div", { className: "panel-body" }, [node("ul", { className: "quick-list" }, recent)]),
-      ]),
-      node("article", { className: "panel" }, [
-        node("header", { className: "panel-header" }, [node("h2", { text: "Regression scenarios" })]),
-        node("div", { className: "panel-body" }, [node("ul", { className: "quick-list" }, scenarioItems)]),
-      ]),
-    ]),
-  );
+function indexedHistoryPosition(state) {
+  const index = state?.[HISTORY_INDEX_KEY];
+  return Number.isInteger(index) ? index : null;
 }
 
-async function renderEntityRoute(route, token) {
-  const config = ENTITY_UI[route.entity];
-  showLoading(`Loading ${config.label} seed data…`);
-  try {
-    await ensureEntity(route.entity);
-  } catch (error) {
-    if (token !== app.navigationToken) return;
-    showLoadError(`Failed to load ${config.label}`, error, async () => {
-      app.loadedEntities.delete(route.entity);
-      await navigate();
-    });
+async function runHistoryPrompt() {
+  const proceed = await resolveDirtyState();
+  const transition = transitionHistoryPrompt(app.navigationHistory, proceed);
+  app.navigationHistory = transition.state;
+  if (transition.effect.type === "traverse") window.history.go(transition.effect.delta);
+}
+
+function serializedHistoryPrompt() {
+  if (app.historyPromptPromise) return app.historyPromptPromise;
+  const prompt = runHistoryPrompt();
+  const serialized = prompt.finally(() => {
+    if (app.historyPromptPromise === serialized) app.historyPromptPromise = null;
+  });
+  app.historyPromptPromise = serialized;
+  return serialized;
+}
+
+async function handlePopState(event) {
+  const transition = transitionHistoryPop(
+    app.navigationHistory,
+    indexedHistoryPosition(event.state),
+    app.dirty,
+  );
+  app.navigationHistory = transition.state;
+  if (transition.effect.type === "traverse") {
+    window.history.go(transition.effect.delta);
     return;
   }
-  if (token !== app.navigationToken) return;
-  if (!route.id) renderGrid(route.entity);
-  else if (route.id === "new") renderRecordForm(route.entity, null);
-  else await renderRecord(route.entity, route.id, token);
+  if (transition.effect.type === "prompt") {
+    await serializedHistoryPrompt();
+    return;
+  }
+  if (transition.effect.type === "navigate" || transition.effect.type === "unknown") {
+    app.currentHash = window.location.hash || "#/dashboard";
+    await navigate();
+  }
 }
 
-function getGridState(entity) {
-  if (!app.grid.has(entity)) app.grid.set(entity, { search: "", sort: ENTITY_UI[entity].columns[0][0], direction: "asc" });
-  return app.grid.get(entity);
-}
-
-function formattedValue(value, type, entity = null, field = null) {
-  if (value === undefined || value === null || value === "") return "—";
-  if (type === "date") {
-    const parsed = Date.parse(value);
-    return Number.isFinite(parsed) ? new Date(parsed).toLocaleString() : String(value);
-  }
-  if (type === "number") return Number(value).toLocaleString();
-  if (type === "state" || type === "priority") {
-    return gridCodeLabel(entity, field, value)
-      ?? (type === "state"
-        ? (Number(value) === 0 ? "Active" : "Inactive")
-        : ({ 1: "High", 2: "Normal", 3: "Low" })[Number(value)] || String(value));
-  }
-  return String(value);
+function formatUtcDate(value) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return String(value || "");
+  const date = new Date(timestamp);
+  const pad = (part, length = 2) => String(part).padStart(length, "0");
+  return `${pad(date.getUTCFullYear(), 4)}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())} UTC`;
 }
 
 function formatUtcDateTimeLocal(value) {
@@ -638,362 +961,981 @@ function parseUtcDateTimeLocal(value) {
   return valid ? date.toISOString() : value;
 }
 
-function valueNode(value, type, entity = null, field = null) {
-  if (type === "state") return node("span", { className: `badge ${Number(value) === 0 ? "active" : "inactive"}`, text: formattedValue(value, type, entity, field) });
-  if (type === "status") {
-    const normalized = String(value || "pending").toLocaleLowerCase();
-    const state = ["active", "ok", "met"].includes(normalized) ? "active" : ["breached", "inactive"].includes(normalized) ? "inactive" : "pending";
-    return node("span", { className: `badge ${state}`, text: formattedValue(value, type) });
-  }
-  return document.createTextNode(formattedValue(value, type, entity, field));
+function choiceLabel(descriptor, value) {
+  const match = descriptor.choices?.find(([choice]) => String(choice) === String(value));
+  return match ? match[1] : String(value ?? "");
 }
 
-function renderGrid(entity) {
-  const config = ENTITY_UI[entity];
-  const state = getGridState(entity);
-  const records = app.twin.getState(entity);
-  const search = state.search.toLocaleLowerCase();
-  let filtered = search
-    ? records.filter((record) => config.columns.some(([key]) => String(record[key] ?? "").toLocaleLowerCase().includes(search)))
-    : records;
-  filtered = [...filtered].sort((left, right) => {
-    const compared = String(left[state.sort] ?? "").localeCompare(String(right[state.sort] ?? ""), undefined, { numeric: true });
-    const stable = String(left[config.primaryKey]).localeCompare(String(right[config.primaryKey]));
-    return (compared || stable) * (state.direction === "asc" ? 1 : -1);
+function formattedValue(value, descriptor, entity = null, record = null) {
+  if (value === undefined || value === null || value === "") return "";
+  if (descriptor.type === "date" || descriptor.type === "datetime") return formatUtcDate(value);
+  if (descriptor.type === "number") {
+    const number = Number(value);
+    return Number.isFinite(number) ? number.toLocaleString("en-US") : String(value);
+  }
+  if (descriptor.type === "choice") return choiceLabel(descriptor, value);
+  if (descriptor.type === "status-reason") {
+    const labels = {
+      contacts: { 1: "Active", 2: "Inactive" },
+      accounts: { 1: "Active", 2: "Inactive" },
+      emails: { 3: "Sent" },
+      tasks: { 2: "Not Started", 5: "Completed", 6: "Canceled" },
+      incidents: { 1: "In Progress", 5: "Problem Solved", 6: "Canceled" },
+    };
+    return labels[entity]?.[Number(value)] || String(value);
+  }
+  if (descriptor.type === "state") return gridCodeLabel(entity, "statecode", value, app.twin.now(), record) || "";
+  if (descriptor.type === "task-state") return gridCodeLabel("tasks", "statecode", value, app.twin.now(), record) || "";
+  if (descriptor.type === "priority") return gridCodeLabel(entity, "prioritycode", value) || "";
+  if (descriptor.type === "activity-priority") {
+    return record?._entity === "tasks" ? gridCodeLabel("tasks", "prioritycode", value) || "" : "";
+  }
+  if (descriptor.type === "contact-status") {
+    return contactStatusLabel(value);
+  }
+  return String(value);
+}
+
+function statusClass(label) {
+  const normalized = String(label).toLowerCase();
+  if (["active", "open", "sent", "completed", "met"].includes(normalized)) return "positive";
+  if (["inactive", "canceled", "cancelled", "resolved"].includes(normalized)) return "neutral";
+  if (["overdue", "breached"].includes(normalized)) return "negative";
+  return "neutral";
+}
+
+function valueNode(record, descriptor, entity) {
+  const value = record[descriptor.key];
+  const label = formattedValue(value, descriptor, entity, record);
+  if (["state", "task-state", "activity-status", "service-status", "contact-status"].includes(descriptor.type)) {
+    return label ? node("span", { className: `status-badge ${statusClass(label)}`, text: label }) : document.createTextNode("");
+  }
+  return document.createTextNode(label);
+}
+
+function createBarChart(title, data, ariaLabel) {
+  const width = 520;
+  const rowHeight = 34;
+  const height = Math.max(82, data.length * rowHeight + 26);
+  const maximum = Math.max(1, ...data.map((item) => Number(item.value) || 0));
+  const svg = svgElement("svg", {
+    viewBox: `0 0 ${width} ${height}`,
+    role: "img",
+    "aria-label": ariaLabel,
+    preserveAspectRatio: "xMinYMin meet",
   });
-  setBreadcrumb([{ label: "Service Hub", href: "#/dashboard" }, { label: config.label }]);
-  setCommands([
-    command("New", "+", () => { window.location.hash = routeHref(entity, "new"); }, {
-      primary: true,
-      disabled: !config.creatable,
-      title: config.creatable ? `New ${config.singular}` : `${config.label} are immutable seed records in this twin`,
-    }),
-    command("Refresh seed", "↻", () => refreshEntity(entity)),
-    "separator",
-    command("Open raw seed", "↗", () => openExternal(new URL(`${entity}.json`, API_ROOT)), {
-      disabled: !safeHttpUrl(new URL(`${entity}.json`, API_ROOT)),
-    }),
+  data.forEach((item, index) => {
+    const y = index * rowHeight + 8;
+    const barWidth = Math.max(0, (Number(item.value) || 0) / maximum * 300);
+    const label = svgElement("text", { x: 0, y: y + 18, class: "chart-label" });
+    label.textContent = item.label;
+    const background = svgElement("rect", { x: 150, y, width: 300, height: 22, rx: 2, class: "chart-track" });
+    const bar = svgElement("rect", { x: 150, y, width: barWidth, height: 22, rx: 2, class: "chart-bar" });
+    const count = svgElement("text", { x: 462, y: y + 17, class: "chart-value" });
+    count.textContent = String(item.value);
+    svg.append(label, background, bar, count);
+  });
+  return node("figure", { className: "chart-figure" }, [
+    node("figcaption", { text: title }),
+    svg,
+    node("ul", { className: "sr-only" }, data.map((item) =>
+      node("li", { text: `${item.label}: ${item.value}` }))),
   ]);
+}
+
+function recordLink(entity, record, text) {
+  const config = ENTITY_UI[entity];
+  return node("a", {
+    href: routeHref(entity, record[config.primaryKey]),
+    text: text || record[config.nameField] || "",
+  });
+}
+
+function dashboardChartPanel(title, data) {
+  return node("article", { className: "dashboard-panel" }, [
+    createBarChart(
+      title,
+      data,
+      data.map((item) => `${item.label} ${item.value}`).join(", "),
+    ),
+  ]);
+}
+
+function customerServiceDashboardPanels(metrics) {
+  const activeCases = metrics.activeCases.slice(0, 8);
+  const accountChart = metrics.accountActivity.slice(0, 8);
+  return [
+    dashboardListPanel("Active Cases", activeCases, (record) => ({
+      href: routeHref("incidents", record.incidentid),
+      title: record.title,
+      meta: `${gridCodeLabel("incidents", "prioritycode", record.prioritycode) || ""} priority`,
+    }), "There are no active cases."),
+    dashboardListPanel("Recent Activities", metrics.recentActivities, (record) => ({
+      href: routeHref(record._entity, record._id),
+      title: record.subject,
+      meta: `${record._activityType} · ${record._status}`,
+    }), "There are no recent activities."),
+    dashboardChartPanel("Cases by Priority", metrics.casePriority),
+    dashboardChartPanel("Contacts by Status", metrics.contactStatus),
+    node("article", { className: "dashboard-panel wide" }, [
+      createBarChart(
+        "Accounts by Activity Volume",
+        accountChart,
+        accountChart.map((item) => `${item.label} ${item.value}`).join(", "),
+      ),
+      node("ol", { className: "ranked-list" }, accountChart.map((item) => node("li", {}, [
+        node("a", { href: routeHref("accounts", item.id), text: item.label }),
+        node("span", { text: item.value.toLocaleString("en-US") }),
+      ]))),
+    ]),
+    dashboardListPanel("Open Activities", metrics.openActivities.slice(0, 8), (record) => ({
+      href: routeHref(record._entity, record._id),
+      title: record.subject,
+      meta: record._status,
+    }), "There are no open activities."),
+  ];
+}
+
+function serviceActivityDashboardPanels(metrics) {
+  return [
+    dashboardListPanel("Recent Activities", metrics.recentActivities, (record) => ({
+      href: routeHref(record._entity, record._id),
+      title: record.subject,
+      meta: `${record._activityType} · ${record._status}`,
+    }), "There are no recent activities."),
+    dashboardListPanel("Open Activities", metrics.openActivities.slice(0, 8), (record) => ({
+      href: routeHref(record._entity, record._id),
+      title: record.subject,
+      meta: `${record._activityType} · ${record._status}`,
+    }), "There are no open activities."),
+    dashboardListPanel("Sent Email", metrics.sentEmails.slice(0, 8), (record) => ({
+      href: routeHref(record._entity, record._id),
+      title: record.subject,
+      meta: formatUtcDate(record._dueOrSent),
+    }), "There is no sent email."),
+    dashboardChartPanel("Activities by Type", metrics.activitiesByType),
+    dashboardChartPanel("Activities by Status", metrics.activitiesByStatus),
+    dashboardListPanel("Tasks", metrics.taskActivities.slice(0, 8), (record) => ({
+      href: routeHref(record._entity, record._id),
+      title: record.subject,
+      meta: record._dueOrSent
+        ? `${record._status} · Due ${formatUtcDate(record._dueOrSent)}`
+        : record._status,
+    }), "There are no tasks."),
+  ];
+}
+
+async function renderDashboard(expectedToken = app.navigationToken, focusTarget = null) {
+  const routeGuard = captureRouteGuard(expectedToken, app.currentRoute);
+  if (focusTarget) setBusy(true);
+  else showLoading("Loading dashboard");
+  try {
+    await ensureEntities(DASHBOARD_ENTITIES);
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    const metrics = deriveDashboardMetrics({
+      incidents: app.twin.getState("incidents"),
+      emails: app.twin.getState("emails"),
+      tasks: app.twin.getState("tasks"),
+      contacts: app.twin.getState("contacts"),
+      accounts: app.twin.getState("accounts"),
+    }, app.twin.now());
+    setCommands([
+      command("Refresh", "refresh", async () => {
+        const refreshGuard = currentRouteGuard();
+        await renderDashboard(refreshGuard.navigationToken, "refresh");
+        if (!routeGuardIsCurrent(refreshGuard)) return;
+        announce("Dashboard refreshed.");
+      }, { id: "dashboard-refresh", action: "refresh-dashboard" }),
+    ]);
+    const dashboardChoices = [
+      ["customer-service", "Customer Service Dashboard"],
+      ["service-activity", "Service Activity Dashboard"],
+    ];
+    const dashboardTitle = dashboardChoices.find(([value]) => value === app.dashboardView)?.[1]
+      || dashboardChoices[0][1];
+    const selector = node("select", {
+      id: "dashboard-selector",
+      "data-action": "select-dashboard",
+      "aria-label": "Dashboard",
+      on: {
+        change: async (event) => {
+          app.dashboardView = event.currentTarget.value;
+          await renderDashboard(app.navigationToken, "selector");
+        },
+      },
+    }, dashboardChoices.map(([value, label]) =>
+      node("option", { value, text: label, selected: app.dashboardView === value })));
+    const panels = app.dashboardView === "service-activity"
+      ? serviceActivityDashboardPanels(metrics)
+      : customerServiceDashboardPanels(metrics);
+    replace(ui.root,
+      pageHeading(dashboardTitle),
+      node("div", { className: "dashboard-selector" }, [
+        node("label", { for: "dashboard-selector", text: "Dashboard" }),
+        selector,
+      ]),
+      node("div", { className: "dashboard-layout" }, panels),
+    );
+  } finally {
+    if (routeGuardIsCurrent(routeGuard)) {
+      const completion = dashboardRenderCompletion(focusTarget);
+      setBusy(completion.busy);
+      if (completion.focusTargetId) {
+        document.getElementById(completion.focusTargetId)?.focus();
+      }
+    }
+  }
+}
+
+function dashboardListPanel(title, records, describe, emptyMessage) {
+  return node("article", { className: "dashboard-panel" }, [
+    node("header", { className: "panel-heading" }, [node("h2", { text: title })]),
+    records.length
+      ? node("ul", { className: "record-list" }, records.map((record) => {
+        const item = describe(record);
+        return node("li", {}, [
+          node("a", { href: item.href, text: item.title || "" }),
+          node("span", { text: item.meta || "" }),
+        ]);
+      }))
+      : node("div", { className: "component-empty" }, [
+        icon("search", "empty-icon"),
+        node("p", { text: emptyMessage }),
+      ]),
+  ]);
+}
+
+function getGridState(entity, initialView = null) {
+  const config = entity === "activities" ? ACTIVITIES_GRID : ENTITY_UI[entity];
+  if (!app.grid.has(entity)) {
+    app.grid.set(entity, {
+      view: initialView || config.defaultView,
+      search: "",
+      sort: config.columns[0].key,
+      direction: "asc",
+      page: 1,
+      selected: new Set(),
+    });
+  }
+  const state = app.grid.get(entity);
+  if (initialView && state.view !== initialView) {
+    state.view = initialView;
+    state.page = 1;
+    state.selected.clear();
+  }
+  return state;
+}
+
+async function gridRecords(entity) {
+  if (entity === "activities") {
+    await ensureEntities(["emails", "tasks"]);
+    return combineActivities(
+      app.twin.getState("emails"),
+      app.twin.getState("tasks"),
+      app.twin.now(),
+    ).map((record) => ({ ...record, _key: `${record._entity}:${record._id}` }));
+  }
+  await ensureEntity(entity);
+  return app.twin.getState(entity);
+}
+
+function gridRecordKey(entity, record) {
+  const config = entity === "activities" ? ACTIVITIES_GRID : ENTITY_UI[entity];
+  return String(record[config.primaryKey]);
+}
+
+function gridRecordHref(entity, record) {
+  return entity === "activities"
+    ? routeHref(record._entity, record._id)
+    : routeHref(entity, record[ENTITY_UI[entity].primaryKey]);
+}
+
+async function renderGridRoute(route, expectedToken) {
+  const config = route.entity === "activities" ? ACTIVITIES_GRID : ENTITY_UI[route.entity];
+  const routeGuard = captureRouteGuard(expectedToken, route);
+  showLoading(`Loading ${config.label}`);
+  const records = await gridRecords(route.entity);
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  renderGrid(route.entity, records, route.initialView);
+}
+
+function renderGrid(entity, records, initialView = null, focusTarget = null) {
+  const config = entity === "activities" ? ACTIVITIES_GRID : ENTITY_UI[entity];
+  const state = getGridState(entity, initialView);
+  const viewed = applySystemView(records, entity, state.view);
+  const columns = new Map(config.columns.map((column) => [column.key, column]));
+  const searched = searchRows(
+    viewed,
+    config.columns.map((column) => column.key),
+    state.search,
+    (record, key) => formattedValue(
+      record[key],
+      columns.get(key),
+      entity === "activities" ? record._entity : entity,
+      record,
+    ),
+  );
+  const sorted = stableSortRows(searched, state.sort, state.direction, config.primaryKey);
+  const page = paginateRows(sorted, state.page, PAGE_SIZE);
+  state.page = page.page;
+  const recordMap = new Map(records.map((record) => [gridRecordKey(entity, record), record]));
+  const selected = [...state.selected].map((key) => recordMap.get(key)).filter(Boolean);
+  setGridCommands(entity, state, records, selected);
+
+  const viewSelector = node("select", {
+    id: "system-view",
+    className: "view-selector",
+    "aria-label": `${config.label} system view`,
+    value: state.view,
+    on: {
+      change: (event) => {
+        state.view = event.target.value;
+        state.page = 1;
+        state.selected.clear();
+        renderGrid(entity, records, null, "system-view");
+      },
+    },
+  }, (SYSTEM_VIEWS[entity] || []).map((view) =>
+    node("option", { value: view.id, text: view.label, selected: state.view === view.id })));
+
   const searchInput = node("input", {
+    id: "view-search",
     type: "search",
     value: state.search,
-    placeholder: `Search ${config.label.toLocaleLowerCase()}…`,
-    "aria-label": `Search ${config.label}`,
+    placeholder: "Search this view",
+    "aria-label": "Search this view",
     on: {
+      keydown: (event) => {
+        if (event.key === "Enter") event.preventDefault();
+      },
       input: (event) => {
         state.search = event.target.value;
-        renderGrid(entity);
-        const next = ui.root.querySelector('input[type="search"]');
+        state.page = 1;
+        state.selected.clear();
+        renderGrid(entity, records, null, "view-search");
+        const next = document.querySelector("#view-search");
         next?.focus();
         next?.setSelectionRange(state.search.length, state.search.length);
       },
     },
   });
-  const headerCells = config.columns.map(([key, label]) => {
-    const direction = state.sort === key ? (state.direction === "asc" ? "▲" : "▼") : "";
-    return node("th", { scope: "col" }, [
-      node("button", {
-        type: "button",
-        text: `${label} ${direction}`.trim(),
-        "aria-label": `Sort by ${label}`,
+
+  const pageKeys = page.rows.map((record) => gridRecordKey(entity, record));
+  const allPageSelected = pageKeys.length > 0 && pageKeys.every((key) => state.selected.has(key));
+  const headerCells = [
+    node("th", { scope: "col", className: "selection-column" }, [
+      node("input", {
+        type: "checkbox",
+        checked: allPageSelected,
+        "aria-label": allPageSelected ? "Clear page selection" : "Select page",
         on: {
-          click: () => {
-            if (state.sort === key) state.direction = state.direction === "asc" ? "desc" : "asc";
-            else { state.sort = key; state.direction = "asc"; }
-            renderGrid(entity);
+          change: (event) => {
+            state.selected = updateSelection(state.selected, pageKeys, event.target.checked);
+            renderGrid(entity, records);
           },
         },
       }),
+    ]),
+    ...config.columns.map((column) => {
+      const active = state.sort === column.key;
+      return node("th", {
+        scope: "col",
+        "aria-sort": active ? (state.direction === "asc" ? "ascending" : "descending") : "none",
+      }, [
+        node("button", {
+          type: "button",
+          className: "sort-button",
+          on: {
+            click: () => {
+              if (active) state.direction = state.direction === "asc" ? "desc" : "asc";
+              else {
+                state.sort = column.key;
+                state.direction = "asc";
+              }
+              state.page = 1;
+              renderGrid(entity, records);
+            },
+          },
+        }, [
+          node("span", { text: column.label }),
+          active ? icon(state.direction === "asc" ? "back" : "back", `sort-icon ${state.direction}`) : null,
+        ]),
+      ]);
+    }),
+  ];
+
+  const bodyRows = page.rows.map((record) => {
+    const key = gridRecordKey(entity, record);
+    return node("tr", { className: state.selected.has(key) ? "selected" : "" }, [
+      node("td", { className: "selection-column" }, [
+        node("input", {
+          id: `select-${key.replace(/[^a-zA-Z0-9_-]/g, "-")}`,
+          type: "checkbox",
+          checked: state.selected.has(key),
+          "aria-label": `Select ${record[config.columns[0].key] || config.singular}`,
+          on: {
+            change: (event) => {
+              state.selected = updateSelection(state.selected, [key], event.target.checked);
+              renderGrid(entity, records, null, `select-${key.replace(/[^a-zA-Z0-9_-]/g, "-")}`);
+            },
+          },
+        }),
+      ]),
+      ...config.columns.map((column, index) => node("td", {
+        dataset: { label: column.label },
+        title: formattedValue(record[column.key], column, entity === "activities" ? record._entity : entity, record),
+      }, [
+        index === 0
+          ? node("a", {
+            className: "record-link",
+            href: gridRecordHref(entity, record),
+            text: formattedValue(record[column.key], column, entity === "activities" ? record._entity : entity, record),
+          })
+          : valueNode(record, column, entity === "activities" ? record._entity : entity),
+      ])),
     ]);
   });
-  const bodyRows = filtered.slice(0, MAX_GRID_ROWS).map((record) => {
-    const cells = config.columns.map(([key, , type], columnIndex) => {
-      if (columnIndex === 0) {
-        return node("td", {}, [
-          node("a", {
-            className: "record-link",
-            href: routeHref(entity, record[config.primaryKey]),
-            text: formattedValue(record[key], type, entity, key),
-          }),
-        ]);
-      }
-      return node("td", { title: formattedValue(record[key], type, entity, key) }, [valueNode(record[key], type, entity, key)]);
-    });
-    return node("tr", {}, cells);
-  });
-  const tableBody = bodyRows.length
+
+  const columnCount = config.columns.length + 1;
+  const body = bodyRows.length
     ? node("tbody", {}, bodyRows)
-    : node("tbody", {}, [node("tr", {}, [node("td", {
-      colspan: String(config.columns.length),
-      text: state.search ? "No records match this search." : "This entity set contains no seed or local records.",
-    })])]);
-  replace(ui.root,
-    pageHeader(config.label, `${filtered.length.toLocaleString()} of ${records.length.toLocaleString()} browser-local records · ${entity}`),
-    localNotice(),
-    node("div", { className: "toolbar" }, [
-      node("div", { className: "search-box" }, [searchInput]),
-      node("span", { className: "record-summary", text: filtered.length > MAX_GRID_ROWS ? `Showing first ${MAX_GRID_ROWS.toLocaleString()}` : "All matching rows shown" }),
-    ]),
-    node("div", { className: "grid-wrap" }, [
-      node("table", { className: "data-grid" }, [
-        node("thead", {}, [node("tr", {}, headerCells)]),
-        tableBody,
+    : node("tbody", {}, [
+      node("tr", {}, [
+        node("td", { className: "grid-empty", colspan: String(columnCount) }, [
+          icon("search", "empty-icon"),
+          node("strong", { text: "No records found" }),
+          node("span", { text: state.search ? "Try a different search." : "This view has no records." }),
+        ]),
       ]),
+    ]);
+  replace(ui.root,
+    pageHeading(config.label),
+    node("div", { className: "view-toolbar" }, [
+      node("div", { className: "view-choice" }, [
+        node("label", { for: "system-view", text: "View" }),
+        viewSelector,
+      ]),
+      node("div", { className: "view-search" }, [icon("search"), searchInput]),
+    ]),
+    node("div", { className: "grid-surface" }, [
+      node("div", { className: "grid-scroll" }, [
+        node("table", { className: "data-grid", "aria-label": `${config.label} — ${viewLabel(entity, state.view)}` }, [
+          node("thead", {}, [node("tr", {}, headerCells)]),
+          body,
+        ]),
+      ]),
+      gridFooter(page, () => {
+        state.page -= 1;
+        renderGrid(entity, records);
+      }, () => {
+        state.page += 1;
+        renderGrid(entity, records);
+      }),
     ]),
   );
+  if (focusTarget) document.getElementById(focusTarget)?.focus();
 }
 
-async function refreshEntity(entity) {
-  const navigationToken = app.navigationToken;
-  const currentEntity = app.currentRoute?.entity;
-  const refreshIsCurrent = () => currentEntity === entity
-    && isActiveEntityRoute(app.navigationToken, app.currentRoute, navigationToken, currentEntity);
-  showLoading(`Refreshing ${ENTITY_UI[entity].label} from immutable seed JSON…`);
-  app.loadedEntities.delete(entity);
-  try {
-    await ensureEntity(entity);
-    if (!refreshIsCurrent()) return;
-    renderGrid(entity);
-    announce(`${ENTITY_UI[entity].label} seed refreshed. Local changes to this entity were reset.`);
-  } catch (error) {
-    if (!refreshIsCurrent()) return;
-    showLoadError(`Failed to refresh ${ENTITY_UI[entity].label}`, error, () => refreshEntity(entity));
+function viewLabel(entity, viewId) {
+  return SYSTEM_VIEWS[entity]?.find((view) => view.id === viewId)?.label || "Records";
+}
+
+function gridFooter(page, previous, next) {
+  return node("footer", { className: "grid-footer" }, [
+    node("span", { text: `${page.start}-${page.end} of ${page.total}` }),
+    node("span", { text: `Page ${page.page} of ${page.pageCount}` }),
+    node("div", { className: "pager-buttons" }, [
+      node("button", {
+        type: "button",
+        disabled: !page.hasPrevious,
+        "aria-label": "Previous page",
+        title: "Previous page",
+        on: { click: previous },
+      }, [icon("back")]),
+      node("button", {
+        type: "button",
+        disabled: !page.hasNext,
+        "aria-label": "Next page",
+        title: "Next page",
+        on: { click: next },
+      }, [icon("back", "ui-icon next")]),
+    ]),
+  ]);
+}
+
+function setGridCommands(entity, state, records, selected) {
+  const config = entity === "activities" ? ACTIVITIES_GRID : ENTITY_UI[entity];
+  const commands = [];
+  if (config.creatable) {
+    commands.push(command(entity === "activities" ? "New Task" : "New", "add", () => {
+      requestNavigation(entity === "activities" ? "#/tasks/new" : routeHref(entity, "new"));
+    }, { primary: true }));
   }
+  commands.push(command("Refresh", "refresh", () => {
+    renderGrid(entity, records);
+    announce(`${config.label} refreshed.`);
+  }));
+  commands.push("separator");
+  const editableSelection = selected.length === 1
+    && (entity !== "activities" || selected[0]._entity === "tasks");
+  commands.push(command("Edit", "edit", () => {
+    if (selected[0]) requestNavigation(gridRecordHref(entity, selected[0]));
+  }, { disabled: !editableSelection }));
+  commands.push(command("Delete", "delete", () => bulkDelete(entity, state, records, selected), {
+    disabled: selected.length === 0,
+    danger: true,
+  }));
+  if (entity === "contacts" || entity === "accounts") {
+    commands.push(command("Activate", "state", () => bulkTransition(entity, state, records, selected, "activate"), {
+      disabled: !selected.length || selected.some((record) => Number(record.statecode) === 0),
+    }));
+    commands.push(command("Deactivate", "cancel", () => bulkTransition(entity, state, records, selected, "deactivate"), {
+      disabled: !selected.length || selected.some((record) => Number(record.statecode) !== 0),
+    }));
+  } else if (entity === "incidents") {
+    commands.push(command("Resolve Case", "check", () => bulkTransition(entity, state, records, selected, "resolve"), {
+      disabled: !selected.length || selected.some((record) => Number(record.statecode) !== 0),
+    }));
+    commands.push(command("Cancel Case", "cancel", () => bulkTransition(entity, state, records, selected, "cancel"), {
+      disabled: !selected.length || selected.some((record) => Number(record.statecode) !== 0),
+    }));
+    commands.push(command("Reopen", "reopen", () => bulkTransition(entity, state, records, selected, "reopen"), {
+      disabled: !selected.length || selected.some((record) => Number(record.statecode) === 0),
+    }));
+  } else if (entity === "activities") {
+    const unavailable = !selected.length || selected.some((record) => record._entity !== "tasks" || Number(record.statecode) !== 0);
+    commands.push(command("Mark Complete", "check", () => bulkTransition(entity, state, records, selected, "complete"), {
+      disabled: unavailable,
+    }));
+    commands.push(command("Cancel Task", "cancel", () => bulkTransition(entity, state, records, selected, "cancel"), {
+      disabled: unavailable,
+    }));
+  }
+  setCommands(commands);
 }
 
-async function renderRecord(entity, id, token) {
-  const result = await app.twin.request({
-    method: "GET",
-    path: `/${entity}(${id})`,
-    logicalRequestId: requestId(`open-${entity}`),
-    clientId: "service-hub",
-  });
-  if (token !== app.navigationToken) return;
-  if (!result.ok) {
-    showLoadError(`${ENTITY_UI[entity].singular} could not be opened`, new Error(result.body.error.message), () => {
-      window.location.hash = routeHref(entity);
+function contactDeletionBlockedMessage(preflight) {
+  const names = preflight.blockers.map((blocker) => `“${blocker.contactName}”`).join(", ");
+  const connectionCount = new Set(
+    preflight.blockers.flatMap((blocker) => blocker.connectionIds),
+  ).size;
+  return `${names} cannot be deleted because ${connectionCount} Connection ${
+    connectionCount === 1 ? "record references" : "records reference"
+  } the selected contact${preflight.blockers.length === 1 ? "" : "s"}. Deactivate instead.`;
+}
+
+function accountDeletionBlockedMessage(preflight) {
+  const names = preflight.blockers.map((blocker) => `“${blocker.accountName}”`).join(", ");
+  const emailCount = new Set(
+    preflight.blockers.flatMap((blocker) => blocker.emailIds),
+  ).size;
+  return `${names} cannot be deleted because ${emailCount} Email ${
+    emailCount === 1 ? "record references" : "records reference"
+  } the selected account${preflight.blockers.length === 1 ? "" : "s"}. Deactivate instead.`;
+}
+
+async function bulkDelete(entity, state, records, selected) {
+  const routeGuard = currentRouteGuard();
+  const confirmed = await confirmAction(
+    "Delete selected records",
+    `Delete ${selected.length} selected ${selected.length === 1 ? "record" : "records"}?`,
+    "Delete",
+    true,
+  );
+  if (confirmed !== true || !routeGuardIsCurrent(routeGuard)) return;
+  if (entity === "contacts") {
+    await ensureEntities(["contacts", "connections"]);
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    const preflight = preflightContactDeletion(
+      selected.map((record) => record.contactid),
+      app.twin.getState("contacts"),
+      app.twin.getState("connections"),
+    );
+    if (!preflight.allowed) {
+      await showErrorDialog("Contacts cannot be deleted", contactDeletionBlockedMessage(preflight));
+      return;
+    }
+  }
+  if (entity === "accounts") {
+    await ensureEntities(["accounts", "emails"]);
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    const preflight = preflightAccountDeletion(
+      selected.map((record) => record.accountid),
+      app.twin.getState("accounts"),
+      app.twin.getState("emails"),
+    );
+    if (!preflight.allowed) {
+      await showErrorDialog("Accounts cannot be deleted", accountDeletionBlockedMessage(preflight));
+      return;
+    }
+  }
+  for (const record of selected) {
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    const actualEntity = entity === "activities" ? record._entity : entity;
+    const config = ENTITY_UI[actualEntity];
+    const result = await app.twin.request({
+      method: "DELETE",
+      path: `/${actualEntity}(${record[config.primaryKey]})`,
+      logicalRequestId: requestId(`delete-${actualEntity}`),
+      headers: { "If-Match": record["@odata.etag"] },
     });
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    if (!result.ok) {
+      await showErrorDialog("Delete failed", result.body.error.message);
+      return;
+    }
+  }
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  state.selected.clear();
+  const current = await gridRecords(entity);
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  renderGrid(entity, current);
+  announce("Selected records deleted.");
+}
+
+async function bulkTransition(entity, state, records, selected, action) {
+  const routeGuard = currentRouteGuard();
+  const label = {
+    activate: "Activate",
+    deactivate: "Deactivate",
+    complete: "Mark Complete",
+    cancel: entity === "incidents" ? "Cancel Case" : "Cancel",
+    resolve: "Resolve Case",
+    reopen: "Reopen",
+  }[action];
+  const confirmed = await confirmAction(
+    label,
+    `${label} for ${selected.length} selected ${selected.length === 1 ? "record" : "records"}?`,
+    label,
+  );
+  if (confirmed !== true || !routeGuardIsCurrent(routeGuard)) return;
+  for (const record of selected) {
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    const actualEntity = entity === "activities" ? record._entity : entity;
+    const config = ENTITY_UI[actualEntity];
+    const result = await app.twin.request({
+      method: "PATCH",
+      path: `/${actualEntity}(${record[config.primaryKey]})`,
+      logicalRequestId: requestId(`${action}-${actualEntity}`),
+      headers: { "If-Match": record["@odata.etag"], Prefer: "return=representation" },
+      body: transitionPatch(actualEntity, action, app.twin.now()),
+    });
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    if (!result.ok) {
+      await showErrorDialog(`${label} failed`, result.body.error.message);
+      return;
+    }
+  }
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  state.selected.clear();
+  const current = await gridRecords(entity);
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  renderGrid(entity, current);
+  announce(`${label} completed.`);
+}
+
+async function renderRecordRoute(route, token) {
+  const config = ENTITY_UI[route.entity];
+  const routeGuard = captureRouteGuard(token, route);
+  showLoading(`Loading ${config.singular}`);
+  await ensureEntity(route.entity);
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  if (route.id === "new") {
+    if (!config.creatable) throw new Error(`New ${config.singular.toLowerCase()} records are not supported.`);
+    renderRecordForm(route.entity, null, route.initialTab);
     return;
   }
-  renderRecordForm(entity, result.body);
+  const result = await app.twin.request({
+    method: "GET",
+    path: `/${route.entity}(${route.id})`,
+    logicalRequestId: requestId(`open-${route.entity}`),
+    clientId: "customer-service-hub",
+  });
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  if (!result.ok) throw new Error(result.body.error.message);
+  renderRecordForm(route.entity, result.body, route.initialTab);
 }
 
 function recordTitle(config, record) {
-  if (!record) return `New ${config.singular}`;
-  return record[config.nameField] || record[config.primaryKey] || config.singular;
+  return record ? record[config.nameField] || config.singular : `New ${config.singular}`;
 }
 
-function editableInput(descriptor, record) {
+function editableControl(descriptor, record) {
   const current = record?.[descriptor.key];
+  let control;
   if (descriptor.type === "textarea") {
-    return node("textarea", { name: descriptor.key, text: current ?? "" });
-  }
-  if (descriptor.type === "select") {
-    const select = node("select", { name: descriptor.key });
-    for (const value of descriptor.options || []) {
-      select.append(node("option", { value, text: value, selected: value === current ? "selected" : null }));
+    control = node("textarea", { name: descriptor.key, text: current ?? "", rows: "4" });
+  } else if (descriptor.type === "choice") {
+    const selectedValue = current ?? descriptor.defaultValue ?? descriptor.choices?.[0]?.[0];
+    control = node("select", { name: descriptor.key }, (descriptor.choices || []).map(([value, label]) =>
+      node("option", { value, text: label, selected: String(value) === String(selectedValue) })));
+  } else {
+    let type = descriptor.type;
+    let value = current ?? "";
+    if (type === "datetime") {
+      type = "datetime-local";
+      value = current ? formatUtcDateTimeLocal(current) : "";
     }
-    return select;
+    control = node("input", {
+      name: descriptor.key,
+      type: ["email", "url", "number", "datetime-local"].includes(type) ? type : "text",
+      value,
+      step: type === "datetime-local" ? "0.001" : null,
+    });
   }
-  let type = descriptor.type;
-  let value = current ?? "";
-  if (type === "datetime") {
-    type = "datetime-local";
-    if (value) value = formatUtcDateTimeLocal(value);
+  control.id = `field-${descriptor.key}`;
+  if (descriptor.required) {
+    control.required = true;
+    control.setAttribute("aria-required", "true");
   }
-  return node("input", {
-    name: descriptor.key,
-    type: ["email", "url", "number", "datetime-local"].includes(type) ? type : "text",
-    value,
-    step: type === "datetime-local" ? "0.001" : null,
-  });
+  return control;
 }
 
-function readOnlyValue(descriptor, record) {
+function readOnlyField(descriptor, record, entity) {
   const value = record?.[descriptor.key];
   if (descriptor.type === "url" && value) return externalLink(value);
-  const empty = value === undefined || value === null || value === "";
   return node("span", {
-    className: `read-value${empty ? " empty" : ""}`,
-    text: empty ? "—" : formattedValue(value, descriptor.type === "datetime" ? "date" : descriptor.type),
+    className: "field-value",
+    text: formattedValue(value, descriptor, entity, record),
   });
 }
 
-function renderRecordForm(entity, record) {
+function formField(descriptor, record, entity, editable) {
+  const label = node("label", { for: `field-${descriptor.key}` }, [
+    node("span", { text: descriptor.label }),
+    descriptor.required ? node("span", { className: "required-marker", "aria-hidden": "true", text: "*" }) : null,
+  ]);
+  return node("div", { className: `form-field${descriptor.full ? " full" : ""}` }, [
+    label,
+    editable && descriptor.editable
+      ? editableControl(descriptor, record)
+      : readOnlyField(descriptor, record, entity),
+  ]);
+}
+
+function formSection(section, record, entity, editable) {
+  return node("section", { className: "form-section" }, [
+    node("h2", { text: section.title }),
+    node("div", { className: "form-grid" }, section.fields.map((descriptor) =>
+      formField(descriptor, record, entity, editable))),
+  ]);
+}
+
+function recordNavigation(entity, record) {
+  const config = ENTITY_UI[entity];
+  const backHref = entity === "emails" || entity === "tasks" ? "#/activities" : routeHref(entity);
+  if (!record) {
+    return node("nav", { className: "record-navigation", "aria-label": "Record navigation" }, [
+      node("a", { href: backHref }, [icon("back"), node("span", { text: `Back to ${entity === "incidents" ? "Cases" : config.label}` })]),
+    ]);
+  }
+  const records = app.twin.getState(entity);
+  const index = records.findIndex((item) => item[config.primaryKey] === record[config.primaryKey]);
+  const previous = index > 0 ? records[index - 1] : null;
+  const next = index >= 0 && index < records.length - 1 ? records[index + 1] : null;
+  return node("nav", { className: "record-navigation", "aria-label": "Record navigation" }, [
+    node("a", { href: backHref }, [icon("back"), node("span", { text: "Back" })]),
+    previous ? node("a", {
+      href: routeHref(entity, previous[config.primaryKey]),
+      title: `Previous ${config.singular.toLowerCase()}`,
+    }, [icon("back"), node("span", { className: "sr-only", text: "Previous record" })]) : null,
+    next ? node("a", {
+      href: routeHref(entity, next[config.primaryKey]),
+      title: `Next ${config.singular.toLowerCase()}`,
+    }, [icon("back", "ui-icon next"), node("span", { className: "sr-only", text: "Next record" })]) : null,
+  ]);
+}
+
+function buildBusinessProcess(record, editable) {
+  const key = record?.incidentid || "new";
+  const stages = ["Identify", "Research", "Resolve"];
+  const active = Math.min(2, app.bpfStages.get(key) || 0);
+  return node("section", { className: "business-process", "aria-label": "Case process" }, [
+    node("span", { className: "process-label", text: "Case process" }),
+    node("ol", {}, stages.map((stage, index) => node("li", { className: index < active ? "complete" : index === active ? "active" : "" }, [
+      node("button", {
+        type: "button",
+        disabled: !editable,
+        "aria-current": index === active ? "step" : null,
+        on: {
+          click: () => {
+            app.bpfStages.set(key, index);
+            document.querySelector(".business-process")?.replaceWith(buildBusinessProcess(record, editable));
+            announce(`${stage} stage selected.`);
+          },
+        },
+      }, [
+        node("span", { className: "stage-marker", text: String(index + 1) }),
+        node("span", { text: stage }),
+      ]),
+    ]))),
+  ]);
+}
+
+function renderRecordForm(entity, record, initialTab = null) {
   const config = ENTITY_UI[entity];
   const creating = !record;
-  const editable = config.editable;
+  const editable = isRecordEditable(entity, record, config.editable);
   const title = recordTitle(config, record);
-  setBreadcrumb([
-    { label: "Service Hub", href: "#/dashboard" },
-    { label: config.label, href: routeHref(entity) },
-    { label: title },
-  ]);
+  let baseline = {};
+  const markFormDirty = (event) => {
+    if (event.target instanceof HTMLElement && event.target.getAttribute("name")) {
+      setDirty(!editableSnapshotsEqual(baseline, formPayload(form, entity)));
+    }
+  };
   const form = node("form", {
     id: "record-form",
+    novalidate: "novalidate",
     on: {
       submit: (event) => {
         event.preventDefault();
         saveRecord(entity, record, event.currentTarget);
       },
+      input: markFormDirty,
+      change: markFormDirty,
     },
   });
-  for (const [sectionTitle, descriptors] of config.sections) {
-    const fields = descriptors.map((descriptor) => {
-      const canEdit = editable && descriptor.editable;
-      return node("div", { className: `form-field${descriptor.full ? " full" : ""}` }, [
-        node("label", { for: `field-${descriptor.key}`, text: descriptor.label }),
-        canEdit
-          ? withId(editableInput(descriptor, record), `field-${descriptor.key}`)
-          : readOnlyValue(descriptor, record),
-      ]);
+  const summaryPanel = node("div", {
+    id: "form-panel-summary", className: "form-panel", role: "tabpanel", "aria-labelledby": "tab-summary",
+  },
+    config.sections.filter((section) => section.tab === "summary").map((section) =>
+      formSection(section, record, entity, editable)));
+  const detailsPanel = node("div", {
+    id: "form-panel-details",
+    className: "form-panel",
+    role: "tabpanel",
+    "aria-labelledby": "tab-details",
+    hidden: true,
+  }, config.sections.filter((section) => section.tab === "details").map((section) =>
+    formSection(section, record, entity, editable)));
+  const relatedPanel = node("div", {
+    id: "form-panel-related",
+    className: "form-panel",
+    role: "tabpanel",
+    "aria-labelledby": "tab-related",
+    hidden: true,
+  });
+  form.append(summaryPanel, detailsPanel, relatedPanel);
+  baseline = normalizeEditableSnapshot(formPayload(form, entity));
+
+  const tabs = ["Summary", "Details", "Related"].map((label) => {
+    const tab = label.toLowerCase();
+    return node("button", {
+      type: "button",
+      className: "form-tab",
+      role: "tab",
+      id: `tab-${tab}`,
+      "aria-controls": `form-panel-${tab}`,
+      "aria-selected": "false",
+      disabled: tab === "related" && creating,
+      on: {
+        click: () => selectFormTab(tab, form, entity, record),
+        keydown: (event) => handleFormTabKeydown(event, form, entity, record),
+      },
+      text: label,
     });
-    form.append(node("section", { className: "form-section" }, [
-      node("h2", { text: sectionTitle }),
-      node("div", { className: "form-grid" }, fields),
-    ]));
-  }
-  const formContent = node("div", { className: "form-content" }, [form]);
-  const tabContent = node("div", { id: "record-tab-content" }, [formContent]);
-  const summaryTab = node("button", {
-    type: "button", className: "tab-button active", text: "Summary",
-    on: { click: () => selectRecordTab("summary", summaryTab, tabContent, entity, record, formContent) },
   });
-  const relatedTab = node("button", {
-    type: "button", className: "tab-button", text: "Related timeline",
-    on: { click: () => selectRecordTab("related", relatedTab, tabContent, entity, record, formContent) },
-    disabled: creating,
-    title: creating ? "Save the record before loading related activity" : "Load related activity",
-  });
-  const jsonTab = node("button", {
-    type: "button", className: "tab-button", text: "Raw JSON",
-    on: { click: () => selectRecordTab("json", jsonTab, tabContent, entity, record, formContent) },
-    disabled: creating,
-  });
-  setCommands([
-    command("Save", "💾", () => form.requestSubmit(), {
-      primary: true,
-      disabled: !editable,
-      title: editable ? "Save to browser-local twin state" : "This entity is read-only",
-    }),
-    command("Save & close", "✓", async () => {
-      const saved = await saveRecord(entity, record, form);
-      if (saved) window.location.hash = routeHref(entity);
-    }, { disabled: !editable }),
-    "separator",
-    command("Deactivate", "⊘", () => deactivateRecord(entity, record), {
-      disabled: creating || !editable || record?.statecode === 1,
-      title: !editable ? "This entity is read-only" : "Set this browser-local row inactive",
-    }),
-    command("Delete", "⌫", () => deleteRecord(entity, record), {
-      danger: true,
-      disabled: creating || !editable,
-    }),
-    command("Refresh", "↻", () => { if (record) renderRecord(entity, record[config.primaryKey], app.navigationToken); }, { disabled: creating }),
-    command("Back", "←", () => { window.location.hash = routeHref(entity); }),
-  ]);
+  const keyFields = config.headerFields.slice(0, 4).map((descriptor) => node("div", { className: "header-field" }, [
+    node("span", { text: descriptor.label }),
+    valueNode(record || {}, descriptor, entity),
+  ]));
+  setRecordCommands(entity, record, form);
+  setDirty(false);
+  app.activeForm = { entity, record, form, baseline };
   replace(ui.root,
-    localNotice(),
-    node("article", { className: "form-shell" }, [
+    recordNavigation(entity, record),
+    node("article", { className: "record-shell" }, [
       node("header", { className: "record-header" }, [
-        node("div", { className: "record-avatar", text: config.icon }),
-        node("div", { className: "record-heading" }, [
+        node("div", { className: "record-symbol", "aria-hidden": "true" }, [icon(entity === "incidents" ? "state" : "edit")]),
+        node("div", { className: "record-title" }, [
+          node("span", { text: creating ? `New ${config.singular}` : config.singular }),
           node("h1", { text: title }),
-          node("p", { text: `${config.singular} · ${creating ? "unsaved local row" : record[config.primaryKey]}` }),
         ]),
-        node("code", { className: "record-etag", text: record?.["@odata.etag"] || "ETag assigned on save" }),
+        node("div", { className: "record-header-fields" }, keyFields),
       ]),
-      node("div", { className: "tabs", role: "tablist" }, [summaryTab, relatedTab, jsonTab]),
-      tabContent,
+      entity === "incidents" ? buildBusinessProcess(record, editable) : null,
+      node("div", { className: "form-tabs", role: "tablist", "aria-label": `${config.singular} form tabs` }, tabs),
+      form,
     ]),
   );
+  selectFormTab(initialTab || "summary", form, entity, record);
 }
 
-function withId(element, id) {
-  element.id = id;
-  return element;
+function selectFormTab(tab, form, entity, record) {
+  const buttons = [...form.closest(".record-shell").querySelectorAll(".form-tab")];
+  const requested = buttons.find((button) => button.id === `tab-${tab}` && !button.disabled);
+  const selectedButton = requested || buttons.find((button) => !button.disabled);
+  const selectedTab = selectedButton?.id.replace(/^tab-/, "") || "summary";
+  for (const button of buttons) {
+    const selected = button === selectedButton;
+    button.classList.toggle("active", selected);
+    button.setAttribute("aria-selected", String(selected));
+    button.tabIndex = selected ? 0 : -1;
+  }
+  for (const panel of form.querySelectorAll(".form-panel")) {
+    panel.hidden = panel.id !== `form-panel-${selectedTab}`;
+  }
+  if (selectedTab === "related" && record) {
+    loadRelatedPanel(entity, record, form.querySelector("#form-panel-related"));
+  }
+  return selectedButton;
 }
 
-async function selectRecordTab(kind, tab, container, entity, record, formContent) {
-  const selectionToken = (recordTabSelectionTokens.get(container) || 0) + 1;
-  recordTabSelectionTokens.set(container, selectionToken);
-  const isCurrentSelection = () => recordTabSelectionTokens.get(container) === selectionToken;
-  for (const button of tab.parentElement.querySelectorAll(".tab-button")) button.classList.remove("active");
-  tab.classList.add("active");
-  if (kind === "summary") {
-    replace(container, formContent);
-    return;
-  }
-  if (kind === "json") {
-    replace(container, node("div", { className: "form-content" }, [rawJson(record)]));
-    return;
-  }
-  replace(container, node("div", { className: "form-content" }, [
-    node("div", { className: "loading-card", role: "status" }, [
-      node("span", { className: "spinner", "aria-hidden": "true" }),
-      node("span", { text: "Loading related timeline…" }),
-    ]),
-  ]));
-  try {
-    const timeline = await buildRelatedTimeline(entity, record);
-    if (!isCurrentSelection()) return;
-    replace(container, node("div", { className: "form-content" }, [timeline]));
-  } catch (error) {
-    if (!isCurrentSelection()) return;
-    replace(container, node("div", { className: "form-content" }, [
-      node("section", { className: "error-card", role: "alert" }, [
-        node("h2", { text: "Related records could not be loaded" }),
-        node("p", { text: error.message }),
-      ]),
-    ]));
-  }
+function handleFormTabKeydown(event, form, entity, record) {
+  if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+  const tabs = [...form.closest(".record-shell").querySelectorAll(".form-tab")];
+  const nextIndex = nextRovingTabIndex(tabs, tabs.indexOf(event.currentTarget), event.key);
+  if (nextIndex < 0) return;
+  event.preventDefault();
+  const nextTab = tabs[nextIndex];
+  selectFormTab(nextTab.id.replace(/^tab-/, ""), form, entity, record)?.focus();
 }
 
-async function buildRelatedTimeline(entity, record) {
+function setRecordCommands(entity, record, form) {
   const config = ENTITY_UI[entity];
-  let items = [];
-  if (entity === "contacts" || entity === "accounts") {
-    await ensureEntity("emails");
-    const emails = app.twin.getState("emails");
-    const related = entity === "contacts"
-      ? emails.filter((email) => email.new_author === record.new_agentid)
-      : emails.filter((email) => email.new_channel === record.new_slug);
-    items = newestRelatedEmails(related).map((email) => ({
-      title: email.subject,
-      detail: `${email.new_author || "unknown"} · ${email.new_channel || "general"} · ${email.new_commentcount || 0} replies`,
-      at: email.createdon,
-      href: routeHref("emails", email.activityid),
+  const actions = new Set(recordCommandActions(entity, record, {
+    editable: config.editable,
+    deletable: config.deletable,
+    hasSafeSource: Boolean(record?.new_url && safeHttpUrl(record.new_url)),
+  }));
+  const commands = [];
+  if (actions.has("save")) {
+    commands.push(command("Save", "save", () => form.requestSubmit(), { primary: true }));
+    commands.push(command("Save & Close", "check", async () => {
+      const saved = await saveRecord(entity, record, form, { render: false });
+      if (saved) requestNavigation(entity === "tasks" ? "#/activities" : routeHref(entity));
     }));
-  } else {
-    const id = record[config.primaryKey];
-    items = app.twin.getTrace()
-      .filter((event) => event.entity === entity && event.recordId === id)
-      .slice(-25)
-      .reverse()
-      .map((event) => ({
-        title: event.type,
-        detail: event.requestId || event.transition || "local event",
-        at: event.at,
-      }));
+    commands.push("separator");
   }
-  if (!items.length) {
-    return node("section", { className: "empty-state" }, [
-      node("div", {}, [
-        node("h2", { text: "No related local activity" }),
-        node("p", { text: "The seed and append-only twin trace contain no related records yet." }),
-      ]),
-    ]);
+  if (actions.has("activate") || actions.has("deactivate")) {
+    const action = actions.has("activate") ? "activate" : "deactivate";
+    commands.push(command(action === "activate" ? "Activate" : "Deactivate", action === "activate" ? "state" : "cancel",
+      () => transitionRecord(entity, action)));
   }
-  return node("section", { className: "form-section" }, [
-    node("h2", { text: `Timeline · ${items.length} related items` }),
-    node("div", { className: "panel-body" }, [
-      node("ol", { className: "timeline" }, items.map((item) => node("li", {}, [
-        item.href ? node("a", { href: item.href, text: item.title }) : node("strong", { text: item.title }),
-        node("span", { text: item.detail }),
-        node("time", { datetime: item.at || "", text: formattedValue(item.at, "date") }),
-      ]))),
-    ]),
-  ]);
+  if (actions.has("complete")) {
+    commands.push(command("Mark Complete", "check", () => transitionRecord(entity, "complete")));
+    commands.push(command("Cancel", "cancel", () => transitionRecord(entity, "cancel")));
+  }
+  if (actions.has("resolve")) {
+    commands.push(command("Resolve Case", "check", () => transitionRecord(entity, "resolve")));
+    commands.push(command("Cancel Case", "cancel", () => transitionRecord(entity, "cancel")));
+  }
+  if (actions.has("reopen")) {
+    commands.push(command("Reopen", "reopen", () => transitionRecord(entity, "reopen")));
+  }
+  if (actions.has("open-source")) {
+    commands.push(command("Open source", "external", () => openExternal(record.new_url)));
+  }
+  if (actions.has("delete")) {
+    commands.push(command("Delete", "delete", () => deleteCurrentRecord(entity), { danger: true }));
+  }
+  if (actions.has("refresh")) {
+    commands.push(command("Refresh", "refresh", () => refreshCurrentRecord(entity)));
+  }
+  commands.push(command("Back", "back", () => requestNavigation(
+    entity === "emails" || entity === "tasks" ? "#/activities" : routeHref(entity),
+  )));
+  setCommands(commands);
 }
 
 function formPayload(form, entity) {
@@ -1013,165 +1955,712 @@ function formPayload(form, entity) {
   return payload;
 }
 
-async function saveRecord(entity, record, form) {
+async function saveRecord(entity, record, form, options = {}) {
+  const routeGuard = currentRouteGuard();
   const config = ENTITY_UI[entity];
-  if (!config.editable) return false;
+  if (!isRecordEditable(entity, record, config.editable) || !form.reportValidity()) return false;
+  if (!routeGuardIsCurrent(routeGuard)) return false;
   const creating = !record;
-  const payload = formPayload(form, entity);
   const result = await app.twin.request({
     method: creating ? "POST" : "PATCH",
     path: creating ? `/${entity}` : `/${entity}(${record[config.primaryKey]})`,
     logicalRequestId: requestId(`save-${entity}`),
-    clientId: "service-hub-form",
+    clientId: "customer-service-form",
     headers: {
       Prefer: "return=representation",
       ...(creating ? {} : { "If-Match": record["@odata.etag"] }),
     },
-    body: payload,
+    body: formPayload(form, entity),
   });
-  updateClock();
+  if (!routeGuardIsCurrent(routeGuard)) return false;
   if (!result.ok) {
-    announceError(`Save failed: ${result.body.error.message}`);
     const message = result.status === 412
-      ? "This row changed after the form opened. Refresh it, review the new values, and save again."
+      ? "This record changed after the form was opened. Refresh the record, review the latest values, and save again."
       : result.body.error.message;
-    window.alert(message);
+    await showErrorDialog("Save failed", message);
     return false;
   }
-  announce(`${config.singular} saved in browser-local twin state.`);
-  if (creating) window.location.hash = routeHref(entity, result.body[config.primaryKey]);
-  else renderRecordForm(entity, result.body);
-  return true;
+  setDirty(false);
+  app.activeForm = {
+    entity,
+    record: result.body,
+    form,
+    baseline: normalizeEditableSnapshot(formPayload(form, entity)),
+  };
+  announce(`${config.singular} saved.`);
+  if (options.render === false) return result.body;
+  if (creating) {
+    await requestNavigation(routeHref(entity, result.body[config.primaryKey]));
+  } else {
+    renderRecordForm(entity, result.body);
+  }
+  return result.body;
 }
 
-async function deactivateRecord(entity, record) {
+async function refreshCurrentRecord(entity) {
+  const routeGuard = currentRouteGuard();
+  if (!(await resolveDirtyState())) return;
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  const current = app.activeForm?.record;
+  if (!current) return;
+  const config = ENTITY_UI[entity];
+  const result = await app.twin.request({
+    method: "GET",
+    path: `/${entity}(${current[config.primaryKey]})`,
+    logicalRequestId: requestId(`refresh-${entity}`),
+  });
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  if (!result.ok) {
+    await showErrorDialog("Refresh failed", result.body.error.message);
+    return;
+  }
+  renderRecordForm(entity, result.body);
+  announce(`${config.singular} refreshed.`);
+}
+
+async function transitionRecord(entity, action) {
+  const routeGuard = currentRouteGuard();
+  if (!(await resolveDirtyState())) return;
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  const record = app.activeForm?.record;
   if (!record) return;
   const config = ENTITY_UI[entity];
-  const statuscode = entity === "contacts" || entity === "accounts" ? 2 : 5;
+  const labels = {
+    activate: "Activate",
+    deactivate: "Deactivate",
+    complete: "Mark Complete",
+    cancel: entity === "incidents" ? "Cancel Case" : "Cancel Task",
+    resolve: "Resolve Case",
+    reopen: "Reopen Case",
+  };
+  const label = labels[action];
+  const confirmed = await confirmAction(
+    label,
+    `${label} for “${recordTitle(config, record)}”?`,
+    label,
+    action === "cancel",
+  );
+  if (confirmed !== true || !routeGuardIsCurrent(routeGuard)) return;
   const result = await app.twin.request({
     method: "PATCH",
     path: `/${entity}(${record[config.primaryKey]})`,
-    logicalRequestId: requestId(`deactivate-${entity}`),
+    logicalRequestId: requestId(`${action}-${entity}`),
     headers: { "If-Match": record["@odata.etag"], Prefer: "return=representation" },
-    body: { statecode: 1, statuscode },
+    body: transitionPatch(entity, action, app.twin.now()),
   });
+  if (!routeGuardIsCurrent(routeGuard)) return;
   if (!result.ok) {
-    announceError(`Deactivate failed: ${result.body.error.message}`);
+    await showErrorDialog(`${label} failed`, result.body.error.message);
     return;
   }
-  announce(`${config.singular} deactivated locally.`);
   renderRecordForm(entity, result.body);
+  announce(`${label} completed.`);
 }
 
-async function deleteRecord(entity, record) {
+async function deleteCurrentRecord(entity) {
+  const routeGuard = currentRouteGuard();
+  if (!(await resolveDirtyState())) return;
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  const record = app.activeForm?.record;
   if (!record) return;
   const config = ENTITY_UI[entity];
-  if (!window.confirm(`Delete "${recordTitle(config, record)}" from browser-local twin state?`)) return;
+  const confirmed = await confirmAction(
+    `Delete ${config.singular.toLowerCase()}`,
+    `Delete “${recordTitle(config, record)}”? This action cannot be undone.`,
+    "Delete",
+    true,
+  );
+  if (confirmed !== true || !routeGuardIsCurrent(routeGuard)) return;
+  if (entity === "contacts") {
+    await ensureEntities(["contacts", "connections"]);
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    const preflight = preflightContactDeletion(
+      [record.contactid],
+      app.twin.getState("contacts"),
+      app.twin.getState("connections"),
+    );
+    if (!preflight.allowed) {
+      await showErrorDialog("Contact cannot be deleted", contactDeletionBlockedMessage(preflight));
+      return;
+    }
+  }
+  if (entity === "accounts") {
+    await ensureEntities(["accounts", "emails"]);
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    const preflight = preflightAccountDeletion(
+      [record.accountid],
+      app.twin.getState("accounts"),
+      app.twin.getState("emails"),
+    );
+    if (!preflight.allowed) {
+      await showErrorDialog("Account cannot be deleted", accountDeletionBlockedMessage(preflight));
+      return;
+    }
+  }
+  if (!routeGuardIsCurrent(routeGuard)) return;
   const result = await app.twin.request({
     method: "DELETE",
     path: `/${entity}(${record[config.primaryKey]})`,
     logicalRequestId: requestId(`delete-${entity}`),
     headers: { "If-Match": record["@odata.etag"] },
   });
+  if (!routeGuardIsCurrent(routeGuard)) return;
   if (!result.ok) {
-    announceError(`Delete failed: ${result.body.error.message}`);
+    await showErrorDialog("Delete failed", result.body.error.message);
     return;
   }
-  announce(`${config.singular} deleted from local twin state.`);
-  window.location.hash = routeHref(entity);
+  setDirty(false);
+  announce(`${config.singular} deleted.`);
+  await requestNavigation(entity === "emails" || entity === "tasks" ? "#/activities" : routeHref(entity));
 }
 
-function renderLab() {
-  setBreadcrumb([{ label: "Service Hub", href: "#/dashboard" }, { label: "Twin Lab" }]);
-  setCommands([
-    command("Run selected", "▶", () => document.querySelector("#scenario-run")?.click(), { primary: true }),
-    command("Reset twin", "↺", resetTwin),
-    command("Advance 1 minute", "+1m", () => advanceClock(60_000)),
-    command("Advance 1 hour", "+1h", () => advanceClock(3_600_000)),
-    command("Replay run", "⟳", replayCurrentRun),
+async function loadRelatedPanel(entity, record, container) {
+  const routeGuard = currentRouteGuard();
+  replace(container, node("div", { className: "loading-state compact", role: "status" }, [
+    node("span", { className: "spinner", "aria-hidden": "true" }),
+    node("span", { text: "Loading related records" }),
+  ]));
+  try {
+    if (entity === "contacts") {
+      await ensureEntities(["emails", "connections", "contacts"]);
+      if (!routeGuardIsCurrent(routeGuard)) return;
+      renderContactRelated(record, container);
+      return;
+    }
+    if (entity === "accounts") {
+      await ensureEntity("emails");
+      if (!routeGuardIsCurrent(routeGuard)) return;
+      const emails = relatedEmailsForAccount(app.twin.getState("emails"), record.accountid);
+      replace(container, relatedEmailSection(emails));
+      return;
+    }
+    replace(container, honestRelatedEmpty());
+  } catch (error) {
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    replace(container, node("section", { className: "inline-error", role: "alert" }, [
+      node("h2", { text: "Related records could not be loaded" }),
+      node("p", { text: error.message }),
+    ]));
+  }
+}
+
+function renderContactRelated(record, container) {
+  const connections = relatedConnectionsForContact(
+    app.twin.getState("connections"),
+    record.contactid,
+    app.twin.getState("contacts"),
+  ).map((connection) => {
+    return {
+      ...connection,
+      _status: Number(connection.statecode) === 0 ? "Active" : "Inactive",
+    };
+  });
+  const emails = relatedEmailsForContact(app.twin.getState("emails"), record);
+  const state = associatedState(record.contactid);
+  const viewed = applySystemView(connections, "connections", state.view);
+  const searched = searchRows(viewed, ["_relatedName", "_relationship", "_status"], state.search);
+  const sorted = stableSortRows(searched, state.sort, state.direction, "connectionid");
+  const page = paginateRows(sorted, state.page, PAGE_SIZE);
+  state.page = page.page;
+  const pageKeys = page.rows.map((connection) => connection.connectionid);
+  const allPageSelected = pageKeys.length > 0 && pageKeys.every((key) => state.selected.has(key));
+  const selected = connections.filter((connection) => state.selected.has(connection.connectionid));
+  const viewSelector = node("select", {
+    id: "connection-view",
+    "aria-label": "Connections system view",
+    on: {
+      change: (event) => {
+        state.view = event.target.value;
+        state.page = 1;
+        state.selected.clear();
+        renderContactRelated(record, container);
+      },
+    },
+  }, SYSTEM_VIEWS.connections.map((view) =>
+    node("option", { value: view.id, text: view.label, selected: view.id === state.view })));
+  const searchInput = node("input", {
+    id: "connection-search",
+    type: "search",
+    value: state.search,
+    placeholder: "Search this view",
+    "aria-label": "Search this view",
+    on: {
+      keydown: (event) => {
+        if (event.key === "Enter") event.preventDefault();
+      },
+      input: (event) => {
+        state.search = event.target.value;
+        state.page = 1;
+        state.selected.clear();
+        renderContactRelated(record, container);
+        const next = document.querySelector("#connection-search");
+        next?.focus();
+        next?.setSelectionRange(state.search.length, state.search.length);
+      },
+    },
+  });
+  const sortHeader = (key, label) => {
+    const active = state.sort === key;
+    return node("th", {
+      scope: "col",
+      "aria-sort": active ? (state.direction === "asc" ? "ascending" : "descending") : "none",
+    }, [
+      node("button", {
+        type: "button",
+        className: "sort-button",
+        on: {
+          click: () => {
+            if (active) state.direction = state.direction === "asc" ? "desc" : "asc";
+            else {
+              state.sort = key;
+              state.direction = "asc";
+            }
+            state.page = 1;
+            renderContactRelated(record, container);
+          },
+        },
+      }, [
+        node("span", { text: label }),
+        active ? icon("back", `sort-icon ${state.direction}`) : null,
+      ]),
+    ]);
+  };
+  const rows = page.rows.map((connection) => {
+    return node("tr", {}, [
+      node("td", { className: "selection-column" }, [
+        node("input", {
+          type: "checkbox",
+          checked: state.selected.has(connection.connectionid),
+          "aria-label": `Select connection with ${connection._relatedName}`,
+          on: {
+            change: (event) => {
+              state.selected = updateSelection(state.selected, [connection.connectionid], event.target.checked);
+              renderContactRelated(record, container);
+            },
+          },
+        }),
+      ]),
+      node("td", { dataset: { label: "Related Contact" } }, [
+        node("a", { className: "record-link", href: routeHref("contacts", connection._relatedId), text: connection._relatedName }),
+      ]),
+      node("td", { dataset: { label: "Relationship" }, text: connection._relationship }),
+      node("td", { dataset: { label: "Status" } }, [
+        node("span", { className: `status-badge ${statusClass(connection._status)}`, text: connection._status }),
+      ]),
+    ]);
+  });
+  replace(container,
+    node("section", { className: "related-section" }, [
+      node("div", { className: "related-heading" }, [
+        node("h2", { text: "Connections" }),
+      ]),
+      node("div", { className: "associated-toolbar" }, [
+        node("div", { className: "view-choice" }, [
+          node("label", { for: "connection-view", text: "View" }),
+          viewSelector,
+        ]),
+        node("div", { className: "view-search" }, [icon("search"), searchInput]),
+        node("button", {
+          type: "button",
+          className: "secondary-button",
+          disabled: selected.length !== 1,
+          text: "Open related contact",
+          on: { click: () => selected[0] && requestNavigation(routeHref("contacts", selected[0]._relatedId)) },
+        }),
+        node("button", {
+          type: "button",
+          className: "secondary-button",
+          text: "Refresh",
+          on: {
+            click: () => {
+              renderContactRelated(record, container);
+              announce("Connections refreshed.");
+            },
+          },
+        }),
+      ]),
+      node("div", { className: "grid-surface related-grid" }, [
+        node("div", { className: "grid-scroll" }, [
+          node("table", { className: "data-grid", "aria-label": "Contact connections" }, [
+            node("thead", {}, [node("tr", {}, [
+              node("th", { scope: "col", className: "selection-column" }, [
+                node("input", {
+                  type: "checkbox",
+                  checked: allPageSelected,
+                  "aria-label": allPageSelected ? "Clear page selection" : "Select page",
+                  on: {
+                    change: (event) => {
+                      state.selected = updateSelection(state.selected, pageKeys, event.target.checked);
+                      renderContactRelated(record, container);
+                    },
+                  },
+                }),
+              ]),
+              sortHeader("_relatedName", "Related Contact"),
+              sortHeader("_relationship", "Relationship"),
+              sortHeader("_status", "Status"),
+            ])]),
+            rows.length
+              ? node("tbody", {}, rows)
+              : node("tbody", {}, [node("tr", {}, [node("td", {
+                colspan: "4", className: "grid-empty", text: "No connections are available in this view.",
+              })])]),
+          ]),
+        ]),
+        gridFooter(page, () => {
+          state.page -= 1;
+          renderContactRelated(record, container);
+        }, () => {
+          state.page += 1;
+          renderContactRelated(record, container);
+        }),
+      ]),
+    ]),
+    relatedEmailSection(emails),
+  );
+}
+
+function associatedState(contactId) {
+  if (!app.associatedGrid.has(contactId)) {
+    app.associatedGrid.set(contactId, {
+      view: "active",
+      search: "",
+      sort: "_relatedName",
+      direction: "asc",
+      page: 1,
+      selected: new Set(),
+    });
+  }
+  return app.associatedGrid.get(contactId);
+}
+
+function relatedEmailSection(emails) {
+  return node("section", { className: "related-section" }, [
+    node("h2", { text: "Email Activities" }),
+    emails.length
+      ? node("ol", { className: "timeline" }, emails.map((email) => node("li", {}, [
+        node("span", { className: "timeline-marker", "aria-hidden": "true" }),
+        node("div", {}, [
+          node("a", { href: routeHref("emails", email.activityid), text: email.subject || "" }),
+          node("span", { text: `${email.sender || ""}${email.new_channel ? ` · ${email.new_channel}` : ""}` }),
+          node("time", { datetime: email.createdon || "", text: formatUtcDate(email.createdon) }),
+        ]),
+      ])))
+      : node("div", { className: "component-empty" }, [
+        icon("search", "empty-icon"),
+        node("p", { text: "There are no related email activities." }),
+      ]),
   ]);
-  const selectedFromUrl = new URLSearchParams(window.location.hash.split("?")[1] || "").get("scenario");
-  const scenarioSelect = node("select", { id: "scenario-select", "aria-label": "Built-in scenario" });
-  for (const scenario of BUILT_IN_SCENARIOS) {
-    scenarioSelect.append(node("option", {
+}
+
+function honestRelatedEmpty() {
+  return node("section", { className: "related-section component-empty" }, [
+    icon("search", "empty-icon"),
+    node("h2", { text: "Related records" }),
+    node("p", { text: "There are no related activities for this record." }),
+  ]);
+}
+
+function renderEmptyCollection(kind) {
+  const definitions = {
+    queues: {
+      title: "Queues",
+      views: [["active", "Active Queues"], ["all", "All Queues"]],
+      singular: "queue",
+      message: "No queues are available.",
+    },
+    "knowledge-articles": {
+      title: "Knowledge Articles",
+      views: [["active", "Active Knowledge Articles"], ["all", "All Knowledge Articles"]],
+      singular: "knowledge article",
+      message: "No knowledge articles are available.",
+    },
+  };
+  const definition = definitions[kind];
+  const searchKey = `empty-${kind}`;
+  if (!app.grid.has(searchKey)) {
+    app.grid.set(searchKey, { search: "", view: "active", sort: "name", direction: "asc" });
+  }
+  const state = app.grid.get(searchKey);
+  setCommands([command("Refresh", "refresh", () => {
+    renderEmptyCollection(kind);
+    announce(`${definition.title} refreshed.`);
+  })]);
+  const sortHeader = (key, label) => {
+    const active = state.sort === key;
+    return node("th", {
+      scope: "col",
+      "aria-sort": active ? (state.direction === "asc" ? "ascending" : "descending") : "none",
+    }, [
+      node("button", {
+        type: "button",
+        className: "sort-button",
+        on: {
+          click: () => {
+            if (active) state.direction = state.direction === "asc" ? "desc" : "asc";
+            else {
+              state.sort = key;
+              state.direction = "asc";
+            }
+            renderEmptyCollection(kind);
+          },
+        },
+      }, [
+        node("span", { text: label }),
+        active ? icon("back", `sort-icon ${state.direction}`) : null,
+      ]),
+    ]);
+  };
+  const searchInput = node("input", {
+    id: "view-search",
+    type: "search",
+    value: state.search,
+    placeholder: "Search this view",
+    "aria-label": "Search this view",
+    on: {
+      input: (event) => {
+        state.search = event.target.value;
+        renderEmptyCollection(kind);
+        const next = document.querySelector("#view-search");
+        next?.focus();
+        next?.setSelectionRange(event.target.value.length, event.target.value.length);
+      },
+    },
+  });
+  replace(ui.root,
+    pageHeading(definition.title),
+    node("div", { className: "view-toolbar" }, [
+      node("div", { className: "view-choice" }, [
+        node("label", { for: "empty-view", text: "View" }),
+        node("select", {
+          id: "empty-view",
+          "aria-label": `${definition.title} system view`,
+          on: {
+            change: (event) => {
+              state.view = event.target.value;
+              renderEmptyCollection(kind);
+            },
+          },
+        }, definition.views.map(([value, label]) =>
+          node("option", { text: label, value, selected: state.view === value }))),
+      ]),
+      node("div", { className: "view-search" }, [icon("search"), searchInput]),
+    ]),
+    node("div", { className: "grid-surface" }, [
+      node("table", { className: "data-grid empty-collection-grid", "aria-label": definition.title }, [
+        node("thead", {}, [node("tr", {}, [
+          sortHeader("name", "Name"),
+          sortHeader("status", "Status"),
+          sortHeader("modifiedon", "Modified On"),
+        ])]),
+        node("tbody", {}, [node("tr", {}, [
+          node("td", { colspan: "3", className: "grid-empty" }, [
+            icon("search", "empty-icon"),
+            node("strong", { text: state.search ? `No ${definition.singular}s match this search.` : definition.message }),
+          ]),
+        ])]),
+      ]),
+      gridFooter(paginateRows([], 1), () => {}, () => {}),
+    ]),
+  );
+}
+
+function renderKnowledgeSearch(query) {
+  setCommands([]);
+  const input = node("input", {
+    id: "knowledge-query",
+    type: "search",
+    value: query,
+    placeholder: "Search knowledge",
+    "aria-label": "Search knowledge",
+  });
+  const form = node("form", {
+    className: "knowledge-search-form",
+    on: {
+      submit: (event) => {
+        event.preventDefault();
+        requestNavigation(`#/knowledge-search?q=${encodeURIComponent(input.value.trim())}`);
+      },
+    },
+  }, [
+    icon("search"),
+    input,
+    node("button", { className: "primary-button", type: "submit", text: "Search" }),
+  ]);
+  replace(ui.root,
+    pageHeading("Knowledge Search", "Find published knowledge articles."),
+    form,
+    query
+      ? node("section", { className: "large-empty-state" }, [
+        icon("search", "state-icon"),
+        node("h2", { text: "No results found" }),
+        node("p", { text: `No knowledge articles match “${query}”.` }),
+      ])
+      : node("section", { className: "large-empty-state" }, [
+        icon("search", "state-icon"),
+        node("h2", { text: "Search knowledge" }),
+        node("p", { text: "Enter words or a phrase to search published articles." }),
+      ]),
+  );
+}
+
+async function renderGlobalSearch(query, expectedToken = app.navigationToken) {
+  const routeGuard = captureRouteGuard(expectedToken, app.currentRoute);
+  setCommands([]);
+  if (!query.trim()) {
+    replace(ui.root,
+      pageHeading("Search"),
+      node("section", { className: "large-empty-state" }, [
+        icon("search", "state-icon"),
+        node("h2", { text: "Search Dynamics 365" }),
+        node("p", { text: "Enter a name, subject, email, topic, or case title in the header search box." }),
+      ]),
+    );
+    return;
+  }
+  showLoading("Searching");
+  await ensureEntities(["contacts", "accounts", "incidents", "emails", "tasks"]);
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  const activities = combineActivities(app.twin.getState("emails"), app.twin.getState("tasks"), app.twin.now());
+  const groups = [
+    {
+      title: "Contacts", entity: "contacts", records: app.twin.getState("contacts"),
+      fields: ["fullname", "emailaddress1", "jobtitle", "description"], key: "contactid", name: "fullname",
+    },
+    {
+      title: "Accounts", entity: "accounts", records: app.twin.getState("accounts"),
+      fields: ["name", "description", "new_slug"], key: "accountid", name: "name",
+    },
+    {
+      title: "Cases", entity: "incidents", records: app.twin.getState("incidents"),
+      fields: ["title", "description", "new_category"], key: "incidentid", name: "title",
+    },
+    {
+      title: "Activities", entity: "activities", records: activities,
+      fields: ["subject", "description", "_regarding", "sender"], key: "_id", name: "subject",
+    },
+  ];
+  const resultGroups = groups.map((group) => ({
+    ...group,
+    matches: searchRows(group.records, group.fields, query).slice(0, 25),
+  })).filter((group) => group.matches.length);
+  replace(ui.root,
+    pageHeading("Search", `Results for “${query}”`),
+    resultGroups.length
+      ? node("div", { className: "search-results" }, resultGroups.map((group) => node("section", {}, [
+        node("h2", { text: `${group.title} (${group.matches.length})` }),
+        node("ul", {}, group.matches.map((record) => node("li", {}, [
+          node("a", {
+            href: group.entity === "activities"
+              ? routeHref(record._entity, record._id)
+              : routeHref(group.entity, record[group.key]),
+            text: record[group.name] || "",
+          }),
+          node("span", {
+            text: group.entity === "activities"
+              ? `${record._activityType} · ${record._status}`
+              : formattedValue(record.statecode, field("statecode", "", { type: "state" }), group.entity, record),
+          }),
+        ]))),
+      ])))
+      : node("section", { className: "large-empty-state" }, [
+        icon("search", "state-icon"),
+        node("h2", { text: "No results found" }),
+        node("p", { text: "Try different words or check the spelling." }),
+      ]),
+  );
+}
+
+function simulationDisclosure() {
+  return node("aside", { className: "simulation-disclosure" }, [
+    node("strong", { text: "Simulation boundary" }),
+    node("p", {
+      text: "Generated OData files are read-only. Changes, faults, retries, ETags, replay, and virtual UTC time run only in memory in this browser tab; no Dataverse service receives them.",
+    }),
+  ]);
+}
+
+function renderSimulationSettings() {
+  setCommands([
+    command("Run selected", "check", () => document.querySelector("#scenario-run")?.click(), { primary: true }),
+    command("Reset", "refresh", resetRuntime),
+    command("Advance 1 minute", "time", () => advanceClock(60_000)),
+    command("Advance 1 hour", "time", () => advanceClock(3_600_000)),
+    command("Replay", "reopen", replayCurrentRun),
+  ]);
+  const selectedFromRoute = app.currentRoute?.scenario;
+  const scenarioSelect = node("select", { id: "scenario-select", "aria-label": "Built-in scenario" },
+    BUILT_IN_SCENARIOS.map((scenario) => node("option", {
       value: scenario.id,
       text: `${scenario.label} — ${scenario.description}`,
-      selected: scenario.id === selectedFromUrl ? "selected" : null,
-    }));
-  }
-  const scenarioPanel = node("article", { className: "panel" }, [
-    node("header", { className: "panel-header" }, [node("h2", { text: "Built-in deterministic scenarios" })]),
-    node("div", { className: "panel-body" }, [
-      node("div", { className: "lab-field" }, [
-        node("label", { for: "scenario-select", text: "Scenario" }),
-        scenarioSelect,
-      ]),
-      node("div", { className: "button-row" }, [
-        node("button", {
-          id: "scenario-run", className: "action-button primary", type: "button", text: "Run scenario",
-          on: { click: () => runScenario(scenarioSelect.value) },
-        }),
-        node("button", {
-          className: "action-button", type: "button", text: "Run all",
-          on: { click: runAllScenarios },
-        }),
-      ]),
-    ]),
-  ]);
-  const clockPanel = node("article", { className: "clock-card" }, [
-    node("strong", { text: "Virtual UTC clock" }),
-    node("output", { id: "lab-clock", className: "clock-value", text: app.twin.now() }),
-    node("div", { className: "button-row" }, [
-      node("button", { className: "action-button", type: "button", text: "+1 minute", on: { click: () => advanceClock(60_000) } }),
-      node("button", { className: "action-button", type: "button", text: "+1 hour", on: { click: () => advanceClock(3_600_000) } }),
-      node("button", { className: "action-button", type: "button", text: "+1 day", on: { click: () => advanceClock(86_400_000) } }),
-    ]),
-  ]);
-  const customPanel = buildCustomRequestPanel();
-  const results = node("div", { id: "scenario-results", className: "lab-stack" }, [buildScenarioResults()]);
-  const trace = node("div", { id: "trace-panel" }, [buildTracePanel()]);
+      selected: scenario.id === selectedFromRoute,
+    })));
   replace(ui.root,
-    pageHeader("Twin Lab", "Deterministic faults, retries, concurrency, replay, state diffs, and virtual time"),
-    localNotice(),
-    node("section", { className: "lab-layout" }, [
-      node("div", { className: "lab-stack" }, [scenarioPanel, clockPanel, customPanel]),
-      node("div", { className: "lab-stack" }, [results, trace]),
+    pageHeading("Simulation settings", "Deterministic runtime controls and verification"),
+    simulationDisclosure(),
+    node("div", { className: "management-layout" }, [
+      node("div", { className: "management-stack" }, [
+        node("article", { className: "management-panel" }, [
+          node("h2", { text: "Built-in scenarios" }),
+          node("label", { for: "scenario-select", text: "Scenario" }),
+          scenarioSelect,
+          node("div", { className: "button-row" }, [
+            node("button", {
+              id: "scenario-run", className: "primary-button", type: "button", text: "Run scenario",
+              on: { click: () => runScenario(scenarioSelect.value) },
+            }),
+            node("button", { className: "secondary-button", type: "button", text: "Run all", on: { click: runAllScenarios } }),
+          ]),
+        ]),
+        node("article", { className: "management-panel" }, [
+          node("h2", { text: "Virtual UTC clock" }),
+          node("output", { className: "clock-output", text: app.twin.now() }),
+          node("div", { className: "button-row" }, [
+            node("button", { className: "secondary-button", type: "button", text: "Add 1 minute", on: { click: () => advanceClock(60_000) } }),
+            node("button", { className: "secondary-button", type: "button", text: "Add 1 hour", on: { click: () => advanceClock(3_600_000) } }),
+            node("button", { className: "secondary-button", type: "button", text: "Add 1 day", on: { click: () => advanceClock(86_400_000) } }),
+          ]),
+        ]),
+        buildCustomRequestPanel(),
+      ]),
+      node("div", { className: "management-stack" }, [
+        buildScenarioResults(),
+        buildTracePanel(),
+      ]),
     ]),
   );
 }
 
 function buildCustomRequestPanel() {
-  const methods = node("select", { id: "request-method" }, ["GET", "POST", "PATCH", "DELETE"].map((method) => node("option", { value: method, text: method })));
-  const faults = node("select", { id: "request-fault" }, [
+  const method = node("select", { id: "request-method" },
+    ["GET", "POST", "PATCH", "DELETE"].map((value) => node("option", { value, text: value })));
+  const fault = node("select", { id: "request-fault" }, [
     ["none", "No fault"], ["network", "Network error"], ["503", "HTTP 503"],
-    ["429", "HTTP 429 + Retry-After"], ["malformed", "Malformed response"],
+    ["429", "HTTP 429 with Retry-After"], ["malformed", "Malformed response"],
     ["delay", "Virtual 750 ms delay"], ["timeout", "Virtual timeout"],
     ["postCommitLoss", "Post-commit response loss"],
   ].map(([value, label]) => node("option", { value, text: label })));
-  return node("article", { className: "panel" }, [
-    node("header", { className: "panel-header" }, [node("h2", { text: "Request & fault console" })]),
-    node("div", { className: "panel-body lab-fields" }, [
-      node("div", { className: "lab-field" }, [node("label", { for: "request-method", text: "Method" }), methods]),
-      node("div", { className: "lab-field" }, [
-        node("label", { for: "request-path", text: "D365 path" }),
-        node("input", { id: "request-path", value: "/tasks", spellcheck: "false" }),
-      ]),
-      node("div", { className: "lab-field" }, [
-        node("label", { for: "request-id", text: "Logical request ID" }),
-        node("input", { id: "request-id", value: `lab-${String(app.requestCounter + 1).padStart(4, "0")}` }),
-      ]),
-      node("div", { className: "lab-field" }, [node("label", { for: "request-fault", text: "Injected fault" }), faults]),
-      node("div", { className: "lab-field" }, [
-        node("label", { for: "request-body", text: "Raw JSON body (malformed input is allowed)" }),
-        node("textarea", { id: "request-body", spellcheck: "false", text: '{"subject":"Twin Lab probe","scheduledend":"2026-07-01T10:00:00.000Z"}' }),
-      ]),
-      node("label", {}, [
+  return node("article", { className: "management-panel" }, [
+    node("h2", { text: "Request and fault console" }),
+    node("div", { className: "management-fields" }, [
+      node("label", { for: "request-method", text: "Method" }), method,
+      node("label", { for: "request-path", text: "D365 path" }),
+      node("input", { id: "request-path", value: "/tasks", spellcheck: "false" }),
+      node("label", { for: "request-id", text: "Logical request ID" }),
+      node("input", { id: "request-id", value: `console-${String(app.requestCounter + 1).padStart(5, "0")}` }),
+      node("label", { for: "request-fault", text: "Injected fault" }), fault,
+      node("label", { for: "request-body", text: "Raw JSON body" }),
+      node("textarea", {
+        id: "request-body",
+        rows: "5",
+        spellcheck: "false",
+        text: '{"subject":"Console probe","scheduledend":"2026-07-01T10:00:00.000Z"}',
+      }),
+      node("label", { className: "checkbox-label" }, [
         node("input", { id: "request-retry", type: "checkbox", checked: true }),
-        " Use bounded virtual-time retry",
+        node("span", { text: "Use bounded retry" }),
       ]),
-      node("div", { className: "button-row" }, [
-        node("button", { className: "action-button primary", type: "button", text: "Send request", on: { click: sendManualRequest } }),
-      ]),
+      node("button", { className: "primary-button", type: "button", text: "Send request", on: { click: sendManualRequest } }),
       app.lastManualResponse ? rawJson(app.lastManualResponse, "trace-detail") : null,
     ]),
   ]);
@@ -1187,9 +2676,10 @@ function selectedFault(value) {
 }
 
 async function sendManualRequest() {
+  const routeGuard = currentRouteGuard();
   const method = document.querySelector("#request-method").value;
   const path = document.querySelector("#request-path").value;
-  const logicalRequestId = document.querySelector("#request-id").value || requestId("lab");
+  const logicalRequestId = document.querySelector("#request-id").value || requestId("console");
   const body = document.querySelector("#request-body").value;
   const fault = selectedFault(document.querySelector("#request-fault").value);
   const retry = document.querySelector("#request-retry").checked;
@@ -1197,18 +2687,52 @@ async function sendManualRequest() {
     method,
     path,
     logicalRequestId,
-    clientId: "twin-lab",
+    clientId: "service-management",
     headers: { Prefer: "return=representation" },
     ...(method === "GET" || method === "DELETE" ? {} : { body }),
   };
   try {
     const target = parsePath(path);
-    if (!target.error && ENTITY_DEFINITIONS[target.entity]) await ensureEntity(target.entity);
-    app.lastManualResponse = retry
+    if (!target.error && ENTITY_DEFINITIONS[target.entity]) {
+      if (method === "DELETE" && target.entity === "contacts" && target.id) {
+        await ensureEntities(["contacts", "connections"]);
+      } else if (method === "DELETE" && target.entity === "accounts" && target.id) {
+        await ensureEntities(["accounts", "emails"]);
+      } else {
+        await ensureEntity(target.entity);
+      }
+    }
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    if (method === "DELETE" && target.entity === "contacts" && target.id) {
+      const preflight = preflightContactDeletion(
+        [target.id],
+        app.twin.getState("contacts"),
+        app.twin.getState("connections"),
+      );
+      if (!preflight.allowed) {
+        await showErrorDialog("Contact cannot be deleted", contactDeletionBlockedMessage(preflight));
+        return;
+      }
+    }
+    if (method === "DELETE" && target.entity === "accounts" && target.id) {
+      const preflight = preflightAccountDeletion(
+        [target.id],
+        app.twin.getState("accounts"),
+        app.twin.getState("emails"),
+      );
+      if (!preflight.allowed) {
+        await showErrorDialog("Account cannot be deleted", accountDeletionBlockedMessage(preflight));
+        return;
+      }
+    }
+    const response = retry
       ? await app.twin.requestWithRetry(spec, { maxAttempts: 3, baseDelayMs: 200, faults: fault ? [fault] : [] })
       : await app.twin.request({ ...spec, fault });
-    announce(`Twin Lab request completed with status ${app.lastManualResponse.status}.`);
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    app.lastManualResponse = response;
+    announce(`Request completed with status ${app.lastManualResponse.status}.`);
   } catch (error) {
+    if (!routeGuardIsCurrent(routeGuard)) return;
     app.lastManualResponse = {
       transportError: error.name,
       code: error.code || "RETRY_EXHAUSTED",
@@ -1216,20 +2740,25 @@ async function sendManualRequest() {
       attempts: error.attempts,
       committed: error.committed,
     };
-    announceError(`Twin Lab transport failure: ${error.message}`);
+    announceError(`Request failed: ${error.message}`);
   }
-  updateClock();
-  renderLab();
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  renderSimulationSettings();
 }
 
 async function runScenario(id) {
+  const routeGuard = currentRouteGuard();
   try {
-    await ensureScenarioEntities(id);
+    const scenario = BUILT_IN_SCENARIOS.find((item) => item.id === id);
+    await ensureEntities(scenario?.entities || []);
+    if (!routeGuardIsCurrent(routeGuard)) return;
     app.twin.reset();
-    updateClock();
-    app.lastScenario = await runBuiltInScenario(app.twin, id);
+    const result = await runBuiltInScenario(app.twin, id);
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    app.lastScenario = result;
     announce(`${app.lastScenario.label} ${app.lastScenario.passed ? "passed" : "failed"}.`);
   } catch (error) {
+    if (!routeGuardIsCurrent(routeGuard)) return;
     app.lastScenario = {
       id,
       label: id,
@@ -1240,264 +2769,320 @@ async function runScenario(id) {
     };
     announceError(`Scenario failed: ${error.message}`);
   }
-  renderLab();
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  renderSimulationSettings();
 }
 
 async function runAllScenarios() {
+  const routeGuard = currentRouteGuard();
   const results = [];
   try {
     await ensureEntities(BUILT_IN_SCENARIOS.flatMap((scenario) => scenario.entities || []));
+    if (!routeGuardIsCurrent(routeGuard)) return;
     for (const scenario of BUILT_IN_SCENARIOS) {
+      if (!routeGuardIsCurrent(routeGuard)) return;
       app.twin.reset();
       results.push(await runBuiltInScenario(app.twin, scenario.id));
+      if (!routeGuardIsCurrent(routeGuard)) return;
     }
-  } catch (error) {
     app.lastScenario = {
       id: "all",
       label: "All built-in scenarios",
+      passed: results.every((result) => result.passed),
+      assertions: results.flatMap((result) =>
+        result.assertions.map((assertion) => ({ ...assertion, label: `${result.label}: ${assertion.label}` }))),
+      diff: results.at(-1)?.diff || [],
+      trace: app.twin.getTrace(),
+      before: results[0]?.before,
+      after: results.at(-1)?.after,
+    };
+    announce(`All scenarios completed: ${results.filter((result) => result.passed).length} of ${results.length} passed.`);
+  } catch (error) {
+    if (!routeGuardIsCurrent(routeGuard)) return;
+    app.lastScenario = {
+      label: "All built-in scenarios",
       passed: false,
-      assertions: [{ label: error.message, pass: false, actual: error.name, expected: "successful scenario" }],
+      assertions: [{ label: error.message, pass: false, actual: error.name, expected: "successful scenarios" }],
       diff: [],
       trace: [],
     };
-    announceError(`Scenarios failed: ${error.message}`);
-    renderLab();
-    return;
   }
-  app.lastScenario = {
-    id: "all",
-    label: "All built-in scenarios",
-    passed: results.every((result) => result.passed),
-    assertions: results.flatMap((result) => result.assertions.map((item) => ({ ...item, label: `${result.label}: ${item.label}` }))),
-    diff: results.at(-1)?.diff || [],
-    trace: app.twin.getTrace(),
-    before: results[0]?.before,
-    after: results.at(-1)?.after,
-  };
-  announce(`All scenarios completed: ${results.filter((result) => result.passed).length} of ${results.length} passed.`);
-  renderLab();
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  renderSimulationSettings();
 }
 
 function buildScenarioResults() {
   const result = app.lastScenario;
   if (!result) {
-    return node("article", { className: "panel" }, [
-      node("header", { className: "panel-header" }, [node("h2", { text: "Scenario result" })]),
-      node("div", { className: "panel-body" }, [
-        node("p", { text: "Run a built-in scenario to see assertions, before/after digests, and a canonical state diff." }),
-      ]),
+    return node("article", { className: "management-panel" }, [
+      node("h2", { text: "Scenario result" }),
+      node("p", { text: "Run a scenario to inspect assertions and the canonical state difference." }),
     ]);
   }
-  const assertions = result.assertions.map((item) => node("li", {}, [
-    node("span", { className: `assert-icon ${item.pass ? "pass" : "fail"}`, text: item.pass ? "✓" : "✕" }),
-    node("span", {}, [
-      node("strong", { text: item.label }),
-      node("small", { className: "read-value", text: `actual: ${String(item.actual)} · expected: ${String(item.expected)}` }),
-    ]),
-  ]));
-  const diffs = result.diff?.length
-    ? result.diff.map((change) => node("li", {}, [
-      node("strong", { text: `${change.kind.toLocaleUpperCase()} ${change.entity}` }),
-      node("code", { text: change.id }),
-      change.fields ? node("span", { className: "read-value", text: change.fields.map((field) => field.field).join(", ") }) : null,
-    ]))
-    : [node("li", {}, [node("span", { text: "No canonical state changes." })])];
-  return node("article", { className: "panel" }, [
-    node("header", { className: "panel-header" }, [
+  return node("article", { className: "management-panel" }, [
+    node("div", { className: "result-heading" }, [
       node("h2", { text: result.label }),
-      node("span", { className: `badge ${result.passed ? "pass" : "fail"}`, text: result.passed ? "Passed" : "Failed" }),
+      node("span", { className: `status-badge ${result.passed ? "positive" : "negative"}`, text: result.passed ? "Passed" : "Failed" }),
     ]),
-    node("div", { className: "panel-body" }, [
-      node("h3", { text: "Assertions" }),
-      node("ul", { className: "assertions" }, assertions),
-      node("h3", { text: "State diff" }),
-      node("ul", { className: "diff-list" }, diffs),
-      result.before && result.after ? node("details", {}, [
-        node("summary", { text: "Before / after digests and raw diff" }),
-        rawJson({
-          before: { at: result.before.at, stateDigest: result.before.stateDigest, traceDigest: result.before.traceDigest },
-          after: { at: result.after.at, stateDigest: result.after.stateDigest, traceDigest: result.after.traceDigest },
-          diff: result.diff,
-        }, "diff-json"),
-      ]) : null,
-    ]),
+    node("ul", { className: "assertion-list" }, result.assertions.map((assertion) => node("li", {}, [
+      icon(assertion.pass ? "check" : "cancel", `assertion-icon ${assertion.pass ? "pass" : "fail"}`),
+      node("span", {}, [
+        node("strong", { text: assertion.label }),
+        node("small", { text: `Actual: ${String(assertion.actual)} · Expected: ${String(assertion.expected)}` }),
+      ]),
+    ]))),
+    node("h3", { text: "State difference" }),
+    result.diff?.length
+      ? node("ul", { className: "diff-list" }, result.diff.map((change) =>
+        node("li", { text: `${change.kind} ${change.entity} ${change.id}` })))
+      : node("p", { text: "No canonical state changes." }),
+    result.before && result.after ? node("details", {}, [
+      node("summary", { text: "Digests and raw difference" }),
+      rawJson({
+        before: { at: result.before.at, stateDigest: result.before.stateDigest, traceDigest: result.before.traceDigest },
+        after: { at: result.after.at, stateDigest: result.after.stateDigest, traceDigest: result.after.traceDigest },
+        diff: result.diff,
+      }),
+    ]) : null,
   ]);
 }
 
 function buildTracePanel() {
   const trace = app.twin.getTrace().slice(-120).reverse();
-  const rows = trace.map((event) => {
-    const detail = rawJson(event, "trace-detail");
-    detail.hidden = true;
-    const button = node("button", {
-      type: "button",
-      text: event.type,
-      on: {
-        click: () => {
-          detail.hidden = !detail.hidden;
-          button.setAttribute("aria-expanded", String(!detail.hidden));
-        },
-      },
-      "aria-expanded": "false",
-    });
-    return [
-      node("tr", { className: "trace-row" }, [
-        node("td", { text: event.sequence }),
-        node("td", { className: "trace-type" }, [button]),
-        node("td", { text: event.requestId || event.recordId || "—" }),
-        node("td", { text: event.at }),
-      ]),
-      node("tr", {}, [node("td", { colspan: "4" }, [detail])]),
-    ];
-  }).flat();
-  return node("article", { className: "panel" }, [
-    node("header", { className: "panel-header" }, [
-      node("h2", { text: `Append-only event/request trace · ${app.twin.getTrace().length}` }),
+  return node("article", { className: "management-panel" }, [
+    node("div", { className: "result-heading" }, [
+      node("h2", { text: `Append-only trace (${app.twin.getTrace().length})` }),
       node("code", { text: app.twin.traceDigest().slice(0, 16) }),
     ]),
-    node("div", { className: "panel-body grid-wrap" }, [
-      trace.length
-        ? node("table", { className: "trace-table" }, [
+    trace.length
+      ? node("div", { className: "grid-scroll" }, [
+        node("table", { className: "trace-table", "aria-label": "Runtime trace" }, [
           node("thead", {}, [node("tr", {}, [
-            node("th", { text: "#" }), node("th", { text: "Event" }),
-            node("th", { text: "Request / record" }), node("th", { text: "Virtual UTC" }),
+            node("th", { text: "Sequence" }),
+            node("th", { text: "Event" }),
+            node("th", { text: "Request or record" }),
+            node("th", { text: "Virtual UTC" }),
           ])]),
-          node("tbody", {}, rows),
-        ])
-        : node("p", { text: "No trace events yet." }),
-    ]),
+          node("tbody", {}, trace.map((event) => {
+            const detail = rawJson(event, "trace-detail");
+            detail.hidden = true;
+            const toggle = node("button", {
+              type: "button",
+              text: event.type,
+              "aria-expanded": "false",
+              on: {
+                click: () => {
+                  detail.hidden = !detail.hidden;
+                  toggle.setAttribute("aria-expanded", String(!detail.hidden));
+                },
+              },
+            });
+            return node("tr", {}, [
+              node("td", { text: event.sequence }),
+              node("td", {}, [toggle, detail]),
+              node("td", { text: event.requestId || event.recordId || "" }),
+              node("td", { text: event.at }),
+            ]);
+          })),
+        ]),
+      ])
+      : node("p", { text: "No trace events have been recorded." }),
   ]);
 }
 
 function advanceClock(milliseconds) {
-  app.twin.advanceTime(milliseconds, "ui.manual");
-  updateClock();
+  app.twin.advanceTime(milliseconds, "service-management");
   announce(`Virtual clock advanced to ${app.twin.now()}.`);
-  if (app.currentRoute?.view === "lab") renderLab();
+  renderSimulationSettings();
 }
 
-function resetTwin() {
+function resetRuntime() {
   app.twin.reset();
   app.lastScenario = null;
   app.lastManualResponse = null;
-  updateClock();
-  announce("Twin state reset to the immutable seed snapshot.");
-  navigate();
+  announce("Runtime reset to the loaded generated data.");
+  renderSimulationSettings();
 }
 
 async function replayCurrentRun() {
+  const routeGuard = currentRouteGuard();
   const replay = app.twin.exportReplay();
   try {
     const reproduced = await app.twin.constructor.replay(replay);
-    const matches = reproduced.stateDigest() === app.twin.stateDigest()
-      && reproduced.traceDigest() === app.twin.traceDigest();
+    if (!routeGuardIsCurrent(routeGuard)) return;
     app.lastManualResponse = {
       replayedActions: replay.actions.length,
       stateDigest: reproduced.stateDigest(),
       traceDigest: reproduced.traceDigest(),
-      matches,
+      matches: reproduced.stateDigest() === app.twin.stateDigest()
+        && reproduced.traceDigest() === app.twin.traceDigest(),
     };
-    announce(matches ? "Replay reproduced state and trace digests." : "Replay digest mismatch.");
+    announce(app.lastManualResponse.matches ? "Replay reproduced both digests." : "Replay digest mismatch.");
   } catch (error) {
+    if (!routeGuardIsCurrent(routeGuard)) return;
     app.lastManualResponse = { replayError: error.message };
     announceError(`Replay failed: ${error.message}`);
   }
-  renderLab();
+  if (!routeGuardIsCurrent(routeGuard)) return;
+  renderSimulationSettings();
 }
 
-function renderAbout() {
-  setBreadcrumb([{ label: "Service Hub", href: "#/dashboard" }, { label: "API & simulation" }]);
+function renderApiSimulation() {
   setCommands([
-    command("Open metadata", "↗", () => openExternal(new URL("$metadata.json", API_ROOT)), {
-      disabled: !safeHttpUrl(new URL("$metadata.json", API_ROOT)),
-    }),
-    command("Twin Lab", "⚗", () => { window.location.hash = "#/lab"; }, { primary: true }),
+    command("Open metadata", "external", () => openExternal(new URL("$metadata.json", API_ROOT))),
+    command("Simulation settings", "time", () => requestNavigation("#/service-management/simulation-settings"), { primary: true }),
   ]);
-  const endpoints = [...app.counts.entries()].map(([entity, count]) => node("div", { className: "endpoint" }, [
-    node("code", { text: `GET /api/data/v9.2/${entity}.json` }),
-    node("span", { text: `${count.toLocaleString()} immutable seed records · loaded only when routed` }),
+  const endpoints = (app.metadata?.EntitySets || []).map((entity) => node("li", {}, [
+    node("code", { text: `GET /api/data/v9.2/${entity.name}.json` }),
+    node("span", { text: `${Number(entity.recordCount || 0).toLocaleString("en-US")} generated records` }),
   ]));
   replace(ui.root,
-    pageHeader("Dynamics 365 API & digital twin", "A deterministic browser-local Service Hub over immutable generated JSON"),
-    localNotice(),
-    node("aside", { className: "callout" }, [
-      node("strong", { text: "Honest simulation boundary: " }),
-      "GitHub Pages serves read-only seed JSON. The reusable core simulates POST, PATCH, DELETE, faults, retries, ETags, concurrency, and time only in memory.",
-    ]),
-    node("section", { className: "panel" }, [
-      node("header", { className: "panel-header" }, [node("h2", { text: "Lazy OData-shaped seed endpoints" })]),
-      node("div", { className: "panel-body endpoint-list" }, endpoints),
-    ]),
-    node("section", { className: "dashboard-columns" }, [
-      node("article", { className: "panel" }, [
-        node("header", { className: "panel-header" }, [node("h2", { text: "Deterministic invariants" })]),
-        node("div", { className: "panel-body" }, [
-          node("ul", {}, [
-            node("li", { text: "Injected virtual UTC clock; no wall-time sleeps." }),
-            node("li", { text: "Stable request IDs, GUIDs, ETags, event order, state digest, and trace digest." }),
-            node("li", { text: "If-Match returns 412 on stale writes; failed validation and transport do not commit." }),
-            node("li", { text: "Post-commit response loss retries by logical request ID without double apply." }),
-            node("li", { text: "Connections are fetched only on navigation; metadata supplies counts." }),
-          ]),
+    pageHeading("API & simulation", "OData-shaped data and deterministic runtime information"),
+    simulationDisclosure(),
+    node("div", { className: "management-layout" }, [
+      node("article", { className: "management-panel" }, [
+        node("h2", { text: "Generated endpoints" }),
+        node("ul", { className: "endpoint-list" }, endpoints),
+      ]),
+      node("article", { className: "management-panel" }, [
+        node("h2", { text: "Runtime invariants" }),
+        node("ul", {}, [
+          node("li", { text: "UTC timestamps require explicit offsets." }),
+          node("li", { text: "Stable request IDs, GUIDs, ETags, ordering, and digests." }),
+          node("li", { text: "If-Match rejects stale writes without changing state." }),
+          node("li", { text: "Logical request IDs prevent double application after response loss." }),
+          node("li", { text: "Tasks remain open after their due time until explicitly completed or canceled." }),
         ]),
       ]),
-      node("article", { className: "panel" }, [
-        node("header", { className: "panel-header" }, [node("h2", { text: "Snapshot identity" })]),
-        node("div", { className: "panel-body" }, [
-          node("p", { text: app.metadata?._snapshot || "No snapshot identity loaded." }),
-          externalLink("https://github.com/kody-w/rappterbook", "View Rappterbook source"),
-          rawJson(app.metadata),
-        ]),
+      node("article", { className: "management-panel wide" }, [
+        node("h2", { text: "Metadata" }),
+        rawJson(app.metadata),
       ]),
     ]),
   );
 }
 
 function renderNotFound(path) {
-  setBreadcrumb([{ label: "Service Hub", href: "#/dashboard" }, { label: "Not found" }]);
-  setCommands([command("Dashboard", "←", () => { window.location.hash = "#/dashboard"; })]);
-  replace(ui.root, node("section", { className: "empty-state" }, [
-    node("div", {}, [
-      node("h2", { text: "Service Hub route not found" }),
-      node("p", { text: `No deterministic twin view exists for “${path}”.` }),
-      node("a", { href: "#/dashboard", text: "Return to dashboard" }),
-    ]),
+  setCommands([command("Back to dashboard", "back", () => requestNavigation("#/dashboard"))]);
+  replace(ui.root, node("section", { className: "large-empty-state" }, [
+    icon("search", "state-icon"),
+    node("h1", { text: "Page not found" }),
+    node("p", { text: `No Customer Service Hub page exists for “${path}”.` }),
+    node("a", { href: "#/dashboard", className: "primary-link", text: "Go to Dashboards" }),
   ]));
 }
 
-function toggleSitemap() {
-  const opening = !ui.sitemap.classList.contains("open");
-  ui.sitemap.classList.toggle("open", opening);
-  ui.scrim.classList.toggle("open", opening);
-  ui.sitemapToggle.setAttribute("aria-expanded", String(opening));
+async function navigate() {
+  setCommands([]);
+  closePopup();
+  closeSitemap();
+  const route = parseRoute();
+  app.currentRoute = route;
+  const token = ++app.navigationToken;
+  setActiveNavigation(route);
+  setBusy(true);
+  app.activeForm = null;
+  try {
+    if (route.view === "dashboard") await renderDashboard(token);
+    else if (route.view === "grid") await renderGridRoute(route, token);
+    else if (route.view === "record") await renderRecordRoute(route, token);
+    else if (route.view === "queues" || route.view === "knowledge-articles") renderEmptyCollection(route.view);
+    else if (route.view === "knowledge-search") renderKnowledgeSearch(route.query);
+    else if (route.view === "search") await renderGlobalSearch(route.query, token);
+    else if (route.view === "simulation-settings") renderSimulationSettings();
+    else if (route.view === "api-simulation") renderApiSimulation();
+    else renderNotFound(route.path);
+  } catch (error) {
+    if (token !== app.navigationToken) return;
+    showLoadError("This page could not be loaded", error, navigate);
+  } finally {
+    if (token === app.navigationToken) {
+      setBusy(false);
+      ui.main.focus();
+    }
+  }
+}
+
+function handleDocumentClick(event) {
+  const link = event.target instanceof Element
+    ? event.target.closest("a[href^='#/']")
+    : null;
+  if (link && shouldInterceptSpaNavigation({
+    button: event.button,
+    defaultPrevented: event.defaultPrevented,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    shiftKey: event.shiftKey,
+    altKey: event.altKey,
+    download: link.hasAttribute("download"),
+    target: link.getAttribute("target"),
+  })) {
+    event.preventDefault();
+    requestNavigation(link.getAttribute("href"));
+    return;
+  }
+  if (app.activePopup && !app.activePopup.panel.contains(event.target)
+    && !app.activePopup.button.contains(event.target)
+    && event.target !== ui.selector) {
+    closePopup();
+  }
+}
+
+function handleDocumentKeydown(event) {
+  if (event.key !== "Escape") return;
+  if (ui.sitemap.classList.contains("open")) {
+    event.preventDefault();
+    closeSitemap(true);
+  } else if (app.activePopup) {
+    event.preventDefault();
+    closePopup(true);
+  }
+}
+
+function beforeUnload(event) {
+  if (!app.dirty) return;
+  event.preventDefault();
+  event.returnValue = "";
 }
 
 async function boot() {
-  ui.mainContent = document.querySelector("#main-content");
-  ui.sitemapToggle.addEventListener("click", toggleSitemap);
-  ui.scrim.addEventListener("click", closeSitemap);
-  document.querySelector("#header-reset").addEventListener("click", resetTwin);
-  window.addEventListener("hashchange", navigate);
-  window.addEventListener("unhandledrejection", (event) => {
-    announceError(`Unexpected twin error: ${event.reason?.message || event.reason}`);
-  });
-  updateClock();
+  if (!app.shellListenersReady) {
+    ui.navigationToggle.addEventListener("click", openSitemap);
+    ui.navigationClose.addEventListener("click", () => closeSitemap(true));
+    ui.scrim.addEventListener("click", () => closeSitemap(true));
+    ui.launcher.addEventListener("click", () => togglePopup(ui.launcher, ui.launcherMenu));
+    ui.selector.addEventListener("click", () => togglePopup(ui.selector, ui.launcherMenu));
+    ui.quickCreate.addEventListener("click", () => togglePopup(ui.quickCreate, ui.quickCreateMenu));
+    ui.areaSwitcher.addEventListener("click", () => togglePopup(ui.areaSwitcher, ui.areaMenu));
+    ui.globalSearch.addEventListener("submit", (event) => {
+      event.preventDefault();
+      requestNavigation(`#/search?q=${encodeURIComponent(ui.globalSearchInput.value.trim())}`);
+    });
+    document.addEventListener("click", handleDocumentClick);
+    document.addEventListener("keydown", handleDocumentKeydown);
+    window.addEventListener("popstate", handlePopState);
+    window.addEventListener("beforeunload", beforeUnload);
+    window.addEventListener("unhandledrejection", (event) => {
+      announceError(`Unexpected error: ${event.reason?.message || event.reason}`);
+    });
+    app.shellListenersReady = true;
+  }
+  showLoading("Loading Customer Service Hub");
   try {
     await loadMetadata();
   } catch (error) {
-    showLoadError("Failed to load D365 metadata", error, async () => {
-      showLoading("Retrying D365 metadata…");
-      try {
-        await loadMetadata();
-        await navigate();
-      } catch (retryError) {
-        showLoadError("Failed to load D365 metadata", retryError, boot);
-      }
-    });
+    showLoadError("Customer Service Hub could not start", error, boot);
     return;
   }
-  if (!window.location.hash) window.location.hash = "#/dashboard";
-  else await navigate();
+  const initialHash = window.location.hash || "#/dashboard";
+  const initialIndex = indexedHistoryPosition(window.history.state) ?? 0;
+  app.navigationHistory = createNavigationHistory(initialIndex);
+  window.history.replaceState({
+    ...(window.history.state || {}),
+    [HISTORY_INDEX_KEY]: initialIndex,
+  }, "", initialHash);
+  app.currentHash = initialHash;
+  await navigate();
 }
 
 boot();

--- a/docs/d365/d365.css
+++ b/docs/d365/d365.css
@@ -1,28 +1,29 @@
 :root {
-  --header: #242424;
-  --header-hover: #3b3a39;
-  --accent: #0f6cbd;
-  --accent-hover: #115ea3;
-  --accent-soft: #ebf3fc;
-  --canvas: #f5f5f5;
-  --surface: #ffffff;
-  --surface-alt: #fafafa;
-  --border: #e1dfdd;
-  --border-strong: #c8c6c4;
-  --text: #242424;
-  --muted: #616161;
-  --subtle: #8a8886;
-  --success: #107c10;
-  --success-bg: #dff6dd;
-  --warning: #8a4b08;
-  --warning-bg: #fff4ce;
-  --danger: #c50f1f;
-  --danger-bg: #fde7e9;
-  --info-bg: #deecf9;
-  --shadow: 0 1px 2px rgb(0 0 0 / 8%), 0 2px 8px rgb(0 0 0 / 5%);
-  --radius: 4px;
   color-scheme: light;
-  font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
+  --header: #242424;
+  --canvas: #fafafa;
+  --surface: #ffffff;
+  --text: #242424;
+  --secondary: #616161;
+  --border: #e0e0e0;
+  --border-strong: #c7c7c7;
+  --brand: #0f6cbd;
+  --brand-hover: #115ea3;
+  --selected: #ebf3fc;
+  --danger: #c50f1f;
+  --danger-hover: #a4262c;
+  --success: #107c10;
+  --warning: #8a3707;
+  --focus: #0f6cbd;
+  --header-height: 48px;
+  --sitemap-width: 208px;
+  --command-height: 46px;
+  --radius: 4px;
+  --shadow-4: 0 1px 2px rgb(0 0 0 / 12%), 0 1px 4px rgb(0 0 0 / 8%);
+  --shadow-16: 0 8px 28px rgb(0 0 0 / 18%);
+  font-family: "Segoe UI", SegoeUI, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
 }
 
 * {
@@ -31,15 +32,16 @@
 
 html,
 body {
+  width: 100%;
   height: 100%;
   margin: 0;
 }
 
 body {
-  background: var(--canvas);
-  color: var(--text);
-  font-size: 14px;
+  min-width: 320px;
   overflow: hidden;
+  color: var(--text);
+  background: var(--canvas);
 }
 
 button,
@@ -51,190 +53,424 @@ textarea {
 }
 
 button,
-a,
-input,
-select,
-textarea {
-  outline-offset: 2px;
+a {
+  -webkit-tap-highlight-color: transparent;
 }
 
-:focus-visible {
-  outline: 2px solid var(--accent);
+button {
+  border: 0;
 }
 
 a {
-  color: var(--accent);
-}
-
-.app-header {
-  align-items: center;
-  background: var(--header);
-  color: #fff;
-  display: flex;
-  gap: 10px;
-  height: 48px;
-  padding: 0 12px;
-  position: relative;
-  z-index: 30;
-}
-
-.app-launcher,
-.icon-button,
-.header-action {
-  align-items: center;
-  background: transparent;
-  border: 0;
-  color: inherit;
-  cursor: pointer;
-  display: inline-flex;
-  height: 32px;
-  justify-content: center;
-  min-width: 32px;
-}
-
-.app-launcher:disabled {
-  cursor: not-allowed;
-  opacity: .72;
-}
-
-.icon-button:hover,
-.header-action:hover {
-  background: var(--header-hover);
-}
-
-.brand {
-  align-items: center;
-  color: #fff;
-  display: flex;
-  font-weight: 600;
-  gap: 8px;
+  color: var(--brand);
   text-decoration: none;
 }
 
-.brand-mark {
-  color: #50e6ff;
+a:hover {
+  color: var(--brand-hover);
+  text-decoration: underline;
 }
 
-.app-name {
-  border-left: 1px solid #666;
-  color: #e1dfdd;
-  margin-left: 4px;
-  padding-left: 14px;
+svg {
+  display: block;
 }
 
-.simulation-pill,
-.local-pill {
+svg path,
+svg circle,
+svg rect {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+}
+
+.ui-icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  color: currentColor;
+}
+
+.global-header {
+  position: relative;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: var(--header-height);
+  padding: 0 8px;
+  color: #ffffff;
+  background: var(--header);
+}
+
+.header-icon,
+.plain-icon {
+  display: inline-grid;
+  width: 36px;
+  height: 36px;
+  padding: 8px;
   border-radius: 2px;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .03em;
-  padding: 3px 7px;
-  text-transform: uppercase;
+  place-items: center;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
 }
 
-.simulation-pill {
-  background: #5c2d91;
+.header-icon svg,
+.plain-icon svg {
+  width: 20px;
+  height: 20px;
 }
 
-.local-pill {
-  background: #144b34;
-  color: #dff6dd;
+.header-icon:hover,
+.header-icon[aria-expanded="true"] {
+  color: #ffffff;
+  background: rgb(255 255 255 / 12%);
+  text-decoration: none;
+}
+
+.product-name {
+  margin: 0 10px 0 8px;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 48px;
+  white-space: nowrap;
+}
+
+.product-name:hover {
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.header-divider {
+  width: 1px;
+  height: 24px;
+  background: rgb(255 255 255 / 28%);
+}
+
+.app-selector {
+  display: flex;
+  align-items: center;
+  min-width: 190px;
+  height: 40px;
+  gap: 8px;
+  padding: 0 12px;
+  color: #ffffff;
+  font-weight: 600;
+  text-align: left;
+  background: transparent;
+  cursor: pointer;
+}
+
+.app-selector:hover,
+.app-selector[aria-expanded="true"] {
+  background: rgb(255 255 255 / 10%);
+}
+
+.app-selector svg {
+  width: 16px;
+  height: 16px;
+}
+
+.global-search {
+  display: flex;
+  align-items: center;
+  width: min(30vw, 360px);
+  height: 32px;
+  margin-left: 12px;
+  padding: 0 10px;
+  border-radius: 4px;
+  color: var(--text);
+  background: #ffffff;
+}
+
+.global-search:focus-within {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.global-search svg {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 auto;
+  margin-right: 8px;
+  color: var(--secondary);
+}
+
+.global-search input {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+.global-search input::placeholder {
+  color: var(--secondary);
 }
 
 .header-spacer {
   flex: 1;
 }
 
-.header-clock {
-  color: #e1dfdd;
-  font-family: Consolas, "SFMono-Regular", monospace;
-  font-size: 12px;
-  white-space: nowrap;
+.mobile-navigation {
+  display: none;
 }
 
-.header-action {
-  border-left: 1px solid #555;
-  font-size: 12px;
-  padding: 0 10px;
+.header-flyout {
+  position: fixed;
+  z-index: 100;
+  top: var(--header-height);
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-top: 0;
+  border-radius: 0 0 4px 4px;
+  color: var(--text);
+  background: var(--surface);
+  box-shadow: var(--shadow-16);
+}
+
+.header-flyout[hidden],
+.area-menu[hidden] {
+  display: none;
+}
+
+.header-flyout h2 {
+  margin: 0 0 12px;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.app-flyout {
+  left: 8px;
+  width: 344px;
+}
+
+.app-flyout a {
+  display: flex;
+  align-items: center;
+  min-height: 62px;
+  gap: 12px;
+  padding: 8px;
+  color: var(--text);
+}
+
+.app-flyout a:hover {
+  color: var(--text);
+  text-decoration: none;
+  background: #f5f5f5;
+}
+
+.app-flyout a > span:last-child {
+  display: flex;
+  flex-direction: column;
+}
+
+.app-flyout small {
+  color: var(--secondary);
+}
+
+.flyout-tile {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  color: #ffffff;
+  background: var(--brand);
+  place-items: center;
+}
+
+.flyout-tile svg {
+  width: 24px;
+  height: 24px;
+}
+
+.quick-create-flyout {
+  right: 50px;
+  width: 240px;
+}
+
+.quick-create-flyout a {
+  display: block;
+  padding: 9px 10px;
+  color: var(--text);
+}
+
+.quick-create-flyout a:hover {
+  text-decoration: none;
+  background: #f5f5f5;
 }
 
 .workspace {
   display: flex;
-  height: calc(100% - 48px);
+  width: 100%;
+  height: calc(100% - var(--header-height));
+  min-width: 0;
 }
 
 .sitemap {
-  background: var(--surface);
-  border-right: 1px solid var(--border);
+  position: relative;
+  z-index: 30;
   display: flex;
-  flex: 0 0 230px;
+  width: var(--sitemap-width);
+  height: 100%;
+  flex: 0 0 var(--sitemap-width);
   flex-direction: column;
-  overflow-y: auto;
-  z-index: 20;
+  overflow: hidden;
+  border-right: 1px solid var(--border);
+  background: #f3f3f3;
 }
 
-.area-picker {
-  align-items: center;
-  background: var(--surface-alt);
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  font-weight: 600;
-  gap: 10px;
-  min-height: 44px;
-  padding: 0 16px;
+.sitemap-mobile-heading {
+  display: none;
 }
 
-.sitemap nav {
-  padding: 5px 0 16px;
+.sitemap-navigation {
+  flex: 1;
+  overflow: auto;
+  padding: 8px 0 12px;
+  scrollbar-width: thin;
 }
 
-.sitemap h2 {
-  color: var(--muted);
+.sitemap-navigation section + section {
+  margin-top: 4px;
+}
+
+.sitemap-navigation [data-area="service-management"] {
+  display: none;
+}
+
+.sitemap.management-area .sitemap-navigation [data-area="customer-service"] {
+  display: none;
+}
+
+.sitemap.management-area .sitemap-navigation [data-area="service-management"] {
+  display: block;
+}
+
+.sitemap-navigation h2 {
+  margin: 0;
+  padding: 10px 14px 5px;
+  color: var(--secondary);
   font-size: 11px;
   font-weight: 600;
-  letter-spacing: .05em;
-  margin: 14px 16px 5px;
-  text-transform: uppercase;
+  letter-spacing: .02em;
+  text-transform: none;
 }
 
-.sitemap nav a {
-  align-items: center;
-  border-left: 3px solid transparent;
-  color: var(--text);
+.sitemap-navigation a {
+  position: relative;
   display: flex;
-  gap: 10px;
+  align-items: center;
   min-height: 36px;
-  padding: 6px 12px 6px 13px;
+  gap: 10px;
+  padding: 5px 12px 5px 14px;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.sitemap-navigation a::before {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 0;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: transparent;
+  content: "";
+}
+
+.sitemap-navigation a:hover {
+  color: var(--text);
   text-decoration: none;
+  background: #e9e9e9;
 }
 
-.sitemap nav a:hover {
-  background: #f0f0f0;
-}
-
-.sitemap nav a.active {
-  background: var(--accent-soft);
-  border-left-color: var(--accent);
-  color: var(--accent-hover);
+.sitemap-navigation a.active {
+  color: #0b4a7d;
   font-weight: 600;
+  background: var(--selected);
 }
 
-.nav-count {
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 400;
+.sitemap-navigation a.active::before {
+  background: var(--brand);
+}
+
+.sitemap-navigation a svg {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  color: var(--secondary);
+}
+
+.sitemap-navigation a.active svg {
+  color: var(--brand);
+}
+
+.area-switcher-wrap {
+  position: relative;
+  padding: 7px;
+  border-top: 1px solid var(--border);
+  background: #eeeeee;
+}
+
+.area-switcher {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 38px;
+  gap: 8px;
+  padding: 0 8px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+  background: transparent;
+  cursor: pointer;
+}
+
+.area-switcher:hover,
+.area-switcher[aria-expanded="true"] {
+  background: #dedede;
+}
+
+.area-switcher > svg {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+}
+
+.area-switcher .area-chevron {
+  width: 14px;
+  height: 14px;
   margin-left: auto;
 }
 
-.sitemap-footer {
-  border-top: 1px solid var(--border);
-  color: var(--muted);
-  display: flex;
-  flex-direction: column;
-  font-size: 11px;
-  gap: 3px;
-  margin-top: auto;
-  padding: 12px 16px;
+.area-menu {
+  position: fixed;
+  z-index: 90;
+  bottom: 50px;
+  left: 7px;
+  width: 194px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  box-shadow: var(--shadow-16);
+}
+
+.area-menu a {
+  display: block;
+  padding: 8px 10px;
+  color: var(--text);
+}
+
+.area-menu a:hover {
+  text-decoration: none;
+  background: #f5f5f5;
 }
 
 .sitemap-scrim {
@@ -243,513 +479,878 @@ a {
 
 .main-content {
   display: flex;
+  width: calc(100% - var(--sitemap-width));
+  min-width: 0;
+  height: 100%;
   flex: 1;
   flex-direction: column;
-  min-width: 0;
   overflow: hidden;
-}
-
-.breadcrumb {
-  align-items: center;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-  color: var(--muted);
-  display: flex;
-  font-size: 12px;
-  gap: 7px;
-  min-height: 34px;
-  padding: 0 22px;
-}
-
-.breadcrumb a {
-  text-decoration: none;
+  outline: 0;
 }
 
 .command-bar {
-  align-items: center;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
+  z-index: 15;
   display: flex;
-  gap: 2px;
-  min-height: 44px;
-  overflow-x: auto;
-  padding: 4px 18px;
-}
-
-.command-button {
   align-items: center;
-  background: transparent;
-  border: 0;
+  min-height: var(--command-height);
+  gap: 2px;
+  margin: 8px 16px 0;
+  padding: 4px 8px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
-  cursor: pointer;
-  display: inline-flex;
-  gap: 7px;
-  min-height: 34px;
-  padding: 5px 10px;
-  white-space: nowrap;
+  background: var(--surface);
+  box-shadow: var(--shadow-4);
+  scrollbar-width: thin;
 }
 
-.command-button:hover:not(:disabled) {
+.command-bar[hidden] {
+  display: none;
+}
+
+.command {
+  display: inline-flex;
+  align-items: center;
+  min-width: max-content;
+  height: 34px;
+  gap: 7px;
+  padding: 0 10px;
+  border-radius: 3px;
+  color: var(--text);
+  background: transparent;
+  cursor: pointer;
+}
+
+.command:hover:not(:disabled) {
   background: #f0f0f0;
 }
 
-.command-button.primary {
-  background: var(--accent);
-  color: #fff;
+.command.primary {
+  color: #ffffff;
+  background: var(--brand);
 }
 
-.command-button.primary:hover:not(:disabled) {
-  background: var(--accent-hover);
+.command.primary:hover:not(:disabled) {
+  background: var(--brand-hover);
 }
 
-.command-button.danger {
+.command.danger:not(:disabled) {
   color: var(--danger);
 }
 
-.command-button:disabled {
-  color: var(--subtle);
-  cursor: not-allowed;
+.command:disabled {
+  color: #a1a1a1;
+  cursor: default;
 }
 
 .command-separator {
-  align-self: stretch;
-  border-left: 1px solid var(--border);
-  margin: 5px 6px;
+  width: 1px;
+  height: 24px;
+  margin: 0 4px;
+  background: var(--border);
 }
 
 .view-root {
-  flex: 1;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 12px 16px 16px;
   overflow: auto;
-  padding: 20px 24px 40px;
+  scrollbar-width: thin;
 }
 
-.page-header {
+.page-heading {
+  display: flex;
   align-items: flex-start;
-  display: flex;
-  gap: 16px;
-  justify-content: space-between;
-  margin-bottom: 18px;
-}
-
-.page-header h1 {
-  font-size: 24px;
-  font-weight: 600;
-  line-height: 1.2;
-  margin: 0 0 5px;
-}
-
-.page-subtitle {
-  color: var(--muted);
-  margin: 0;
-}
-
-.local-notice {
-  align-items: center;
-  background: var(--warning-bg);
-  border: 1px solid #f2c811;
-  border-radius: var(--radius);
-  color: #533f03;
-  display: flex;
-  gap: 9px;
-  margin-bottom: 16px;
-  padding: 10px 12px;
-}
-
-.local-notice strong {
-  white-space: nowrap;
-}
-
-.loading-card,
-.error-card,
-.empty-state {
-  align-items: center;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  display: flex;
-  gap: 12px;
-  justify-content: center;
-  min-height: 180px;
-  padding: 28px;
-  text-align: center;
-}
-
-.spinner {
-  animation: spin .8s linear infinite;
-  border: 3px solid var(--border);
-  border-radius: 50%;
-  border-top-color: var(--accent);
-  height: 22px;
-  width: 22px;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-.error-card {
-  align-items: flex-start;
-  background: var(--danger-bg);
-  border-color: #f1aeb5;
-  color: #74000b;
-  flex-direction: column;
-  justify-content: flex-start;
-  text-align: left;
-}
-
-.error-card h2,
-.empty-state h2 {
-  font-size: 17px;
-  margin: 0;
-}
-
-.error-card p,
-.empty-state p {
-  margin: 0;
-}
-
-.retry-button {
-  background: var(--surface);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
-  cursor: pointer;
-  padding: 7px 12px;
-}
-
-.dashboard-grid {
-  display: grid;
-  gap: 14px;
-  grid-template-columns: repeat(4, minmax(150px, 1fr));
-  margin-bottom: 20px;
-}
-
-.metric-card,
-.panel {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-}
-
-.metric-card {
-  color: inherit;
-  min-height: 118px;
-  padding: 16px;
-  position: relative;
-  text-decoration: none;
-}
-
-.metric-card:hover {
-  border-color: var(--accent);
-}
-
-.metric-label {
-  color: var(--muted);
-  display: block;
-  font-size: 12px;
+  min-height: 50px;
   margin-bottom: 8px;
 }
 
-.metric-value {
-  display: block;
-  font-size: 30px;
+.page-heading h1 {
+  margin: 0;
+  font-size: 24px;
   font-weight: 600;
+  letter-spacing: -.01em;
 }
 
-.metric-detail {
-  bottom: 14px;
-  color: var(--accent);
-  font-size: 12px;
-  position: absolute;
+.page-heading p {
+  margin: 3px 0 0;
+  color: var(--secondary);
 }
 
-.dashboard-columns {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
-}
-
-.panel-header {
-  align-items: center;
-  border-bottom: 1px solid var(--border);
+.loading-state,
+.error-state,
+.large-empty-state {
   display: flex;
-  justify-content: space-between;
-  min-height: 44px;
-  padding: 9px 14px;
+  min-height: 240px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--secondary);
+  text-align: center;
 }
 
-.panel-header h2,
-.panel-header h3 {
-  font-size: 15px;
+.loading-state.compact {
+  min-height: 140px;
+}
+
+.spinner {
+  width: 26px;
+  height: 26px;
+  border: 3px solid #d1d1d1;
+  border-top-color: var(--brand);
+  border-radius: 50%;
+  animation: spin .8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.state-icon {
+  width: 42px;
+  height: 42px;
+  color: var(--secondary);
+}
+
+.error-state h1,
+.large-empty-state h1,
+.large-empty-state h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 22px;
   font-weight: 600;
+}
+
+.error-state p,
+.large-empty-state p {
+  max-width: 580px;
   margin: 0;
 }
 
-.panel-body {
-  padding: 14px;
+.primary-button,
+.secondary-button,
+.primary-link {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border: 1px solid var(--brand);
+  border-radius: 3px;
+  font-weight: 600;
+  cursor: pointer;
 }
 
-.quick-list {
-  list-style: none;
+.primary-button,
+.primary-link {
+  color: #ffffff;
+  background: var(--brand);
+}
+
+.primary-button:hover,
+.primary-link:hover {
+  color: #ffffff;
+  text-decoration: none;
+  background: var(--brand-hover);
+}
+
+.secondary-button {
+  border-color: var(--border-strong);
+  background: var(--surface);
+}
+
+.secondary-button:hover {
+  background: #f5f5f5;
+}
+
+.secondary-button.danger {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.primary-button.danger {
+  border-color: var(--danger);
+  background: var(--danger);
+}
+
+.primary-button.danger:hover {
+  background: var(--danger-hover);
+}
+
+.dashboard-selector {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 46px;
+  gap: 12px;
+  margin-bottom: 12px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.dashboard-selector label,
+.view-choice label {
+  color: var(--secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.dashboard-selector select,
+.view-selector,
+.related-heading select {
+  min-width: 240px;
+  height: 32px;
+  padding: 3px 28px 3px 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: 2px;
+  background: var(--surface);
+}
+
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.dashboard-panel {
+  min-width: 0;
+  min-height: 250px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
+}
+
+.dashboard-panel.wide {
+  grid-column: 1 / -1;
+}
+
+.panel-heading {
+  display: flex;
+  min-height: 43px;
+  align-items: center;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel-heading h2,
+.related-section h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.record-list,
+.ranked-list {
   margin: 0;
   padding: 0;
+  list-style: none;
 }
 
-.quick-list li {
-  align-items: flex-start;
-  border-bottom: 1px solid #f0f0f0;
+.record-list li,
+.ranked-list li {
   display: flex;
-  gap: 10px;
-  padding: 11px 2px;
+  min-height: 40px;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 14px;
+  border-bottom: 1px solid #eeeeee;
 }
 
-.quick-list li:last-child {
+.record-list li:last-child,
+.ranked-list li:last-child {
   border-bottom: 0;
 }
 
-.quick-icon {
-  align-items: center;
-  background: var(--info-bg);
-  border-radius: 50%;
-  display: inline-flex;
-  flex: 0 0 30px;
-  height: 30px;
-  justify-content: center;
-}
-
-.quick-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.quick-copy small {
-  color: var(--muted);
-}
-
-.toolbar {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 12px;
-}
-
-.search-box {
-  min-width: min(380px, 100%);
-  position: relative;
-}
-
-.search-box input {
-  background: var(--surface);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
-  min-height: 34px;
-  padding: 5px 10px 5px 32px;
-  width: 100%;
-}
-
-.search-box::before {
-  color: var(--muted);
-  content: "⌕";
-  font-size: 18px;
-  left: 10px;
-  position: absolute;
-  top: 6px;
-}
-
-.record-summary {
-  color: var(--muted);
-  font-size: 12px;
-  margin-left: auto;
-}
-
-.grid-wrap {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  overflow: auto;
-}
-
-.data-grid {
-  border-collapse: collapse;
-  min-width: 760px;
-  width: 100%;
-}
-
-.data-grid th {
-  background: var(--surface-alt);
-  border-bottom: 1px solid var(--border-strong);
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 600;
-  position: sticky;
-  text-align: left;
-  top: 0;
-  z-index: 2;
-}
-
-.data-grid th button {
-  align-items: center;
-  background: transparent;
-  border: 0;
-  cursor: pointer;
-  display: flex;
-  font-weight: inherit;
-  gap: 6px;
-  min-height: 38px;
-  padding: 7px 12px;
-  text-align: left;
-  width: 100%;
-}
-
-.data-grid td {
-  border-bottom: 1px solid #f0f0f0;
-  height: 42px;
-  max-width: 360px;
+.record-list a,
+.ranked-list a {
+  min-width: 0;
+  flex: 1;
   overflow: hidden;
-  padding: 7px 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.record-list span,
+.ranked-list span {
+  flex: 0 0 auto;
+  color: var(--secondary);
+  font-size: 12px;
+}
+
+.component-empty {
+  display: flex;
+  min-height: 170px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  color: var(--secondary);
+  text-align: center;
+}
+
+.component-empty h2,
+.component-empty p {
+  margin: 0;
+}
+
+.empty-icon {
+  width: 28px;
+  height: 28px;
+  color: #8a8886;
+}
+
+.chart-figure {
+  margin: 0;
+  padding: 12px 14px;
+}
+
+.chart-figure figcaption {
+  margin-bottom: 8px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.chart-figure svg {
+  width: 100%;
+  max-height: 320px;
+}
+
+.chart-label,
+.chart-value {
+  fill: var(--text);
+  stroke: none;
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.chart-value {
+  font-weight: 600;
+  text-anchor: start;
+}
+
+.chart-track {
+  fill: #eeeeee;
+  stroke: none;
+}
+
+.chart-bar {
+  fill: var(--brand);
+  stroke: none;
+}
+
+.dashboard-panel .ranked-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--border);
+}
+
+.view-toolbar {
+  display: flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-bottom: 0;
+  background: var(--surface);
+}
+
+.view-choice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.view-search {
+  display: flex;
+  width: 280px;
+  height: 32px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: 2px;
+  background: var(--surface);
+}
+
+.view-search:focus-within {
+  border-color: var(--brand);
+  box-shadow: inset 0 0 0 1px var(--brand);
+}
+
+.view-search .ui-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--secondary);
+}
+
+.view-search input {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+.grid-surface {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.grid-scroll {
+  width: 100%;
+  min-width: 0;
+  overflow: auto;
+}
+
+.data-grid,
+.trace-table {
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: separate;
+  table-layout: fixed;
+  font-size: 13px;
+}
+
+.data-grid th,
+.data-grid td,
+.trace-table th,
+.trace-table td {
+  height: 40px;
+  padding: 0 10px;
+  overflow: hidden;
+  border-right: 1px solid #eeeeee;
+  border-bottom: 1px solid #eeeeee;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.data-grid thead th,
+.trace-table thead th {
+  position: sticky;
+  z-index: 2;
+  top: 0;
+  height: 42px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+  background: #f5f5f5;
+}
+
+.data-grid th:last-child,
+.data-grid td:last-child,
+.trace-table th:last-child,
+.trace-table td:last-child {
+  border-right: 0;
+}
+
 .data-grid tbody tr:hover {
-  background: #f5f9fd;
+  background: #f8fbfe;
+}
+
+.data-grid tbody tr.selected {
+  background: var(--selected);
+}
+
+.selection-column {
+  width: 42px;
+  padding: 0 !important;
+  text-align: center !important;
+}
+
+input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--brand);
+}
+
+.sort-button {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 0;
+  font-weight: 600;
+  text-align: left;
+  background: transparent;
+  cursor: pointer;
+}
+
+.sort-icon {
+  width: 12px;
+  height: 12px;
+  color: var(--brand);
+  transform: rotate(90deg);
+}
+
+.sort-icon.desc {
+  transform: rotate(-90deg);
 }
 
 .record-link {
   font-weight: 600;
-  text-decoration: none;
 }
 
-.record-link:hover {
-  text-decoration: underline;
-}
-
-.badge {
-  border-radius: 10px;
-  display: inline-block;
-  font-size: 11px;
-  font-weight: 600;
+.status-badge {
+  display: inline-flex;
+  min-height: 22px;
+  align-items: center;
   padding: 2px 8px;
+  border-radius: 11px;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.badge.active,
-.badge.pass,
-.badge.success {
-  background: var(--success-bg);
-  color: var(--success);
+.status-badge.positive {
+  color: #0b5a0b;
+  background: #dff6dd;
 }
 
-.badge.inactive,
-.badge.fail,
-.badge.error {
-  background: var(--danger-bg);
-  color: var(--danger);
+.status-badge.neutral {
+  color: #424242;
+  background: #eeeeee;
 }
 
-.badge.warning,
-.badge.pending {
-  background: var(--warning-bg);
-  color: var(--warning);
+.status-badge.negative {
+  color: #9d1717;
+  background: #fde7e9;
 }
 
-.form-shell {
+.grid-empty {
+  height: 180px !important;
+  color: var(--secondary);
+  text-align: center !important;
+  white-space: normal !important;
+}
+
+.grid-empty .empty-icon,
+.grid-empty strong,
+.grid-empty span {
+  display: block;
+  margin: 6px auto;
+}
+
+.grid-footer {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 20px;
+  padding: 5px 10px;
+  color: var(--secondary);
+  font-size: 12px;
   background: var(--surface);
+}
+
+.pager-buttons {
+  display: flex;
+  gap: 2px;
+}
+
+.pager-buttons button {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  color: var(--text);
+  background: transparent;
+  cursor: pointer;
+  place-items: center;
+}
+
+.pager-buttons button:hover:not(:disabled) {
+  background: #eeeeee;
+}
+
+.pager-buttons button:disabled {
+  color: #b5b5b5;
+  cursor: default;
+}
+
+.ui-icon.next {
+  transform: rotate(180deg);
+}
+
+.record-navigation {
+  display: flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 5px;
+}
+
+.record-navigation a {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 7px;
+  color: var(--text);
+}
+
+.record-navigation a:hover {
+  text-decoration: none;
+  background: #eeeeee;
+}
+
+.record-shell {
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  box-shadow: var(--shadow);
+  background: var(--surface);
 }
 
 .record-header {
+  display: grid;
+  min-height: 92px;
   align-items: center;
+  grid-template-columns: 48px minmax(200px, 1fr) minmax(420px, 1.6fr);
+  gap: 14px;
+  padding: 12px 16px;
   border-bottom: 1px solid var(--border);
-  display: flex;
-  gap: 13px;
-  padding: 15px 18px;
 }
 
-.record-avatar {
-  align-items: center;
-  background: #5c2d91;
-  border-radius: 3px;
-  color: #fff;
-  display: flex;
-  flex: 0 0 44px;
-  font-size: 20px;
+.record-symbol {
+  display: grid;
+  width: 44px;
   height: 44px;
-  justify-content: center;
+  border-radius: 50%;
+  color: #ffffff;
+  background: var(--brand);
+  place-items: center;
 }
 
-.record-heading h1 {
-  font-size: 20px;
-  margin: 0 0 3px;
+.record-symbol .ui-icon {
+  width: 22px;
+  height: 22px;
 }
 
-.record-heading p {
-  color: var(--muted);
-  margin: 0;
+.record-title {
+  min-width: 0;
 }
 
-.record-etag {
-  color: var(--muted);
-  font-family: Consolas, monospace;
+.record-title > span {
+  color: var(--secondary);
+  font-size: 12px;
+}
+
+.record-title h1 {
+  margin: 1px 0 0;
+  overflow: hidden;
+  font-size: 22px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+body.record-dirty .record-title h1::after {
+  margin-left: 8px;
+  color: var(--secondary);
+  content: "(Unsaved)";
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.record-header-fields {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.header-field {
+  min-width: 0;
+}
+
+.header-field > span:first-child {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--secondary);
   font-size: 11px;
-  margin-left: auto;
 }
 
-.tabs {
-  border-bottom: 1px solid var(--border);
+.header-field > span:last-child {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.business-process {
   display: flex;
-  padding: 0 16px;
+  min-height: 62px;
+  align-items: center;
+  gap: 24px;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--border);
+  background: #f8fbfe;
 }
 
-.tab-button {
-  background: transparent;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  cursor: pointer;
-  min-height: 42px;
-  padding: 8px 14px;
-}
-
-.tab-button.active {
-  border-bottom-color: var(--accent);
-  color: var(--accent);
+.process-label {
+  color: var(--secondary);
+  font-size: 12px;
   font-weight: 600;
 }
 
-.form-content {
-  padding: 18px;
+.business-process ol {
+  display: flex;
+  max-width: 720px;
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
-.form-section {
+.business-process li {
+  position: relative;
+  flex: 1;
+}
+
+.business-process li:not(:last-child)::after {
+  position: absolute;
+  z-index: 0;
+  top: 14px;
+  right: 0;
+  left: 32px;
+  height: 2px;
+  background: var(--border-strong);
+  content: "";
+}
+
+.business-process li.complete:not(:last-child)::after {
+  background: var(--brand);
+}
+
+.business-process button {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 8px 3px 0;
+  background: #f8fbfe;
+  cursor: pointer;
+}
+
+.stage-marker {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--border-strong);
+  border-radius: 50%;
+  color: var(--secondary);
+  background: var(--surface);
+  font-size: 12px;
+  place-items: center;
+}
+
+.business-process li.active .stage-marker,
+.business-process li.complete .stage-marker {
+  border-color: var(--brand);
+  color: #ffffff;
+  background: var(--brand);
+}
+
+.business-process li.active button {
+  color: var(--brand);
+  font-weight: 600;
+}
+
+.form-tabs {
+  display: flex;
+  min-height: 44px;
+  gap: 2px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.form-tab {
+  position: relative;
+  min-width: 90px;
+  padding: 0 14px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.form-tab:hover:not(:disabled) {
+  background: #f5f5f5;
+}
+
+.form-tab.active {
+  color: var(--brand);
+  font-weight: 600;
+}
+
+.form-tab.active::after {
+  position: absolute;
+  right: 10px;
+  bottom: 0;
+  left: 10px;
+  height: 3px;
+  background: var(--brand);
+  content: "";
+}
+
+.form-tab:disabled {
+  color: #a1a1a1;
+  cursor: default;
+}
+
+.form-panel {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 14px;
+  background: var(--canvas);
+}
+
+.form-panel[hidden] {
+  display: none;
+}
+
+.form-section,
+.related-section {
+  min-width: 0;
+  padding: 12px 14px 16px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  margin-bottom: 16px;
+  background: var(--surface);
 }
 
-.form-section h2 {
-  background: var(--surface-alt);
+.form-section h2,
+.related-section h2 {
+  margin: 0 0 12px;
+  padding-bottom: 8px;
   border-bottom: 1px solid var(--border);
-  font-size: 14px;
-  margin: 0;
-  padding: 10px 13px;
+  font-size: 15px;
+  font-weight: 600;
 }
 
 .form-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px 14px;
 }
 
 .form-field {
-  border-bottom: 1px solid #f2f2f2;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  min-height: 72px;
-  padding: 11px 13px;
+  min-width: 0;
 }
 
 .form-field.full {
@@ -757,398 +1358,807 @@ a {
 }
 
 .form-field label,
-.field-label {
-  color: var(--muted);
-  font-size: 11px;
+.management-fields label,
+.management-panel > label {
+  display: flex;
+  min-height: 20px;
+  align-items: center;
+  gap: 3px;
+  margin-bottom: 3px;
+  color: var(--secondary);
+  font-size: 12px;
   font-weight: 600;
-  letter-spacing: .03em;
-  text-transform: uppercase;
+}
+
+.required-marker {
+  color: var(--danger);
+  font-size: 15px;
 }
 
 .form-field input,
 .form-field select,
 .form-field textarea,
-.lab-field input,
-.lab-field select,
-.lab-field textarea {
-  background: var(--surface);
-  border: 1px solid transparent;
-  border-bottom-color: var(--border-strong);
-  border-radius: 2px;
-  min-height: 32px;
-  padding: 5px 7px;
+.management-fields input,
+.management-fields select,
+.management-fields textarea,
+.management-panel > select {
   width: 100%;
+  min-height: 32px;
+  padding: 5px 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: 2px;
+  background: var(--surface);
 }
 
-.form-field input:hover,
-.form-field select:hover,
-.form-field textarea:hover,
-.lab-field input:hover,
-.lab-field select:hover,
-.lab-field textarea:hover {
-  border-color: var(--border-strong);
-}
-
-.form-field textarea {
-  min-height: 80px;
+.form-field textarea,
+.management-fields textarea {
+  min-height: 76px;
   resize: vertical;
 }
 
-.read-value {
-  line-height: 1.45;
+.field-value {
+  display: block;
+  min-height: 32px;
+  padding: 6px 0;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
 
-.read-value.empty {
-  color: var(--subtle);
+.related-section {
+  grid-column: 1 / -1;
+}
+
+.related-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.related-heading h2 {
+  flex: 1;
+  margin: 0;
+}
+
+.related-grid {
+  border: 0;
+}
+
+.associated-toolbar {
+  display: flex;
+  min-height: 46px;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  background: #fafafa;
+}
+
+.associated-toolbar .view-search {
+  margin-left: auto;
+}
+
+.associated-toolbar .secondary-button:disabled {
+  border-color: var(--border);
+  color: #a1a1a1;
+  cursor: default;
+  background: #f7f7f7;
+}
+
+.related-grid .data-grid {
+  min-width: 720px;
 }
 
 .timeline {
-  list-style: none;
+  position: relative;
   margin: 0;
   padding: 0;
+  list-style: none;
+}
+
+.timeline::before {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 7px;
+  width: 2px;
+  background: var(--border);
+  content: "";
 }
 
 .timeline li {
-  border-left: 2px solid var(--border);
-  margin-left: 12px;
-  padding: 0 0 18px 18px;
   position: relative;
-}
-
-.timeline li::before {
-  background: var(--surface);
-  border: 2px solid var(--accent);
-  border-radius: 50%;
-  content: "";
-  height: 10px;
-  left: -6px;
-  position: absolute;
-  top: 4px;
-  width: 10px;
-}
-
-.timeline strong,
-.timeline time,
-.timeline span {
-  display: block;
-}
-
-.timeline time,
-.timeline span {
-  color: var(--muted);
-  font-size: 12px;
-  margin-top: 3px;
-}
-
-.json-block,
-.trace-detail,
-.diff-json {
-  background: #1e1e1e;
-  border-radius: var(--radius);
-  color: #d4d4d4;
-  font-family: Consolas, "SFMono-Regular", monospace;
-  font-size: 12px;
-  line-height: 1.5;
-  margin: 0;
-  max-height: 430px;
-  overflow: auto;
-  padding: 14px;
-  white-space: pre-wrap;
-}
-
-.lab-layout {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: minmax(280px, .75fr) minmax(0, 1.65fr);
-}
-
-.lab-stack {
   display: flex;
-  flex-direction: column;
-  gap: 16px;
+  min-height: 58px;
+  gap: 12px;
+  padding: 5px 0 10px;
 }
 
-.lab-fields {
+.timeline-marker {
+  z-index: 1;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  border: 3px solid var(--surface);
+  border-radius: 50%;
+  background: var(--brand);
+  box-shadow: 0 0 0 1px var(--brand);
+}
+
+.timeline li > div {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.timeline a {
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeline span,
+.timeline time {
+  color: var(--secondary);
+  font-size: 12px;
+}
+
+.inline-error {
+  padding: 14px;
+  border: 1px solid #f1aeb5;
+  color: #8b1018;
+  background: #fff4f4;
+}
+
+.empty-collection-grid {
+  min-width: 680px;
+}
+
+.knowledge-search-form {
+  display: flex;
+  width: min(700px, 100%);
+  height: 42px;
+  align-items: center;
+  gap: 8px;
+  margin: 10px auto 0;
+  padding-left: 12px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+}
+
+.knowledge-search-form:focus-within {
+  border-color: var(--focus);
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.knowledge-search-form .ui-icon {
+  color: var(--secondary);
+}
+
+.knowledge-search-form input {
+  min-width: 0;
+  height: 100%;
+  flex: 1;
+  border: 0;
+  outline: 0;
+}
+
+.knowledge-search-form button {
+  height: 100%;
+  border-radius: 0;
+}
+
+.search-results {
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
 
-.lab-field {
+.search-results section {
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.search-results h2 {
+  margin: 0;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 16px;
+}
+
+.search-results ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.search-results li {
   display: flex;
-  flex-direction: column;
-  gap: 5px;
+  min-height: 40px;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid #eeeeee;
 }
 
-.lab-field label {
-  color: var(--muted);
+.search-results li:last-child {
+  border-bottom: 0;
+}
+
+.search-results li a {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-results li span {
+  flex: 0 0 auto;
+  color: var(--secondary);
   font-size: 12px;
-  font-weight: 600;
 }
 
-.lab-field textarea {
-  font-family: Consolas, monospace;
-  min-height: 108px;
-  resize: vertical;
+.simulation-disclosure {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border: 1px solid #9cc2e5;
+  border-left: 4px solid var(--brand);
+  background: #f3f8fc;
+}
+
+.simulation-disclosure p {
+  margin: 3px 0 0;
+}
+
+.management-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, .85fr) minmax(420px, 1.15fr);
+  gap: 12px;
+}
+
+.management-stack {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.management-panel {
+  min-width: 0;
+  padding: 14px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.management-panel.wide {
+  grid-column: 1 / -1;
+}
+
+.management-panel h2 {
+  margin: 0 0 12px;
+  font-size: 17px;
+}
+
+.management-panel h3 {
+  margin: 16px 0 8px;
+  font-size: 14px;
+}
+
+.management-panel > select {
+  margin-bottom: 10px;
 }
 
 .button-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
-.action-button {
-  background: var(--surface);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius);
-  cursor: pointer;
-  min-height: 34px;
-  padding: 6px 12px;
-}
-
-.action-button:hover {
-  background: #f0f0f0;
-}
-
-.action-button.primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-}
-
-.action-button.primary:hover {
-  background: var(--accent-hover);
-}
-
-.clock-card {
-  background: #252423;
-  border-radius: var(--radius);
-  color: #fff;
-  padding: 15px;
-}
-
-.clock-value {
+.clock-output {
   display: block;
-  font-family: Consolas, monospace;
-  font-size: 17px;
-  margin: 5px 0 11px;
-}
-
-.assertions {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.assertions li {
-  align-items: flex-start;
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  gap: 9px;
-  padding: 9px 0;
-}
-
-.assertions li:last-child {
-  border-bottom: 0;
-}
-
-.assert-icon {
-  font-weight: 800;
-}
-
-.assert-icon.pass {
-  color: var(--success);
-}
-
-.assert-icon.fail {
-  color: var(--danger);
-}
-
-.trace-table {
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.trace-table th,
-.trace-table td {
-  border-bottom: 1px solid var(--border);
-  font-size: 12px;
-  padding: 7px 8px;
-  text-align: left;
-  vertical-align: top;
-}
-
-.trace-table th {
-  color: var(--muted);
-}
-
-.trace-type {
-  font-family: Consolas, monospace;
-  white-space: nowrap;
-}
-
-.trace-row button {
-  background: transparent;
-  border: 0;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 0;
-  text-align: left;
-}
-
-.diff-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.diff-list li {
-  border-bottom: 1px solid var(--border);
-  padding: 9px 0;
-}
-
-.diff-list code {
-  color: var(--muted);
-  font-size: 11px;
-}
-
-.callout {
-  background: var(--info-bg);
-  border-left: 4px solid var(--accent);
-  margin-bottom: 14px;
-  padding: 11px 13px;
-}
-
-.callout.warning {
-  background: var(--warning-bg);
-  border-color: #f2c811;
-}
-
-.endpoint-list {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.endpoint {
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   padding: 10px;
+  border: 1px solid var(--border);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  background: #f7f7f7;
 }
 
-.endpoint code {
-  display: block;
-  font-size: 12px;
-  margin-bottom: 4px;
-  overflow-wrap: anywhere;
+.management-fields {
+  display: grid;
+  grid-template-columns: 1fr;
 }
 
-.external-link {
-  align-items: center;
-  display: inline-flex;
-  gap: 5px;
+.management-fields .checkbox-label {
+  display: flex;
+  min-height: 34px;
+  flex-direction: row;
+  gap: 8px;
 }
 
-.sr-only {
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+.management-fields .checkbox-label input {
+  width: 16px;
+  min-height: 16px;
 }
 
-.mobile-only {
+.json-block,
+.trace-detail {
+  max-height: 360px;
+  padding: 10px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  color: #1f1f1f;
+  background: #f6f6f6;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.trace-detail[hidden] {
   display: none;
 }
 
-@media (max-width: 1040px) {
-  .dashboard-grid {
-    grid-template-columns: repeat(2, minmax(150px, 1fr));
+.trace-table {
+  min-width: 700px;
+  table-layout: auto;
+}
+
+.trace-table button {
+  color: var(--brand);
+  background: transparent;
+  cursor: pointer;
+}
+
+.result-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.result-heading h2 {
+  margin: 0;
+}
+
+.assertion-list,
+.diff-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.assertion-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.assertion-list li > span {
+  display: flex;
+  flex-direction: column;
+}
+
+.assertion-list small {
+  color: var(--secondary);
+}
+
+.assertion-icon {
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+}
+
+.assertion-icon.pass {
+  color: var(--success);
+}
+
+.assertion-icon.fail {
+  color: var(--danger);
+}
+
+.endpoint-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.endpoint-list li {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.endpoint-list span {
+  color: var(--secondary);
+  font-size: 12px;
+}
+
+.app-dialog {
+  width: min(520px, calc(100vw - 32px));
+  max-height: min(640px, calc(100vh - 32px));
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  color: var(--text);
+  background: var(--surface);
+  box-shadow: var(--shadow-16);
+}
+
+.app-dialog::backdrop {
+  background: rgb(0 0 0 / 42%);
+}
+
+.dialog-heading {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px 8px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.dialog-heading h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.dialog-content {
+  max-height: 440px;
+  padding: 18px;
+  overflow: auto;
+}
+
+.dialog-content p {
+  margin: 0;
+}
+
+.dialog-actions {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 18px;
+  border-top: 1px solid var(--border);
+  background: #fafafa;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.global-header :focus-visible {
+  outline-color: #ffffff;
+}
+
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+@media (max-width: 1120px) {
+  .global-search {
+    width: min(24vw, 280px);
   }
 
-  .dashboard-columns,
-  .lab-layout {
+  .record-header {
+    grid-template-columns: 48px minmax(180px, 1fr);
+  }
+
+  .record-header-fields {
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .management-layout {
     grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 760px) {
-  .mobile-only {
-    display: inline-flex;
+@media (max-width: 860px) {
+  .mobile-navigation {
+    display: inline-grid;
   }
 
-  .app-name,
-  .local-pill,
-  .header-clock {
+  .product-name,
+  .header-divider {
     display: none;
   }
 
+  .app-selector {
+    min-width: 170px;
+    padding-left: 8px;
+  }
+
+  .global-search {
+    width: 200px;
+    margin-left: 4px;
+  }
+
   .sitemap {
-    bottom: 0;
-    box-shadow: 6px 0 20px rgb(0 0 0 / 18%);
-    left: 0;
     position: fixed;
-    top: 48px;
+    z-index: 70;
+    top: var(--header-height);
+    bottom: 0;
+    left: 0;
+    width: min(300px, calc(100vw - 48px));
     transform: translateX(-105%);
-    transition: transform .18s ease;
-    width: min(86vw, 280px);
+    transition: transform .16s ease;
+    box-shadow: var(--shadow-16);
   }
 
   .sitemap.open {
     transform: translateX(0);
   }
 
+  .sitemap-mobile-heading {
+    display: flex;
+    min-height: 48px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 7px 6px 14px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+  }
+
   .sitemap-scrim {
-    background: rgb(0 0 0 / 35%);
-    border: 0;
-    bottom: 0;
-    cursor: pointer;
-    left: 0;
     position: fixed;
-    right: 0;
-    top: 48px;
-    z-index: 15;
+    z-index: 60;
+    inset: var(--header-height) 0 0;
+    display: none;
+    background: rgb(0 0 0 / 36%);
   }
 
   .sitemap-scrim.open {
     display: block;
   }
 
-  .view-root {
-    padding: 15px 12px 30px;
+  .main-content {
+    width: 100%;
   }
 
-  .breadcrumb {
-    padding: 0 12px;
-  }
-
-  .command-bar {
-    padding-left: 8px;
-  }
-
-  .dashboard-grid,
-  .form-grid,
-  .endpoint-list {
+  .dashboard-layout,
+  .search-results {
     grid-template-columns: 1fr;
   }
 
-  .page-header {
+  .dashboard-panel.wide {
+    grid-column: auto;
+  }
+
+  .record-header-fields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .form-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-panel .ranked-list {
+    grid-template-columns: 1fr;
+  }
+
+  .view-toolbar {
+    align-items: stretch;
     flex-direction: column;
+    gap: 8px;
+  }
+
+  .view-search {
+    width: 100%;
+  }
+}
+
+@media (max-width: 620px) {
+  .global-header {
+    padding: 0 4px;
+  }
+
+  .app-selector {
+    min-width: 0;
+    max-width: 160px;
+    flex: 1;
+  }
+
+  .app-selector span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .global-search {
+    width: 42px;
+    padding: 0 11px;
+    background: rgb(255 255 255 / 12%);
+  }
+
+  .global-search input {
+    width: 0;
+    color: #ffffff;
+  }
+
+  .global-search:focus-within {
+    position: absolute;
+    right: 84px;
+    left: 48px;
+    z-index: 2;
+    width: auto;
+    background: #ffffff;
+  }
+
+  .global-search:focus-within input {
+    width: 100%;
+    color: var(--text);
+  }
+
+  .header-spacer {
+    display: none;
+  }
+
+  .header-flyout {
+    right: 8px;
+    left: 8px;
+    width: auto;
+  }
+
+  .quick-create-flyout {
+    right: 8px;
+  }
+
+  .command-bar {
+    margin: 6px 8px 0;
+  }
+
+  .command {
+    padding: 0 8px;
+  }
+
+  .view-root {
+    padding: 10px 8px 12px;
+  }
+
+  .page-heading h1 {
+    font-size: 21px;
+  }
+
+  .dashboard-selector {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .dashboard-selector select,
+  .view-selector,
+  .related-heading select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .data-grid {
+    min-width: 780px;
+  }
+
+  .data-grid th,
+  .data-grid td {
+    height: 42px;
   }
 
   .record-header {
-    align-items: flex-start;
-    flex-wrap: wrap;
+    grid-template-columns: 42px minmax(0, 1fr);
+    padding: 10px;
   }
 
-  .record-etag {
-    margin-left: 57px;
+  .record-symbol {
+    width: 40px;
+    height: 40px;
+  }
+
+  .record-header-fields {
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+
+  .record-title h1 {
+    font-size: 19px;
+  }
+
+  .business-process {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 6px;
+    overflow-x: auto;
+  }
+
+  .business-process ol {
+    min-width: 480px;
+  }
+
+  .form-tabs {
+    padding: 0 4px;
+  }
+
+  .form-tab {
+    min-width: 0;
+    flex: 1;
+    padding: 0 6px;
+  }
+
+  .form-panel {
+    padding: 8px;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .related-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .associated-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .associated-toolbar .view-search {
+    margin-left: 0;
+  }
+
+  .grid-footer {
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .grid-footer > span:nth-child(2) {
+    display: none;
+  }
+
+  .management-panel {
+    padding: 11px;
+  }
+
+  .endpoint-list li {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+    padding: 7px 0;
+  }
+
+  .dialog-actions {
+    align-items: stretch;
+    flex-direction: column-reverse;
+  }
+
+  .dialog-actions button {
     width: 100%;
   }
 }
@@ -1157,8 +2167,9 @@ a {
   *,
   *::before,
   *::after {
-    animation-duration: .001ms !important;
     scroll-behavior: auto !important;
+    animation-duration: .001ms !important;
+    animation-iteration-count: 1 !important;
     transition-duration: .001ms !important;
   }
 }

--- a/docs/d365/index.html
+++ b/docs/d365/index.html
@@ -6,86 +6,202 @@
     content="default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; form-action 'none'">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light">
-  <title>Rappterbook Service Hub — Dynamics 365 Digital Twin</title>
+  <title>Dynamics 365 — Customer Service Hub</title>
   <link rel="stylesheet" href="./d365.css">
   <script type="module" src="./app.mjs"></script>
 </head>
 <body>
-  <header class="app-header">
-    <button id="sitemap-toggle" class="icon-button mobile-only" type="button"
-      aria-label="Open site map" aria-controls="sitemap" aria-expanded="false">☰</button>
-    <button class="app-launcher" type="button" aria-label="Microsoft 365 app launcher" disabled
-      title="App launcher is unavailable in this static twin">⠿</button>
-    <a class="brand" href="#/dashboard" aria-label="Dynamics 365 Service Hub home">
-      <span class="brand-mark" aria-hidden="true">◆</span>
-      <span>Dynamics 365</span>
-    </a>
-    <span class="app-name">Customer Service workspace</span>
-    <span class="simulation-pill">TWIN</span>
-    <span class="local-pill">Browser-local writes</span>
+  <header class="global-header">
+    <button id="navigation-toggle" class="header-icon mobile-navigation" type="button"
+      aria-label="Open navigation" aria-controls="sitemap" aria-expanded="false">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M4 7h16M4 12h16M4 17h16"></path>
+      </svg>
+    </button>
+    <button id="app-launcher" class="header-icon" type="button"
+      aria-label="Open app launcher" aria-controls="app-launcher-menu" aria-expanded="false">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="4" y="4" width="3" height="3"></rect>
+        <rect x="10.5" y="4" width="3" height="3"></rect>
+        <rect x="17" y="4" width="3" height="3"></rect>
+        <rect x="4" y="10.5" width="3" height="3"></rect>
+        <rect x="10.5" y="10.5" width="3" height="3"></rect>
+        <rect x="17" y="10.5" width="3" height="3"></rect>
+        <rect x="4" y="17" width="3" height="3"></rect>
+        <rect x="10.5" y="17" width="3" height="3"></rect>
+        <rect x="17" y="17" width="3" height="3"></rect>
+      </svg>
+    </button>
+    <a class="product-name" href="#/dashboard" aria-label="Dynamics 365 home">Dynamics 365</a>
+    <span class="header-divider" aria-hidden="true"></span>
+    <button id="app-selector" class="app-selector" type="button"
+      aria-controls="app-launcher-menu" aria-expanded="false">
+      <span>Customer Service Hub</span>
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7 9 5 5 5-5"></path></svg>
+    </button>
+
+    <form id="global-search" class="global-search" role="search">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="10.5" cy="10.5" r="5.5"></circle>
+        <path d="m15 15 5 5"></path>
+      </svg>
+      <label class="sr-only" for="global-search-input">Search Dynamics 365</label>
+      <input id="global-search-input" type="search" autocomplete="off"
+        placeholder="Search" aria-label="Search Dynamics 365">
+    </form>
+
     <div class="header-spacer"></div>
-    <output id="header-clock" class="header-clock" aria-label="Virtual UTC clock">—</output>
-    <button id="header-reset" class="header-action" type="button">Reset</button>
+    <button id="quick-create" class="header-icon" type="button"
+      aria-label="Quick Create" title="Quick Create"
+      aria-controls="quick-create-menu" aria-expanded="false">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14"></path></svg>
+    </button>
+    <a class="header-icon" href="#/service-management/simulation-settings"
+      aria-label="Settings" title="Settings">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="12" cy="12" r="3"></circle>
+        <path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6 7 7M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4"></path>
+      </svg>
+    </a>
+    <a class="header-icon" href="#/service-management/api-simulation"
+      aria-label="Help and about" title="Help and about">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="12" cy="12" r="8"></circle>
+        <path d="M9.8 9a2.4 2.4 0 1 1 3.5 2.1c-.9.5-1.3 1-1.3 2M12 17h.01"></path>
+      </svg>
+    </a>
   </header>
 
+  <div id="app-launcher-menu" class="header-flyout app-flyout" hidden>
+    <h2>Apps</h2>
+    <a href="#/dashboard">
+      <span class="flyout-tile" aria-hidden="true">
+        <svg viewBox="0 0 24 24"><path d="M5 19V9l7-4 7 4v10M9 19v-5h6v5"></path></svg>
+      </span>
+      <span><strong>Customer Service Hub</strong><small>Customer service</small></span>
+    </a>
+    <a href="#/service-management/simulation-settings">
+      <span class="flyout-tile" aria-hidden="true">
+        <svg viewBox="0 0 24 24"><path d="M5 7h14M7 7v12h10V7M9 4h6M9 11h6M9 15h4"></path></svg>
+      </span>
+      <span><strong>Service Management</strong><small>Administration</small></span>
+    </a>
+  </div>
+
+  <div id="quick-create-menu" class="header-flyout quick-create-flyout" hidden>
+    <h2>Quick Create</h2>
+    <a href="#/contacts/new">Contact</a>
+    <a href="#/accounts/new">Account</a>
+    <a href="#/tasks/new">Task</a>
+    <a href="#/cases/new">Case</a>
+  </div>
+
   <div class="workspace">
-    <aside id="sitemap" class="sitemap" aria-label="Service Hub site map">
-      <div class="area-picker">
-        <span aria-hidden="true">▦</span>
-        <span>Service</span>
+    <aside id="sitemap" class="sitemap" aria-label="Customer Service Hub sitemap">
+      <div class="sitemap-mobile-heading">
+        <strong>Customer Service Hub</strong>
+        <button id="navigation-close" class="plain-icon" type="button" aria-label="Close navigation">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18"></path></svg>
+        </button>
       </div>
-      <nav>
-        <h2>My work</h2>
-        <a href="#/dashboard" data-nav="dashboard"><span aria-hidden="true">▥</span>Dashboard</a>
-        <a href="#/incidents" data-nav="incidents">
-          <span aria-hidden="true">◫</span>Cases <span class="nav-count" data-count="incidents">—</span>
-        </a>
-        <a href="#/tasks" data-nav="tasks">
-          <span aria-hidden="true">✓</span>Activities <span class="nav-count" data-count="tasks">—</span>
-        </a>
-
-        <h2>Customers</h2>
-        <a href="#/contacts" data-nav="contacts">
-          <span aria-hidden="true">♙</span>Contacts <span class="nav-count" data-count="contacts">—</span>
-        </a>
-        <a href="#/accounts" data-nav="accounts">
-          <span aria-hidden="true">▤</span>Accounts <span class="nav-count" data-count="accounts">—</span>
-        </a>
-
-        <h2>Activity</h2>
-        <a href="#/emails" data-nav="emails">
-          <span aria-hidden="true">✉</span>Emails <span class="nav-count" data-count="emails">—</span>
-        </a>
-        <a href="#/connections" data-nav="connections">
-          <span aria-hidden="true">⇄</span>Connections <span class="nav-count" data-count="connections">—</span>
-        </a>
-
-        <h2>Twin tools</h2>
-        <a href="#/lab" data-nav="lab"><span aria-hidden="true">⚗</span>Twin Lab</a>
-        <a href="#/about" data-nav="about"><span aria-hidden="true">ⓘ</span>API &amp; simulation</a>
+      <nav class="sitemap-navigation">
+        <section data-area="customer-service" aria-labelledby="nav-my-work">
+          <h2 id="nav-my-work">My Work</h2>
+          <a href="#/dashboard" data-nav="dashboard" aria-current="page">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h7v7H4zM13 4h7v4h-7zM13 10h7v10h-7zM4 13h7v7H4z"></path></svg>
+            <span>Dashboards</span>
+          </a>
+          <a href="#/activities" data-nav="activities">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 5h14v14H5zM8 9h8M8 13h5M8 17h3"></path></svg>
+            <span>Activities</span>
+          </a>
+        </section>
+        <section data-area="customer-service" aria-labelledby="nav-customers">
+          <h2 id="nav-customers">Customers</h2>
+          <a href="#/accounts" data-nav="accounts">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 20V8h16v12M8 8V4h8v4M8 12h2M14 12h2M8 16h2M14 16h2"></path></svg>
+            <span>Accounts</span>
+          </a>
+          <a href="#/contacts" data-nav="contacts">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3"></circle><path d="M5 20c.6-4 3-6 7-6s6.4 2 7 6"></path></svg>
+            <span>Contacts</span>
+          </a>
+        </section>
+        <section data-area="customer-service" aria-labelledby="nav-service">
+          <h2 id="nav-service">Service</h2>
+          <a href="#/cases" data-nav="cases">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16v13H4zM8 7V4h8v3M8 12h8M8 16h5"></path></svg>
+            <span>Cases</span>
+          </a>
+          <a href="#/queues" data-nav="queues">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 5h14v4H5zM5 11h14v4H5zM5 17h14v3H5z"></path></svg>
+            <span>Queues</span>
+          </a>
+        </section>
+        <section data-area="customer-service" aria-labelledby="nav-knowledge">
+          <h2 id="nav-knowledge">Knowledge</h2>
+          <a href="#/knowledge-articles" data-nav="knowledge-articles">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 4h10l4 4v12H5zM15 4v5h4M8 13h8M8 17h6"></path></svg>
+            <span>Knowledge Articles</span>
+          </a>
+          <a href="#/knowledge-search" data-nav="knowledge-search">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="5.5"></circle><path d="m15 15 5 5M8 10h5M10.5 7.5v5"></path></svg>
+            <span>Knowledge Search</span>
+          </a>
+        </section>
+        <section data-area="service-management" aria-labelledby="nav-management">
+          <h2 id="nav-management">Service Management</h2>
+          <a href="#/service-management/simulation-settings" data-nav="simulation-settings">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 4h8M10 4v5l-5 9h14l-5-9V4M8 15h8"></path></svg>
+            <span>Simulation settings</span>
+          </a>
+          <a href="#/service-management/api-simulation" data-nav="api-simulation">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="8"></circle><path d="M12 11v5M12 8h.01"></path></svg>
+            <span>API &amp; simulation</span>
+          </a>
+        </section>
       </nav>
-      <div class="sitemap-footer">
-        <strong>Static GitHub Pages</strong>
-        <span>No server or Dataverse writes</span>
+      <div class="area-switcher-wrap">
+        <button id="area-switcher" class="area-switcher" type="button"
+          aria-controls="area-menu" aria-expanded="false">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 5h6v6H5zM13 5h6v6h-6zM5 13h6v6H5zM13 13h6v6h-6z"></path></svg>
+          <span>Customer Service</span>
+          <svg class="area-chevron" viewBox="0 0 24 24" aria-hidden="true"><path d="m7 9 5 5 5-5"></path></svg>
+        </button>
+        <div id="area-menu" class="area-menu" hidden>
+          <a href="#/dashboard">Customer Service</a>
+          <a href="#/service-management/simulation-settings">Service Management</a>
+        </div>
       </div>
     </aside>
 
-    <button id="sitemap-scrim" class="sitemap-scrim" type="button" aria-label="Close site map"></button>
+    <button id="sitemap-scrim" class="sitemap-scrim" type="button"
+      aria-label="Close navigation" tabindex="-1"></button>
 
     <main id="main-content" class="main-content" tabindex="-1">
-      <nav id="breadcrumb" class="breadcrumb" aria-label="Breadcrumb"></nav>
       <section id="command-bar" class="command-bar" aria-label="Command bar"></section>
       <section id="view-root" class="view-root" aria-live="off" aria-busy="true">
-        <div class="loading-card" role="status">
+        <div class="loading-state" role="status">
           <span class="spinner" aria-hidden="true"></span>
-          <span>Starting deterministic Service Hub twin…</span>
+          <span>Loading Customer Service Hub</span>
         </div>
       </section>
     </main>
   </div>
 
+  <dialog id="app-dialog" class="app-dialog" aria-labelledby="dialog-title">
+    <div class="dialog-heading">
+      <h2 id="dialog-title"></h2>
+      <button id="dialog-close" class="plain-icon" type="button" aria-label="Close dialog">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18"></path></svg>
+      </button>
+    </div>
+    <div id="dialog-content" class="dialog-content"></div>
+    <div id="dialog-actions" class="dialog-actions"></div>
+  </dialog>
+
   <div id="live-status" class="sr-only" role="status" aria-live="polite"></div>
   <div id="live-errors" class="sr-only" role="alert" aria-live="assertive"></div>
-  <noscript>This deterministic Dynamics 365 twin requires JavaScript modules.</noscript>
+  <noscript>Customer Service Hub requires JavaScript modules.</noscript>
 </body>
 </html>

--- a/docs/d365/twin-core.mjs
+++ b/docs/d365/twin-core.mjs
@@ -271,6 +271,31 @@ function normalizeHeaders(headers = {}) {
   return normalized;
 }
 
+function normalizedRecordId(value) {
+  let normalized = String(value ?? "").trim().toLowerCase();
+  normalized = normalized.replace(/^['"]|['"]$/g, "").trim();
+  if (normalized.startsWith("{") && normalized.endsWith("}")) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+  return normalized;
+}
+
+function boundAccountId(value) {
+  const match = String(value ?? "").trim().match(
+    /(?:^|\/)accounts\s*\(\s*(\{?[^{}()/?#]+\}?)\s*\)(?:[?#].*)?$/i,
+  );
+  return normalizedRecordId(match?.[1]);
+}
+
+function emailReferencesAccount(email, accountId) {
+  const normalized = normalizedRecordId(accountId);
+  return Boolean(normalized)
+    && (
+      normalizedRecordId(email?._regardingobjectid_value) === normalized
+      || boundAccountId(email?.["regardingobjectid_account@odata.bind"]) === normalized
+    );
+}
+
 function normalizeSeed(seed = {}) {
   const state = {};
   for (const entity of Object.keys(ENTITY_DEFINITIONS).sort()) {
@@ -848,6 +873,27 @@ export class TwinCore {
     if (!this._checkEtag(current, spec)) {
       return this._failure(412, ERROR_CODES.precondition, "The row version does not match the current ETag.", spec);
     }
+    if (entity === "contacts" && (this._state.connections || []).some((connection) => {
+      const contactId = String(id).toLowerCase();
+      return String(connection._record1id_value || "").toLowerCase() === contactId
+        || String(connection._record2id_value || "").toLowerCase() === contactId;
+    })) {
+      return this._failure(
+        409,
+        ERROR_CODES.conflict,
+        "The contact cannot be deleted because a Connection record references it. Deactivate the contact instead.",
+        spec,
+      );
+    }
+    if (entity === "accounts" && (this._state.emails || []).some((email) =>
+      emailReferencesAccount(email, id))) {
+      return this._failure(
+        409,
+        ERROR_CODES.conflict,
+        "The account cannot be deleted because an Email record references it. Deactivate the account instead.",
+        spec,
+      );
+    }
     this._state[entity].splice(index, 1);
     this._event("commit.deleted", { requestId: spec.logicalRequestId, entity, recordId: id });
     const result = response(204, null, {}, spec.logicalRequestId, this.now());
@@ -934,12 +980,6 @@ export class TwinCore {
   _applyTransitions() {
     const nowMs = Number(this.clock.valueOf());
     const transitionTargets = [];
-    for (const task of this._state.tasks) {
-      const due = Date.parse(task.scheduledend || "");
-      if (task.statecode === 0 && Number.isFinite(due) && due <= nowMs) {
-        transitionTargets.push({ entity: "tasks", record: task, transition: "task.completed" });
-      }
-    }
     for (const incident of this._state.incidents) {
       const due = Date.parse(incident.new_sla_due || "");
       if (incident.statecode === 0 && incident.new_sla_status !== "Breached" && Number.isFinite(due) && due <= nowMs) {
@@ -960,14 +1000,8 @@ export class TwinCore {
     const index = this._findIndex(target.entity, target.record[primaryKey]);
     if (index < 0) return;
     const updated = { ...this._state[target.entity][index] };
-    if (target.transition === "task.completed") {
-      updated.statecode = 1;
-      updated.statuscode = 5;
-      updated.actualend = this.now();
-    } else {
-      updated.new_sla_status = "Breached";
-      updated.prioritycode = 1;
-    }
+    updated.new_sla_status = "Breached";
+    updated.prioritycode = 1;
     if (Object.hasOwn(definition.fields, "modifiedon")) updated.modifiedon = this.now();
     updated["@odata.etag"] = nextRecordEtag(updated, this._state[target.entity][index]["@odata.etag"]);
     this._state[target.entity][index] = updated;
@@ -1154,7 +1188,7 @@ async function timeScenario(twin) {
   const currentTask = await twin.request({ method: "GET", path: `/tasks(${task.body.activityid})`, logicalRequestId: "scenario-time-read-task" });
   const currentCase = await twin.request({ method: "GET", path: `/incidents(${incident.body.incidentid})`, logicalRequestId: "scenario-time-read-case" });
   return [
-    assertion("Due task completes", currentTask.body.statecode === 1, currentTask.body.statecode, 1),
+    assertion("Due task remains open", currentTask.body.statecode === 0, currentTask.body.statecode, 0),
     assertion("SLA breaches", currentCase.body.new_sla_status === "Breached", currentCase.body.new_sla_status, "Breached"),
   ];
 }
@@ -1183,7 +1217,7 @@ export const BUILT_IN_SCENARIOS = Object.freeze([
   { id: "malformed-payload", label: "Malformed payload", description: "Return 400 and prove state is unchanged.", entities: ["contacts"] },
   { id: "transient-retry", label: "503 → 429 → success", description: "Honor exponential backoff and Retry-After.", entities: ["tasks"] },
   { id: "stale-etag", label: "Two-client ETag conflict", description: "Client B receives a deterministic 412.", entities: ["tasks"] },
-  { id: "virtual-time", label: "Task and SLA clock", description: "Advance UTC time and apply due transitions once.", entities: ["tasks", "incidents"] },
+  { id: "virtual-time", label: "Task and SLA clock", description: "Advance UTC time; keep overdue tasks open and apply the SLA transition once.", entities: ["tasks", "incidents"] },
   { id: "chaos", label: "Lost response chaos", description: "Retry a post-commit response loss without double apply.", entities: ["tasks"] },
 ]);
 

--- a/tests/d365_twin.test.mjs
+++ b/tests/d365_twin.test.mjs
@@ -12,9 +12,44 @@ import {
   runBuiltInScenario,
 } from "../docs/d365/twin-core.mjs";
 import {
+  NAV_GROUPS,
+  PAGE_SIZE,
+  RELATED_EMAIL_LIMIT,
+  SYSTEM_VIEWS,
+  applySystemView,
+  captureRouteGuard,
+  combineActivities,
+  contactStatusLabel,
+  createNavigationHistory,
+  dashboardRenderCompletion,
+  deriveDashboardMetrics,
+  editableSnapshotsEqual,
+  emailReferencesAccount,
   gridCodeLabel,
-  isActiveEntityRoute,
+  isRecordEditable,
+  isTaskOverdue,
   newestRelatedEmails,
+  nextRovingTabIndex,
+  normalizeEditableSnapshot,
+  paginateRows,
+  preflightAccountDeletion,
+  preflightContactDeletion,
+  pushNavigationHistory,
+  relatedConnectionsForContact,
+  relatedEmailsForAccount,
+  relatedEmailsForContact,
+  recordCommandActions,
+  replaceDialogState,
+  resolveConnectionRows,
+  routeGuardMatches,
+  savedFormRenderTarget,
+  searchRows,
+  shouldInterceptSpaNavigation,
+  stableSortRows,
+  transitionHistoryPop,
+  transitionHistoryPrompt,
+  transitionPatch,
+  updateSelection,
 } from "../docs/d365/app-helpers.mjs";
 
 const EPOCH = "2026-04-05T10:00:00.000Z";
@@ -80,6 +115,144 @@ test("related emails sort by newest valid date, stable ID, and a 25-record cap",
   assert.equal(newestRelatedEmails(thirty)[0].activityid, "29");
 });
 
+test("production Contact and Account related-email helpers cap the newest 25", () => {
+  assert.equal(RELATED_EMAIL_LIMIT, 25);
+  const emails = Array.from({ length: 31 }, (_, index) => ({
+    activityid: `email-${String(index).padStart(2, "0")}`,
+    createdon: new Date(Date.UTC(2026, 0, index + 1)).toISOString(),
+    new_authorid: "contact-a",
+    new_author: "agent-a",
+    _regardingobjectid_value: "account-a",
+  }));
+  emails.push({
+    activityid: "unrelated-newest",
+    createdon: "2027-01-01T00:00:00.000Z",
+    new_authorid: "contact-b",
+    new_author: "agent-b",
+    _regardingobjectid_value: "account-b",
+  });
+
+  const contactEmails = relatedEmailsForContact(emails, {
+    contactid: "CONTACT-A",
+    new_agentid: "AGENT-A",
+  });
+  const accountEmails = relatedEmailsForAccount(emails, "ACCOUNT-A");
+  for (const related of [contactEmails, accountEmails]) {
+    assert.equal(related.length, 25);
+    assert.equal(related[0].activityid, "email-30");
+    assert.equal(related.at(-1).activityid, "email-06");
+    assert.doesNotMatch(related.map((email) => email.activityid).join(","), /unrelated/);
+  }
+});
+
+test("Account email references and deletion preflight cover lookup values and OData binds", () => {
+  const accounts = [
+    { accountid: "account-a", name: "Alpha" },
+    { accountid: "account-b", name: "Beta" },
+    { accountid: "account-c", name: "Clean" },
+  ];
+  const emails = [
+    {
+      activityid: "email-direct",
+      _regardingobjectid_value: "ACCOUNT-A",
+    },
+    {
+      activityid: "email-bind",
+      "regardingobjectid_account@odata.bind": "/api/data/v9.2/accounts({ACCOUNT-B})",
+    },
+    {
+      activityid: "email-unrelated",
+      _regardingobjectid_value: "account-z",
+      "regardingobjectid_account@odata.bind": "/accounts(account-y)",
+    },
+  ];
+  const pristineAccounts = structuredClone(accounts);
+  const pristineEmails = structuredClone(emails);
+
+  assert.equal(emailReferencesAccount(emails[0], "account-a"), true);
+  assert.equal(emailReferencesAccount(emails[1], "account-b"), true);
+  assert.equal(emailReferencesAccount(emails[2], "account-a"), false);
+  assert.deepEqual(
+    relatedEmailsForAccount(emails, "ACCOUNT-B").map((email) => email.activityid),
+    ["email-bind"],
+  );
+
+  const preflight = preflightAccountDeletion(
+    ["account-c", "ACCOUNT-B", "account-a", "account-a"],
+    accounts,
+    emails,
+  );
+  assert.deepEqual(preflight, {
+    allowed: false,
+    blockers: [
+      { accountId: "ACCOUNT-B", accountName: "Beta", emailIds: ["email-bind"] },
+      { accountId: "account-a", accountName: "Alpha", emailIds: ["email-direct"] },
+    ],
+  });
+  let remainingAccounts = structuredClone(accounts);
+  if (preflight.allowed) {
+    const selectedIds = new Set(["account-a", "account-b", "account-c"]);
+    remainingAccounts = remainingAccounts.filter((account) => !selectedIds.has(account.accountid));
+  }
+  assert.deepEqual(
+    remainingAccounts,
+    accounts,
+    "bulk preflight prevents every delete when any account is blocked",
+  );
+  assert.deepEqual(accounts, pristineAccounts);
+  assert.deepEqual(emails, pristineEmails);
+
+  assert.deepEqual(
+    preflightAccountDeletion(["account-a", "account-c"], accounts, []),
+    { allowed: true, blockers: [] },
+  );
+  const danglingAfterAccountDelete = preflightAccountDeletion(
+    ["account-a"],
+    accounts.filter((account) => account.accountid !== "account-a"),
+    emails,
+  );
+  assert.equal(danglingAfterAccountDelete.allowed, false);
+  assert.equal(danglingAfterAccountDelete.blockers[0].accountId, "account-a");
+});
+
+test("dialog replacement uses the outgoing dialog's own cancel value", () => {
+  for (const incoming of [
+    { kind: "error", cancelValue: "close" },
+    { kind: "info", cancelValue: "dismiss" },
+  ]) {
+    let confirmationResult = "unresolved";
+    const confirmation = {
+      kind: "confirmation",
+      cancelValue: false,
+      finish(value) {
+        confirmationResult = value;
+      },
+    };
+    const transition = replaceDialogState(confirmation, incoming);
+    assert.equal(transition.activeDialog, incoming);
+    assert.equal(transition.replacement.dialog, confirmation);
+    assert.equal(transition.replacement.value, false);
+    transition.replacement.dialog.finish(transition.replacement.value);
+    assert.equal(confirmationResult, false);
+  }
+  assert.deepEqual(replaceDialogState(null, { cancelValue: "close" }).replacement, null);
+});
+
+test("dashboard direct-render completion always clears busy and selects stable focus targets", () => {
+  assert.deepEqual(dashboardRenderCompletion("selector"), {
+    busy: false,
+    focusTargetId: "dashboard-selector",
+  });
+  assert.deepEqual(dashboardRenderCompletion("refresh"), {
+    busy: false,
+    focusTargetId: "dashboard-refresh",
+  });
+  assert.deepEqual(dashboardRenderCompletion(), {
+    busy: false,
+    focusTargetId: null,
+  });
+});
+
 test("grid code labels remain entity-specific", () => {
   assert.deepEqual(
     [0, 1, 2].map((value) => gridCodeLabel("tasks", "statecode", value)),
@@ -101,12 +274,537 @@ test("grid code labels remain entity-specific", () => {
   assert.equal(gridCodeLabel("accounts", "statecode", 1), "Inactive");
 });
 
-test("entity route guard rejects stale refresh completions", () => {
-  const route = { view: "entity", entity: "contacts" };
-  assert.equal(isActiveEntityRoute(7, route, 7, "contacts"), true);
-  assert.equal(isActiveEntityRoute(8, route, 7, "contacts"), false);
-  assert.equal(isActiveEntityRoute(7, { ...route, entity: "accounts" }, 7, "contacts"), false);
-  assert.equal(isActiveEntityRoute(7, { view: "dashboard" }, 7, "contacts"), false);
+test("route guard rejects stale routes and different active records", () => {
+  const route = { view: "record", entity: "contacts", id: "CONTACT-A" };
+  const guard = captureRouteGuard(7, route);
+  assert.equal(routeGuardMatches(guard, 7, route), true);
+  assert.equal(
+    routeGuardMatches(guard, 7, { ...route, id: "contact-a" }),
+    true,
+  );
+  assert.equal(routeGuardMatches(guard, 8, route), false);
+  assert.equal(routeGuardMatches(guard, 7, { ...route, id: "contact-b" }), false);
+  assert.equal(routeGuardMatches(guard, 7, { ...route, entity: "accounts" }), false);
+  assert.equal(routeGuardMatches(guard, 7, { view: "grid", entity: "contacts" }), false);
+});
+
+test("contact deletion preflight is deterministic on pristine and post-delete data", () => {
+  const contacts = [
+    { contactid: "contact-a", fullname: "Ada Agent" },
+    { contactid: "contact-b", fullname: "Bob Agent" },
+    { contactid: "contact-c", fullname: "Clean Contact" },
+  ];
+  const connections = [
+    {
+      connectionid: "connection-2",
+      _record1id_value: "contact-b",
+      _record2id_value: "CONTACT-A",
+    },
+    {
+      connectionid: "connection-1",
+      _record1id_value: "contact-a",
+      _record2id_value: "contact-b",
+    },
+  ];
+  const pristineContacts = JSON.parse(JSON.stringify(contacts));
+  const pristineConnections = JSON.parse(JSON.stringify(connections));
+  const selected = preflightContactDeletion(
+    ["CONTACT-C", "CONTACT-A", "contact-a"],
+    contacts,
+    connections,
+  );
+
+  assert.equal(selected.allowed, false);
+  assert.deepEqual(selected.blockers, [{
+    contactId: "CONTACT-A",
+    contactName: "Ada Agent",
+    connectionIds: ["connection-1", "connection-2"],
+  }]);
+  assert.deepEqual(contacts, pristineContacts);
+  assert.deepEqual(connections, pristineConnections);
+
+  const afterConnectionDelete = preflightContactDeletion(
+    ["contact-a", "contact-c"],
+    contacts,
+    [],
+  );
+  assert.deepEqual(afterConnectionDelete, { allowed: true, blockers: [] });
+
+  const postDeleteWithDanglingConnection = preflightContactDeletion(
+    ["contact-a"],
+    contacts.filter((contact) => contact.contactid !== "contact-a"),
+    connections,
+  );
+  assert.equal(postDeleteWithDanglingConnection.allowed, false);
+  assert.equal(postDeleteWithDanglingConnection.blockers[0].contactId, "contact-a");
+});
+
+test("SPA navigation interception preserves modified and native link clicks", () => {
+  assert.equal(shouldInterceptSpaNavigation({ button: 0 }), true);
+  assert.equal(shouldInterceptSpaNavigation({ button: 0, target: "_self" }), true);
+  for (const options of [
+    { button: 1 },
+    { button: 2 },
+    { button: 0, ctrlKey: true },
+    { button: 0, metaKey: true },
+    { button: 0, shiftKey: true },
+    { button: 0, altKey: true },
+    { button: 0, download: true },
+    { button: 0, target: "_blank" },
+    { button: 0, target: "report-frame" },
+    { button: 0, defaultPrevented: true },
+  ]) {
+    assert.equal(shouldInterceptSpaNavigation(options), false);
+  }
+});
+
+test("normal shell uses Customer Service Hub branding and exact sitemap order", async () => {
+  const html = await readFile(new URL("../docs/d365/index.html", import.meta.url), "utf8");
+  assert.match(html, /<title>Dynamics 365 — Customer Service Hub<\/title>/);
+  assert.match(html, />Dynamics 365<\/a>/);
+  assert.match(html, />Customer Service Hub<\/span>/);
+  assert.deepEqual(
+    NAV_GROUPS.map((group) => [group.label, group.items.map((item) => item.label)]),
+    [
+      ["My Work", ["Dashboards", "Activities"]],
+      ["Customers", ["Accounts", "Contacts"]],
+      ["Service", ["Cases", "Queues"]],
+      ["Knowledge", ["Knowledge Articles", "Knowledge Search"]],
+      ["Service Management", ["Simulation settings", "API & simulation"]],
+    ],
+  );
+  const navHtml = html.slice(
+    html.indexOf('<nav class="sitemap-navigation">'),
+    html.indexOf("</nav>", html.indexOf('<nav class="sitemap-navigation">')),
+  );
+  let previousIndex = -1;
+  for (const group of NAV_GROUPS) {
+    const groupIndex = navHtml.indexOf(`>${group.label}<`);
+    assert.ok(groupIndex > previousIndex, `${group.label} is out of order`);
+    previousIndex = groupIndex;
+    for (const item of group.items) {
+      const itemIndex = navHtml.indexOf(`>${item.label.replace("&", "&amp;")}<`, previousIndex);
+      assert.ok(itemIndex > previousIndex, `${item.label} is out of order`);
+      previousIndex = itemIndex;
+    }
+  }
+  assert.doesNotMatch(html, /nav-count|data-count/);
+  assert.match(html, /data-area="customer-service"/);
+  assert.match(html, /data-area="service-management"/);
+  assert.match(html, /id="area-switcher"[\s\S]*aria-expanded="false"/);
+});
+
+test("normal shell copy excludes product and technical implementation branding", async () => {
+  const [html, appSource] = await Promise.all([
+    readFile(new URL("../docs/d365/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../docs/d365/app.mjs", import.meta.url), "utf8"),
+  ]);
+  const normalShell = html
+    .replace(/<section data-area="service-management"[\s\S]*?<\/section>/, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ");
+  assert.doesNotMatch(
+    normalShell,
+    /\b(?:Rappterbook|twin|simulation|seed|snapshot|GitHub|ETag|Raw JSON|trace|virtual time|browser-local)\b/i,
+  );
+  const entityConfiguration = appSource.slice(
+    appSource.indexOf("const ENTITY_UI"),
+    appSource.indexOf("const ACTIVITIES_GRID"),
+  );
+  assert.doesNotMatch(entityConfiguration, /"[^"]*(?:Rappterbook|Poke|Glitch|Agent|Diagnostics)[^"]*"/);
+});
+
+test("activities combine email and task rows with correct status semantics", () => {
+  const now = "2026-04-05T10:00:00.000Z";
+  const activities = combineActivities(
+    [{
+      activityid: "email-1",
+      subject: "Sent message",
+      statecode: 1,
+      statuscode: 3,
+      actualend: "2026-04-05T09:00:00.000Z",
+    }],
+    [
+      { activityid: "task-open", subject: "Open", statecode: 0, scheduledend: "2026-04-05T11:00:00.000Z" },
+      { activityid: "task-overdue", subject: "Past due", statecode: 0, scheduledend: "2026-04-05T09:00:00.000Z" },
+      { activityid: "task-done", subject: "Done", statecode: 1, statuscode: 5 },
+    ],
+    now,
+  );
+  assert.deepEqual(
+    activities.map((activity) => [activity._activityType, activity._status]),
+    [["Email", "Sent"], ["Task", "Open"], ["Task", "Overdue"], ["Task", "Completed"]],
+  );
+  assert.equal(applySystemView(activities, "activities", "sent-email").length, 1);
+  assert.equal(applySystemView(activities, "activities", "open").length, 2);
+  assert.equal(applySystemView(activities, "activities", "closed").length, 2);
+});
+
+test("system views, search, stable sorting, selection, and 50-row paging are deterministic", () => {
+  assert.equal(PAGE_SIZE, 50);
+  assert.deepEqual(SYSTEM_VIEWS.contacts.map((view) => view.label), ["Active Contacts", "Inactive Contacts", "All Contacts"]);
+  assert.deepEqual(SYSTEM_VIEWS.accounts.map((view) => view.label), ["Active Accounts", "Inactive Accounts", "All Accounts"]);
+  assert.deepEqual(SYSTEM_VIEWS.incidents.map((view) => view.label), ["Active Cases", "Resolved Cases", "All Cases"]);
+  assert.deepEqual(
+    SYSTEM_VIEWS.activities.map((view) => view.label),
+    ["Open Activities", "Closed Activities", "All Activities", "Sent Email"],
+  );
+  assert.deepEqual(SYSTEM_VIEWS.connections.map((view) => view.label), ["Active Connections", "All Connections"]);
+
+  const rows = Array.from({ length: 121 }, (_, index) => ({
+    id: String(index).padStart(3, "0"),
+    name: index % 2 ? "Beta" : "Alpha",
+    statecode: index % 3 ? 0 : 1,
+  }));
+  assert.equal(applySystemView(rows, "contacts", "active").length, 80);
+  assert.equal(searchRows(rows, ["name"], "beta").length, 60);
+  const sorted = stableSortRows(rows, "name", "asc", "id");
+  assert.deepEqual(sorted.slice(0, 3).map((row) => row.id), ["000", "002", "004"]);
+  const first = paginateRows(sorted, 1);
+  const second = paginateRows(sorted, 2);
+  const third = paginateRows(sorted, 3);
+  assert.deepEqual([first.rows.length, second.rows.length, third.rows.length], [50, 50, 21]);
+  assert.deepEqual([...first.rows, ...second.rows, ...third.rows].map((row) => row.id), sorted.map((row) => row.id));
+  let selected = updateSelection(new Set(), ["000", "002"], true);
+  selected = updateSelection(selected, ["000"], false);
+  assert.deepEqual([...selected], ["002"]);
+});
+
+test("indexed history restores before prompting and preserves Back and Forward entries", () => {
+  const runGuardedTraversal = (originIndex, targetIndex, proceed) => {
+    const entries = ["first", "second"];
+    let cursor = targetIndex;
+    let history = createNavigationHistory(originIndex);
+    const attempted = transitionHistoryPop(history, targetIndex, true);
+    history = attempted.state;
+    assert.deepEqual(attempted.effect, {
+      type: "traverse",
+      delta: originIndex - targetIndex,
+    });
+    cursor += attempted.effect.delta;
+    assert.equal(cursor, originIndex);
+    const restored = transitionHistoryPop(history, cursor, true);
+    history = restored.state;
+    assert.equal(restored.effect.type, "prompt");
+    const resolved = transitionHistoryPrompt(history, proceed);
+    history = resolved.state;
+    if (!proceed) {
+      assert.equal(resolved.effect.type, "stay");
+      assert.equal(history.currentIndex, originIndex);
+      assert.equal(cursor, originIndex);
+    } else {
+      assert.deepEqual(resolved.effect, {
+        type: "traverse",
+        delta: targetIndex - originIndex,
+      });
+      cursor += resolved.effect.delta;
+      const arrived = transitionHistoryPop(history, cursor, false);
+      history = arrived.state;
+      assert.equal(arrived.effect.type, "navigate");
+      assert.equal(history.currentIndex, targetIndex);
+      assert.equal(
+        transitionHistoryPop(history, targetIndex, false).effect.type,
+        "stay",
+      );
+    }
+    assert.deepEqual(entries, ["first", "second"]);
+    return cursor;
+  };
+
+  assert.equal(runGuardedTraversal(1, 0, false), 1);
+  for (const choice of ["discard", "save"]) {
+    assert.equal(runGuardedTraversal(1, 0, Boolean(choice)), 0);
+    assert.equal(runGuardedTraversal(0, 1, Boolean(choice)), 1);
+  }
+  assert.deepEqual(pushNavigationHistory(createNavigationHistory(4)), {
+    currentIndex: 5,
+    pending: null,
+  });
+});
+
+test("indexed history restores reentrant Back and Forward pops in every pending phase", () => {
+  const attempted = transitionHistoryPop(createNavigationHistory(4), 3, true);
+  const restoring = attempted.state;
+  assert.equal(restoring.pending.phase, "restoring");
+
+  const assertCorrections = (history, anchorIndex, targets) => {
+    for (const targetIndex of targets) {
+      const transition = transitionHistoryPop(history, targetIndex, true);
+      assert.equal(transition.effect.type, "traverse");
+      assert.equal(transition.effect.delta, anchorIndex - targetIndex);
+      assert.deepEqual(transition.state, history);
+      assert.notEqual(transition.effect.type, "prompt");
+    }
+  };
+
+  assertCorrections(restoring, 4, [2, 3, 5, 1, 5, 2]);
+  assert.deepEqual(
+    transitionHistoryPop(restoring, null, true),
+    { state: restoring, effect: { type: "stay" } },
+  );
+
+  const restored = transitionHistoryPop(restoring, 4, true);
+  assert.equal(restored.effect.type, "prompt");
+  const prompting = restored.state;
+  assert.equal(prompting.pending.phase, "prompting");
+  assertCorrections(prompting, 4, [3, 5, 2, 3, 5, 1]);
+  assert.deepEqual(
+    transitionHistoryPop(prompting, 4, true),
+    { state: prompting, effect: { type: "stay" } },
+  );
+
+  const accepted = transitionHistoryPrompt(prompting, true);
+  const proceeding = accepted.state;
+  assert.equal(proceeding.pending.phase, "proceeding");
+  assertCorrections(proceeding, 3, [2, 4, 1, 5, 4, 2]);
+  const arrived = transitionHistoryPop(proceeding, 3, false);
+  assert.equal(arrived.effect.type, "navigate");
+  assert.deepEqual(arrived.state, { currentIndex: 3, pending: null });
+
+  const canceled = transitionHistoryPrompt(prompting, false);
+  assert.deepEqual(canceled, {
+    state: { currentIndex: 4, pending: null },
+    effect: { type: "stay" },
+  });
+});
+
+test("record tabs use wrapped roving selection and skip disabled Related", () => {
+  const existingTabs = [{ disabled: false }, { disabled: false }, { disabled: false }];
+  assert.equal(nextRovingTabIndex(existingTabs, 0, "ArrowLeft"), 2);
+  assert.equal(nextRovingTabIndex(existingTabs, 2, "ArrowRight"), 0);
+  assert.equal(nextRovingTabIndex(existingTabs, 1, "Home"), 0);
+  assert.equal(nextRovingTabIndex(existingTabs, 1, "End"), 2);
+
+  const newRecordTabs = [{ disabled: false }, { disabled: false }, { disabled: true }];
+  assert.equal(nextRovingTabIndex(newRecordTabs, 1, "ArrowRight"), 0);
+  assert.equal(nextRovingTabIndex(newRecordTabs, 0, "ArrowLeft"), 1);
+  assert.equal(nextRovingTabIndex(newRecordTabs, 0, "End"), 1);
+  assert.equal(nextRovingTabIndex(newRecordTabs, 0, "Tab"), 0);
+});
+
+test("grid search includes formatted values as well as raw values", () => {
+  const contact = { contactid: "c", new_status: "dormant" };
+  const contacts = searchRows(
+    [contact],
+    ["new_status"],
+    "Inactive",
+    (record, field) => field === "new_status"
+      ? contactStatusLabel(record.new_status)
+      : record[field],
+  );
+  assert.deepEqual(contacts, [contact]);
+  assert.deepEqual(searchRows([contact], ["new_status"], "dormant"), [contact]);
+
+  const now = "2026-04-05T10:00:00.000Z";
+  const activities = combineActivities(
+    [
+      { activityid: "sent", subject: "Mail", statecode: 1, statuscode: 3 },
+      { activityid: "email-complete", subject: "Mail", statecode: 1, statuscode: 4 },
+    ],
+    [
+      { activityid: "done", subject: "Done", statecode: 1, prioritycode: 2 },
+      {
+        activityid: "late",
+        subject: "Late",
+        statecode: 0,
+        prioritycode: 0,
+        scheduledend: "2026-04-05T09:00:00.000Z",
+      },
+    ],
+    now,
+  );
+  for (const term of ["Sent", "Completed", "Overdue", "Email", "Task"]) {
+    assert.ok(searchRows(activities, ["_status", "_activityType"], term).length > 0, term);
+  }
+  const highPriority = searchRows(
+    activities,
+    ["prioritycode"],
+    "High",
+    (record, field) => gridCodeLabel(record._entity, field, record[field], now, record),
+  );
+  assert.deepEqual(highPriority.map((record) => record._id), ["done"]);
+  const lowPriority = searchRows(
+    activities,
+    ["prioritycode"],
+    "Low",
+    (record, field) => gridCodeLabel(record._entity, field, record[field], now, record),
+  );
+  assert.deepEqual(lowPriority.map((record) => record._id), ["late"]);
+});
+
+test("editable snapshots clear dirty state after exact value reversion", () => {
+  const baseline = normalizeEditableSnapshot({
+    subject: "Follow up",
+    prioritycode: 1,
+    scheduledend: null,
+    description: "Line one\r\nLine two",
+  });
+  assert.equal(editableSnapshotsEqual(baseline, {
+    description: "Line one\nLine two",
+    scheduledend: undefined,
+    prioritycode: 1,
+    subject: "Follow up",
+  }), true);
+  assert.equal(editableSnapshotsEqual(baseline, {
+    ...baseline,
+    prioritycode: 2,
+  }), false);
+  const restored = { ...baseline, prioritycode: 2 };
+  restored.prioritycode = 1;
+  assert.equal(editableSnapshotsEqual(baseline, restored), true);
+});
+
+test("closed record editability and command contracts are state-controlled", () => {
+  for (const entity of ["contacts", "accounts", "tasks", "incidents"]) {
+    assert.equal(isRecordEditable(entity, null, true), true);
+    assert.equal(isRecordEditable(entity, { statecode: 0 }, true), true);
+    assert.equal(isRecordEditable(entity, { statecode: 1 }, true), false);
+  }
+  assert.equal(isRecordEditable("emails", { statecode: 1 }, false), false);
+  assert.deepEqual(
+    recordCommandActions("contacts", { statecode: 1 }, { editable: true, deletable: true }),
+    ["activate", "delete", "refresh", "back"],
+  );
+  assert.deepEqual(
+    recordCommandActions("accounts", { statecode: 1 }, { editable: true, deletable: true }),
+    ["activate", "delete", "refresh", "back"],
+  );
+  assert.deepEqual(
+    recordCommandActions("tasks", { statecode: 1 }, { editable: true, deletable: true }),
+    ["delete", "refresh", "back"],
+  );
+  assert.deepEqual(
+    recordCommandActions("incidents", { statecode: 2 }, { editable: true, deletable: true }),
+    ["reopen", "delete", "refresh", "back"],
+  );
+  assert.deepEqual(
+    recordCommandActions("incidents", { statecode: 0 }, { editable: true, deletable: true }),
+    ["save", "save-close", "resolve", "cancel", "delete", "refresh", "back"],
+  );
+  assert.deepEqual(transitionPatch("contacts", "deactivate", EPOCH), {
+    statecode: 1,
+    statuscode: 2,
+    new_status: "inactive",
+  });
+  assert.deepEqual(transitionPatch("contacts", "activate", EPOCH), {
+    statecode: 0,
+    statuscode: 1,
+    new_status: "active",
+  });
+});
+
+test("contact relationship rows expose only neutral directional labels", () => {
+  const contacts = [
+    { contactid: "a", fullname: "Ada" },
+    { contactid: "b", fullname: "Babbage" },
+    { contactid: "c", fullname: "Curie" },
+  ];
+  const connections = [
+    {
+      connectionid: "one",
+      name: "source-a follows source-b",
+      _record1id_value: "a",
+      _record2id_value: "b",
+    },
+    {
+      connectionid: "two",
+      name: "source-c follows source-a",
+      _record1id_value: "c",
+      _record2id_value: "a",
+    },
+  ];
+  const related = relatedConnectionsForContact(connections, "a", contacts);
+  assert.deepEqual(
+    related.map((connection) => [
+      connection._relatedName,
+      connection._relationship,
+    ]),
+    [["Babbage", "Follows"], ["Curie", "Followed by"]],
+  );
+  assert.deepEqual(
+    searchRows(related, ["_relatedName", "_relationship"], "followed by")
+      .map((connection) => connection.connectionid),
+    ["two"],
+  );
+  assert.deepEqual(
+    stableSortRows(related, "_relationship", "asc", "connectionid")
+      .map((connection) => connection._relationship),
+    ["Followed by", "Follows"],
+  );
+  assert.equal(related.some((connection) => connection._relationship.includes("source-")), false);
+});
+
+test("all connection rows are reachable through paged contact relationships with resolved names", async () => {
+  const [contactsPayload, connectionsPayload] = await Promise.all([
+    readFile(new URL("../docs/api/data/v9.2/contacts.json", import.meta.url), "utf8").then(JSON.parse),
+    readFile(new URL("../docs/api/data/v9.2/connections.json", import.meta.url), "utf8").then(JSON.parse),
+  ]);
+  const contacts = contactsPayload.value;
+  const connections = connectionsPayload.value;
+  const resolved = resolveConnectionRows(connections, contacts);
+  assert.equal(connections.length, 2426);
+  assert.ok(resolved.every((connection) => connection._record1name && connection._record2name));
+
+  const reachable = new Set();
+  for (const contact of contacts) {
+    const related = relatedConnectionsForContact(connections, contact.contactid, contacts);
+    const pageCount = Math.max(1, Math.ceil(related.length / PAGE_SIZE));
+    for (let pageNumber = 1; pageNumber <= pageCount; pageNumber += 1) {
+      const page = paginateRows(related, pageNumber);
+      assert.ok(page.rows.length <= PAGE_SIZE);
+      for (const connection of page.rows) reachable.add(connection.connectionid);
+    }
+  }
+  assert.equal(reachable.size, connections.length);
+});
+
+test("dashboard components derive their metrics and charts from supplied data", () => {
+  const data = {
+    incidents: [
+      { incidentid: "a", statecode: 0, prioritycode: 1, createdon: "2026-01-02T00:00:00Z" },
+      { incidentid: "b", statecode: 1, prioritycode: 3, createdon: "2026-01-01T00:00:00Z" },
+    ],
+    contacts: [{ contactid: "a", statecode: 0 }, { contactid: "b", statecode: 1 }],
+    accounts: [{ accountid: "a", name: "One", new_postcount: 7 }, { accountid: "b", name: "Two", new_postcount: 3 }],
+    emails: [{ activityid: "e", statecode: 1, statuscode: 3, createdon: "2026-01-03T00:00:00Z" }],
+    tasks: [{ activityid: "t", statecode: 0, scheduledend: "2026-01-04T00:00:00Z" }],
+  };
+  const metrics = deriveDashboardMetrics(data, "2026-01-03T00:00:00Z");
+  assert.deepEqual(metrics.casePriority.map((item) => item.value), [1, 0, 1]);
+  assert.deepEqual(metrics.contactStatus.map((item) => item.value), [1, 1]);
+  assert.deepEqual(metrics.accountActivity.map((item) => item.value), [7, 3]);
+  assert.deepEqual(metrics.activeCases.map((record) => record.incidentid), ["a"]);
+  assert.deepEqual(metrics.recentActivities.map((record) => record._id), ["t", "e"]);
+  assert.deepEqual(metrics.openActivities.map((record) => record._id), ["t"]);
+  assert.deepEqual(metrics.sentEmails.map((record) => record._id), ["e"]);
+  assert.deepEqual(metrics.taskActivities.map((record) => record._id), ["t"]);
+  assert.deepEqual(metrics.activitiesByType, [
+    { label: "Email", value: 1 },
+    { label: "Task", value: 1 },
+  ]);
+  assert.deepEqual(metrics.activitiesByStatus, [
+    { label: "Open", value: 1 },
+    { label: "Sent", value: 1 },
+  ]);
+
+  data.contacts.push({ contactid: "c", statecode: 0 });
+  data.accounts[1].new_postcount = 12;
+  data.tasks.push({ activityid: "done", statecode: 1, scheduledend: "2026-01-02T00:00:00Z" });
+  const changed = deriveDashboardMetrics(data, "2026-01-03T00:00:00Z");
+  assert.deepEqual(changed.contactStatus.map((item) => item.value), [2, 1]);
+  assert.equal(changed.accountActivity[0].label, "Two");
+  assert.deepEqual(changed.activitiesByType, [
+    { label: "Email", value: 1 },
+    { label: "Task", value: 2 },
+  ]);
+  assert.deepEqual(changed.activitiesByStatus, [
+    { label: "Completed", value: 1 },
+    { label: "Open", value: 1 },
+    { label: "Sent", value: 1 },
+  ]);
+
+  const noTasks = deriveDashboardMetrics({ emails: data.emails, tasks: [] }, "2026-01-03T00:00:00Z");
+  assert.deepEqual(noTasks.taskActivities, []);
 });
 
 async function deterministicRun() {
@@ -185,6 +883,136 @@ test("happy CRUD is idempotent and each mutation traces one commit", async () =>
   );
 });
 
+test("connected Contacts are restricted until their Connections are deleted", async () => {
+  const seed = fixtureSeed();
+  seed.contacts.value.push({
+    contactid: "00000000-0000-0000-0000-000000000002",
+    firstname: "Grace",
+    fullname: "Grace Hopper",
+  });
+  seed.connections = {
+    value: [{
+      connectionid: "connection-a",
+      name: "Ada follows Grace",
+      _record1id_value: "00000000-0000-0000-0000-000000000001",
+      _record2id_value: "00000000-0000-0000-0000-000000000002",
+    }],
+  };
+  const twin = createTwin({ seed, epoch: EPOCH });
+  const contact = twin.getState("contacts")[0];
+  const connection = twin.getState("connections")[0];
+  const before = twin.getState("contacts");
+  const blocked = await twin.request({
+    method: "DELETE",
+    path: `/contacts(${contact.contactid})`,
+    logicalRequestId: "connected-contact-delete",
+    headers: { "If-Match": contact["@odata.etag"] },
+  });
+
+  assert.equal(blocked.status, 409);
+  assert.match(blocked.body.error.message, /Connection.*Deactivate/i);
+  assert.deepEqual(twin.getState("contacts"), before);
+
+  const removedConnection = await twin.request({
+    method: "DELETE",
+    path: `/connections(${connection.connectionid})`,
+    logicalRequestId: "connection-delete",
+    headers: { "If-Match": connection["@odata.etag"] },
+  });
+  const removedContact = await twin.request({
+    method: "DELETE",
+    path: `/contacts(${contact.contactid})`,
+    logicalRequestId: "contact-delete-after-preflight",
+    headers: { "If-Match": contact["@odata.etag"] },
+  });
+  assert.equal(removedConnection.status, 204);
+  assert.equal(removedContact.status, 204);
+});
+
+test("Accounts referenced by Emails remain intact until every reference is deleted", async () => {
+  const seed = fixtureSeed();
+  seed.accounts = {
+    value: [
+      { accountid: "account-a", name: "Alpha" },
+      { accountid: "account-b", name: "Beta" },
+      { accountid: "account-c", name: "Clean" },
+    ],
+  };
+  seed.emails = {
+    value: [
+      {
+        activityid: "email-direct",
+        subject: "Direct reference",
+        _regardingobjectid_value: "ACCOUNT-A",
+      },
+      {
+        activityid: "email-bind",
+        subject: "Bind reference",
+        "regardingobjectid_account@odata.bind": "/accounts({ACCOUNT-B})",
+      },
+    ],
+  };
+  const twin = createTwin({ seed, epoch: EPOCH });
+  const accountsBefore = twin.getState("accounts");
+  const emailsBefore = twin.getState("emails");
+  const accountA = accountsBefore.find((account) => account.accountid === "account-a");
+  const accountB = accountsBefore.find((account) => account.accountid === "account-b");
+  const accountC = accountsBefore.find((account) => account.accountid === "account-c");
+
+  const blockedDirect = await twin.request({
+    method: "DELETE",
+    path: "/accounts(account-a)",
+    logicalRequestId: "delete-account-direct-reference",
+    headers: { "If-Match": accountA["@odata.etag"] },
+  });
+  const blockedBind = await twin.request({
+    method: "DELETE",
+    path: "/accounts(account-b)",
+    logicalRequestId: "delete-account-bind-reference",
+    headers: { "If-Match": accountB["@odata.etag"] },
+  });
+  assert.equal(blockedDirect.status, 409);
+  assert.equal(blockedBind.status, 409);
+  assert.match(blockedDirect.body.error.message, /Email.*Deactivate/i);
+  assert.deepEqual(twin.getState("accounts"), accountsBefore);
+  assert.deepEqual(twin.getState("emails"), emailsBefore);
+
+  const cleanDelete = await twin.request({
+    method: "DELETE",
+    path: "/accounts(account-c)",
+    logicalRequestId: "delete-clean-account",
+    headers: { "If-Match": accountC["@odata.etag"] },
+  });
+  assert.equal(cleanDelete.status, 204);
+  assert.equal(twin.getState("accounts").some((account) => account.accountid === "account-c"), false);
+
+  const emailA = twin.getState("emails").find((email) => email.activityid === "email-direct");
+  const removedEmail = await twin.request({
+    method: "DELETE",
+    path: "/emails(email-direct)",
+    logicalRequestId: "delete-account-reference-email",
+    headers: { "If-Match": emailA["@odata.etag"] },
+  });
+  const removedAccount = await twin.request({
+    method: "DELETE",
+    path: "/accounts(account-a)",
+    logicalRequestId: "delete-account-after-email",
+    headers: { "If-Match": accountA["@odata.etag"] },
+  });
+  assert.equal(removedEmail.status, 204);
+  assert.equal(removedAccount.status, 204);
+  assert.equal(twin.getState("accounts").some((account) => account.accountid === "account-a"), false);
+  assert.equal(
+    twin.getState("emails").some((email) => emailReferencesAccount(email, "account-a")),
+    false,
+  );
+  assert.equal(twin.getState("accounts").some((account) => account.accountid === "account-b"), true);
+  assert.equal(
+    twin.getState("emails").some((email) => emailReferencesAccount(email, "account-b")),
+    true,
+  );
+});
+
 test("invalid JSON, fields, and types return 400 without state mutation", async () => {
   const twin = createTwin({ seed: fixtureSeed(), epoch: EPOCH });
   const before = twin.stateDigest();
@@ -225,6 +1053,54 @@ test("two clients sharing an ETag yield one update and one 412", async () => {
   assert.equal(stale.status, 412);
   assert.equal(stale.body.error.code, "0x80060882");
   assert.equal(twin.getTrace().filter((event) => event.type === "commit.updated").length, 1);
+});
+
+test("save-before-action rebases the form record and uses the saved ETag after cancellation", async () => {
+  const twin = createTwin({ seed: fixtureSeed(), epoch: EPOCH });
+  const original = twin.getState("contacts")[0];
+  const saved = await twin.request({
+    method: "PATCH",
+    path: `/contacts(${original.contactid})`,
+    logicalRequestId: "dirty-dialog-save",
+    headers: { "If-Match": original["@odata.etag"], Prefer: "return=representation" },
+    body: { description: "Saved before the requested action." },
+  });
+  const afterSave = twin.stateDigest();
+  const renderTarget = savedFormRenderTarget(
+    { entity: "contacts", record: original },
+    saved.body,
+    "details",
+  );
+
+  assert.equal(saved.status, 200);
+  assert.equal(renderTarget.entity, "contacts");
+  assert.equal(renderTarget.record, saved.body);
+  assert.equal(renderTarget.initialTab, "details");
+  assert.notEqual(renderTarget.record["@odata.etag"], original["@odata.etag"]);
+  assert.equal(twin.stateDigest(), afterSave, "canceling the first action leaves the saved record intact");
+
+  const action = await twin.request({
+    method: "PATCH",
+    path: `/contacts(${renderTarget.record.contactid})`,
+    logicalRequestId: "action-after-canceled-confirmation",
+    headers: {
+      "If-Match": renderTarget.record["@odata.etag"],
+      Prefer: "return=representation",
+    },
+    body: transitionPatch("contacts", "deactivate", twin.now()),
+  });
+  assert.equal(action.status, 200);
+  assert.equal(action.body.statecode, 1);
+  assert.notEqual(action.body["@odata.etag"], renderTarget.record["@odata.etag"]);
+
+  const staleOriginal = await twin.request({
+    method: "PATCH",
+    path: `/contacts(${original.contactid})`,
+    logicalRequestId: "original-form-etag-is-stale",
+    headers: { "If-Match": original["@odata.etag"] },
+    body: { description: "A stale closure must not win." },
+  });
+  assert.equal(staleOriginal.status, 412);
 });
 
 test("runtime ETags reject an original stale writer after an ABA value cycle", async () => {
@@ -480,7 +1356,7 @@ test("a successful delay advances only virtual time and never sleeps wall time",
   assert.ok(elapsed < 100, `delay used ${elapsed}ms of wall time`);
 });
 
-test("advancing virtual time completes a due task exactly once", async () => {
+test("advancing virtual time leaves a past-due task open until Mark Complete is explicit", async () => {
   const twin = createTwin({ seed: fixtureSeed(), epoch: EPOCH });
   const created = await twin.request({
     method: "POST",
@@ -489,7 +1365,7 @@ test("advancing virtual time completes a due task exactly once", async () => {
     headers: { Prefer: "return=representation" },
     body: { subject: "Due in one minute", scheduledend: "2026-04-05T10:01:00.000Z" },
   });
-  twin.advanceTime(60_000, "first tick");
+  twin.advanceTime(60_001, "past due");
   const afterFirst = await twin.request({
     method: "GET", path: `/tasks(${created.body.activityid})`, logicalRequestId: "due-read-1",
   });
@@ -499,10 +1375,77 @@ test("advancing virtual time completes a due task exactly once", async () => {
     method: "GET", path: `/tasks(${created.body.activityid})`, logicalRequestId: "due-read-2",
   });
 
-  assert.equal(afterFirst.body.statecode, 1);
-  assert.equal(afterFirst.body.statuscode, 5);
+  assert.equal(afterFirst.body.statecode, 0);
+  assert.equal(afterFirst.body.statuscode, 2);
+  assert.equal(isTaskOverdue(afterFirst.body, twin.now()), true);
   assert.equal(afterSecond.headers.ETag, firstEtag);
-  assert.equal(twin.getTrace().filter((event) => event.type === "transition.applied").length, 1);
+  assert.equal(twin.getTrace().filter((event) => event.type === "transition.applied").length, 0);
+
+  const completed = await twin.request({
+    method: "PATCH",
+    path: `/tasks(${created.body.activityid})`,
+    logicalRequestId: "mark-complete",
+    headers: { "If-Match": afterSecond.headers.ETag, Prefer: "return=representation" },
+    body: transitionPatch("tasks", "complete", twin.now()),
+  });
+  assert.equal(completed.body.statecode, 1);
+  assert.equal(completed.body.statuscode, 5);
+  assert.equal(completed.body.actualend, twin.now());
+  assert.equal(isTaskOverdue(completed.body, twin.now()), false);
+});
+
+test("task cancellation and case resolve, cancel, and reopen use explicit PATCH transitions", async () => {
+  const twin = createTwin({ seed: fixtureSeed(), epoch: EPOCH });
+  const task = await twin.request({
+    method: "POST",
+    path: "/tasks",
+    logicalRequestId: "task-to-cancel",
+    headers: { Prefer: "return=representation" },
+    body: { subject: "Cancel explicitly" },
+  });
+  const canceledTask = await twin.request({
+    method: "PATCH",
+    path: `/tasks(${task.body.activityid})`,
+    logicalRequestId: "cancel-task",
+    headers: { "If-Match": task.headers.ETag, Prefer: "return=representation" },
+    body: transitionPatch("tasks", "cancel", twin.now()),
+  });
+  assert.deepEqual(
+    [canceledTask.body.statecode, canceledTask.body.statuscode, canceledTask.body.actualend],
+    [2, 6, twin.now()],
+  );
+
+  const incident = await twin.request({
+    method: "POST",
+    path: "/incidents",
+    logicalRequestId: "case-transitions",
+    headers: { Prefer: "return=representation" },
+    body: { title: "Explicit case transitions" },
+  });
+  const resolved = await twin.request({
+    method: "PATCH",
+    path: `/incidents(${incident.body.incidentid})`,
+    logicalRequestId: "resolve-case",
+    headers: { "If-Match": incident.headers.ETag, Prefer: "return=representation" },
+    body: transitionPatch("incidents", "resolve", twin.now()),
+  });
+  assert.deepEqual([resolved.body.statecode, resolved.body.statuscode], [1, 5]);
+  const reopened = await twin.request({
+    method: "PATCH",
+    path: `/incidents(${incident.body.incidentid})`,
+    logicalRequestId: "reopen-case",
+    headers: { "If-Match": resolved.headers.ETag, Prefer: "return=representation" },
+    body: transitionPatch("incidents", "reopen", twin.now()),
+  });
+  assert.deepEqual([reopened.body.statecode, reopened.body.statuscode], [0, 1]);
+  const canceled = await twin.request({
+    method: "PATCH",
+    path: `/incidents(${incident.body.incidentid})`,
+    logicalRequestId: "cancel-case",
+    headers: { "If-Match": reopened.headers.ETag, Prefer: "return=representation" },
+    body: transitionPatch("incidents", "cancel", twin.now()),
+  });
+  assert.deepEqual([canceled.body.statecode, canceled.body.statuscode], [2, 6]);
 });
 
 test("installing a replacement seed invalidates incompatible idempotency entries", async () => {
@@ -564,12 +1507,14 @@ test("replay advances generated request IDs before the next implicit request", a
   assert.deepEqual(replayedNext, originalNext);
 });
 
-test("built-in virtual-time scenario applies task and SLA transitions once", async () => {
+test("built-in virtual-time scenario keeps tasks open and applies only the SLA transition", async () => {
   const twin = createTwin({ seed: fixtureSeed(), epoch: EPOCH });
   const result = await runBuiltInScenario(twin, "virtual-time");
   assert.equal(result.passed, true);
   assert.equal(result.assertions.length, 2);
-  assert.equal(result.trace.filter((event) => event.type === "transition.applied").length, 2);
+  assert.equal(result.assertions[0].actual, 0);
+  assert.equal(result.trace.filter((event) => event.type === "transition.applied").length, 1);
+  assert.equal(result.trace.find((event) => event.type === "transition.applied").transition, "sla.breached");
 });
 
 test("chaos scenario commit assertions are scoped to each rerun", async () => {
@@ -624,9 +1569,10 @@ test("core ordering and casing do not invoke host locale operations", async () =
 });
 
 test("browser shell is externalized, XSS-safe, and has explicit load failures", async () => {
-  const [html, app] = await Promise.all([
+  const [html, app, css] = await Promise.all([
     readFile(new URL("../docs/d365/index.html", import.meta.url), "utf8"),
     readFile(new URL("../docs/d365/app.mjs", import.meta.url), "utf8"),
+    readFile(new URL("../docs/d365/d365.css", import.meta.url), "utf8"),
   ]);
   assert.match(html, /d365\.css/);
   assert.match(html, /app\.mjs/);
@@ -638,36 +1584,254 @@ test("browser shell is externalized, XSS-safe, and has explicit load failures", 
     assert.match(html, new RegExp(directive.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
   assert.doesNotMatch(html, /<script>(?!\s*<\/script>)/);
+  assert.doesNotMatch(html, /\son(?:click|change|input|submit|keydown)=/i);
+  assert.doesNotMatch(html, /(?:src|href)=["']https?:/i);
+  assert.doesNotMatch(css, /@import|@font-face|url\(\s*["']?https?:/i);
   assert.doesNotMatch(app, /\.innerHTML\s*=/);
-  assert.doesNotMatch(app, /insertAdjacentHTML|outerHTML\s*=/);
+  assert.doesNotMatch(app, /insertAdjacentHTML|outerHTML\s*=|window\.(?:alert|confirm)|\.onclick\s*=/);
   assert.match(app, /textContent/);
   assert.match(app, /Failed to load|could not be loaded/i);
   assert.match(app, /noopener/);
   assert.match(app, /noreferrer/);
+  assert.match(html, /<svg[\s>]/);
+  assert.doesNotMatch(html, /[♙▤✉✓⇄◫⚗ⓘ☰◆⠿⚠↻↗⊘⌫]/u);
+  assert.doesNotMatch(app, /\p{Extended_Pictographic}/u);
 });
 
-test("browser app serializes seeds, preloads request targets, and guards async tabs", async () => {
+test("browser release guards are wired into navigation, mutations, and related email rendering", async () => {
   const app = await readFile(new URL("../docs/d365/app.mjs", import.meta.url), "utf8");
-  const refreshStart = app.indexOf("async function refreshEntity(entity)");
-  const refreshEnd = app.indexOf("\nasync function renderRecord(", refreshStart);
-  const refreshSource = app.slice(refreshStart, refreshEnd);
+  const showLoading = app.slice(
+    app.indexOf("function showLoading("),
+    app.indexOf("\nfunction showLoadError("),
+  );
+  const navigate = app.slice(
+    app.indexOf("async function navigate("),
+    app.indexOf("\nfunction handleDocumentClick("),
+  );
+  const bulkDelete = app.slice(
+    app.indexOf("async function bulkDelete("),
+    app.indexOf("\nasync function bulkTransition("),
+  );
+  const singleDelete = app.slice(
+    app.indexOf("async function deleteCurrentRecord("),
+    app.indexOf("\nasync function loadRelatedPanel("),
+  );
+  const clickHandler = app.slice(
+    app.indexOf("function handleDocumentClick("),
+    app.indexOf("\nfunction handleDocumentKeydown("),
+  );
+  const manualRequest = app.slice(
+    app.indexOf("async function sendManualRequest("),
+    app.indexOf("\nasync function runScenario("),
+  );
+
+  assert.match(showLoading, /setCommands\(\[\]\)/);
+  assert.match(navigate, /setCommands\(\[\]\)/);
+  assert.match(app, /captureRouteGuard\(app\.navigationToken, app\.currentRoute\)/);
+  assert.match(app, /routeGuardMatches\(guard, app\.navigationToken, app\.currentRoute\)/);
+  assert.match(app, /routeGuardIsCurrent\(routeGuard\)/);
+
+  assert.match(bulkDelete, /ensureEntities\(\["contacts", "connections"\]\)/);
+  assert.match(bulkDelete, /preflightContactDeletion/);
+  assert.ok(
+    bulkDelete.indexOf("preflightContactDeletion") < bulkDelete.indexOf("for (const record of selected)"),
+    "all selected contacts must be preflighted before the first DELETE",
+  );
+  assert.match(bulkDelete, /ensureEntities\(\["accounts", "emails"\]\)/);
+  assert.match(bulkDelete, /preflightAccountDeletion/);
+  assert.ok(
+    bulkDelete.indexOf("preflightAccountDeletion") < bulkDelete.indexOf("for (const record of selected)"),
+    "all selected accounts must be preflighted before the first DELETE",
+  );
+  assert.match(singleDelete, /ensureEntities\(\["contacts", "connections"\]\)/);
+  assert.match(singleDelete, /Contact cannot be deleted/);
+  assert.match(singleDelete, /ensureEntities\(\["accounts", "emails"\]\)/);
+  assert.match(singleDelete, /preflightAccountDeletion/);
+  assert.match(singleDelete, /Account cannot be deleted/);
+  assert.match(manualRequest, /ensureEntities\(\["contacts", "connections"\]\)/);
+  assert.match(manualRequest, /preflightContactDeletion/);
+  assert.match(manualRequest, /ensureEntities\(\["accounts", "emails"\]\)/);
+  assert.match(manualRequest, /preflightAccountDeletion/);
+  assert.match(app, /Deactivate instead/);
+
+  assert.match(app, /relatedEmailsForContact\(app\.twin\.getState\("emails"\), record\)/);
+  assert.match(app, /relatedEmailsForAccount\(app\.twin\.getState\("emails"\), record\.accountid\)/);
+  assert.doesNotMatch(app, /Number\.POSITIVE_INFINITY/);
+
+  assert.match(clickHandler, /shouldInterceptSpaNavigation/);
+  for (const option of [
+    "button", "ctrlKey", "metaKey", "shiftKey", "altKey", "download", "target",
+  ]) {
+    assert.match(clickHandler, new RegExp(`${option}:`));
+  }
+});
+
+test("Knowledge Search exposes a persistent high-contrast focus-within indicator", async () => {
+  const css = await readFile(new URL("../docs/d365/d365.css", import.meta.url), "utf8");
+  const rule = css.match(/\.knowledge-search-form:focus-within\s*\{([^}]*)\}/);
+  assert.ok(rule, "Knowledge Search must expose focus on its visible container");
+  assert.match(rule[1], /border-color:\s*var\(--focus\)/);
+  assert.match(rule[1], /outline:\s*2px solid var\(--focus\)/);
+  assert.match(rule[1], /outline-offset:\s*2px/);
+  assert.doesNotMatch(rule[1], /outline:\s*(?:0|none)/);
+  assert.match(css, /--focus:\s*#0f6cbd/);
+});
+
+test("browser app implements combined grids, record forms, relationships, and process contracts", async () => {
+  const app = await readFile(new URL("../docs/d365/app.mjs", import.meta.url), "utf8");
+  const processStart = app.indexOf("function buildBusinessProcess(record, editable)");
+  const processEnd = app.indexOf("\nfunction renderRecordForm(", processStart);
+  const processSource = app.slice(processStart, processEnd);
 
   assert.match(app, /seedInstallTail:\s*Promise\.resolve\(\)/);
   assert.match(app, /if \(app\.entityPromises\.has\(entity\)\) return app\.entityPromises\.get\(entity\)/);
   assert.match(app, /const pending = app\.seedInstallTail\.then/);
   assert.match(app, /app\.seedInstallTail = pending\.catch/);
-  assert.match(app, /await ensureScenarioEntities\(id\);\s*app\.twin\.reset\(\)/s);
+  assert.match(app, /combineActivities\(\s*app\.twin\.getState\("emails"\),\s*app\.twin\.getState\("tasks"\)/s);
+  assert.match(app, /captureRouteGuard\(expectedToken, app\.currentRoute\)/);
+  assert.match(app, /routeGuardIsCurrent\(routeGuard\)/);
+  assert.match(app, /PAGE_SIZE/);
+  assert.doesNotMatch(app, /MAX_GRID_ROWS|slice\(0,\s*300\)/);
+  assert.match(app, /"aria-sort"/);
+  assert.match(app, /updateSelection\(state\.selected/);
+  assert.match(app, /SYSTEM_VIEWS\.connections/);
+  assert.match(app, /relatedConnectionsForContact/);
+  assert.match(app, /_relatedName/);
+  assert.match(app, /_relationship/);
+  assert.doesNotMatch(app, /connection\.name/);
+  assert.match(app, /relatedEmailsForContact/);
+  assert.match(app, /relatedEmailsForAccount/);
+  assert.match(app, /\["Summary", "Details", "Related"\]/);
+  assert.match(app, /Contact Information/);
+  assert.match(app, /Professional Information/);
+  assert.match(app, /Engagement Profile/);
+  assert.match(app, /Task Details/);
+  assert.match(app, /Case Summary/);
+  assert.match(app, /Service Level/);
+  for (const commandLabel of [
+    "Mark Complete", "Cancel Case", "Resolve Case", "Reopen", "Save & Close",
+  ]) {
+    assert.match(app, new RegExp(commandLabel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.match(processSource, /\["Identify", "Research", "Resolve"\]/);
+  assert.doesNotMatch(processSource, /twin\.request|transitionPatch/);
   assert.match(app, /await ensureEntities\(BUILT_IN_SCENARIOS\.flatMap/);
   assert.match(app, /const target = parsePath\(path\);[\s\S]*await ensureEntity\(target\.entity\);[\s\S]*app\.twin\.request/);
-  assert.match(app, /const recordTabSelectionTokens = new WeakMap\(\)/);
-  assert.match(app, /if \(!isCurrentSelection\(\)\) return/);
-  assert.match(app, /items = newestRelatedEmails\(related\)\.map/);
-  assert.match(app, /valueNode\(record\[key\], type, entity, key\)/);
-  assert.match(refreshSource, /const navigationToken = app\.navigationToken/);
-  assert.match(refreshSource, /const currentEntity = app\.currentRoute\?\.entity/);
-  assert.match(refreshSource, /await ensureEntity\(entity\);\s*if \(!refreshIsCurrent\(\)\) return;\s*renderGrid\(entity\)/);
-  assert.equal((refreshSource.match(/if \(!refreshIsCurrent\(\)\) return;/g) || []).length, 2);
   assert.match(app, /Date\.UTC\(/);
   assert.match(app, /getUTCFullYear|getUTCHours/);
   assert.doesNotMatch(app, /new Date\(control\.value\)|new Date\(value\)\.toISOString/);
+});
+
+test("browser form and dashboard wiring enforce the hardened interaction contracts", async () => {
+  const app = await readFile(new URL("../docs/d365/app.mjs", import.meta.url), "utf8");
+  const contactStart = app.indexOf("contacts: {");
+  const accountStart = app.indexOf("accounts: {", contactStart);
+  const incidentStart = app.indexOf("incidents: {");
+  const activitiesStart = app.indexOf("const ACTIVITIES_GRID", incidentStart);
+  const contactConfig = app.slice(contactStart, accountStart);
+  const incidentConfig = app.slice(incidentStart, activitiesStart);
+  assert.match(contactConfig, /field\("new_status", "Customer status", \{ type: "contact-status" \}\)/);
+  assert.doesNotMatch(contactConfig, /field\("new_status"[^)]*editable/);
+  assert.match(incidentConfig, /field\("new_sla_status", "SLA status", \{ type: "service-status" \}\)/);
+  assert.doesNotMatch(incidentConfig, /field\("new_sla_status"[^)]*editable/);
+
+  for (const title of [
+    "Recent Activities",
+    "Open Activities",
+    "Sent Email",
+    "Activities by Type",
+    "Activities by Status",
+    "Tasks",
+  ]) {
+    assert.match(app, new RegExp(`"${title}"`));
+  }
+  assert.match(app, /app\.dashboardView === "service-activity"[\s\S]*serviceActivityDashboardPanels/);
+  assert.match(app, /recordCommandActions\(entity, record/);
+  assert.match(app, /nextRovingTabIndex\(tabs/);
+  assert.match(app, /editableSnapshotsEqual\(baseline, formPayload\(form, entity\)\)/);
+  assert.match(app, /disabled: tab === "related" && creating/);
+  assert.match(app, /button\.tabIndex = selected \? 0 : -1/);
+});
+
+test("dialog, saved-form, history, and direct Dashboard wiring enforce final safety contracts", async () => {
+  const app = await readFile(new URL("../docs/d365/app.mjs", import.meta.url), "utf8");
+  const showDialog = app.slice(
+    app.indexOf("function showDialog("),
+    app.indexOf("\nfunction showErrorDialog("),
+  );
+  const dirtyResolution = app.slice(
+    app.indexOf("async function resolveDirtyState("),
+    app.indexOf("\nasync function requestNavigation("),
+  );
+  const dashboard = app.slice(
+    app.indexOf("async function renderDashboard("),
+    app.indexOf("\nfunction dashboardListPanel("),
+  );
+  const history = app.slice(
+    app.indexOf("async function runHistoryPrompt("),
+    app.indexOf("\nfunction formatUtcDate("),
+  );
+
+  assert.match(showDialog, /replaceDialogState\(app\.activeDialog, dialog\)/);
+  assert.match(
+    showDialog,
+    /replacement\.replacement\.dialog\.finish\(replacement\.replacement\.value\)/,
+  );
+  assert.doesNotMatch(app, /dialogFinish/);
+
+  const confirmationCount = [...app.matchAll(/const confirmed = await confirmAction\(/g)].length;
+  const strictConfirmationCount = [...app.matchAll(/if \(confirmed !== true \|\|/g)].length;
+  assert.equal(confirmationCount, 4);
+  assert.equal(strictConfirmationCount, confirmationCount);
+  assert.doesNotMatch(app, /if \(!confirmed/);
+
+  assert.match(dirtyResolution, /const savedRecord = await saveRecord\(/);
+  assert.match(dirtyResolution, /savedFormRenderTarget\(activeForm, savedRecord, selectedTab\)/);
+  assert.match(
+    dirtyResolution,
+    /renderRecordForm\(renderTarget\.entity, renderTarget\.record, renderTarget\.initialTab\)/,
+  );
+  assert.ok(
+    dirtyResolution.indexOf("await saveRecord")
+      < dirtyResolution.indexOf("renderRecordForm(renderTarget.entity"),
+  );
+  assert.doesNotMatch(dirtyResolution, /Boolean\(await saveRecord/);
+  assert.match(app, /const record = app\.activeForm\?\.record/);
+
+  assert.match(history, /function serializedHistoryPrompt/);
+  assert.match(history, /if \(app\.historyPromptPromise\) return app\.historyPromptPromise/);
+  assert.match(history, /transitionHistoryPrompt\(app\.navigationHistory, proceed\)/);
+
+  assert.match(dashboard, /finally\s*\{/);
+  assert.match(dashboard, /dashboardRenderCompletion\(focusTarget\)/);
+  assert.match(dashboard, /setBusy\(completion\.busy\)/);
+  assert.match(dashboard, /document\.getElementById\(completion\.focusTargetId\)\?\.focus\(\)/);
+  assert.match(dashboard, /id: "dashboard-selector"/);
+  assert.match(dashboard, /"data-action": "select-dashboard"/);
+  assert.match(dashboard, /id: "dashboard-refresh", action: "refresh-dashboard"/);
+  assert.match(dashboard, /renderDashboard\(app\.navigationToken, "selector"\)/);
+  assert.match(dashboard, /renderDashboard\(refreshGuard\.navigationToken, "refresh"\)/);
+});
+
+test("dirty navigation and accessible dialogs replace native alert and confirm", async () => {
+  const [html, app] = await Promise.all([
+    readFile(new URL("../docs/d365/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../docs/d365/app.mjs", import.meta.url), "utf8"),
+  ]);
+  assert.match(html, /<dialog id="app-dialog"/);
+  assert.match(html, /aria-labelledby="dialog-title"/);
+  assert.match(app, /function showDialog/);
+  assert.match(app, /\.showModal\(\)/);
+  assert.match(app, /function trapFocus|const trapFocus/);
+  assert.match(app, /event\.key !== "Tab"/);
+  assert.match(app, /previousFocus.*focus\(\)/s);
+  assert.match(app, /function resolveDirtyState/);
+  assert.match(app, /Unsaved changes/);
+  assert.match(app, /Save.*Discard changes.*Cancel|Cancel.*Discard changes.*Save/s);
+  assert.match(app, /window\.addEventListener\("beforeunload", beforeUnload\)/);
+  assert.match(app, /event\.returnValue = ""/);
+  assert.match(app, /window\.addEventListener\("popstate", handlePopState\)/);
+  assert.match(app, /window\.history\.go\(transition\.effect\.delta\)/);
+  assert.doesNotMatch(app, /window\.addEventListener\("hashchange"/);
+  assert.doesNotMatch(app, /window\.(?:alert|confirm)/);
 });


### PR DESCRIPTION
## Summary
- replace the branded simulator shell with a high-fidelity Customer Service Hub New Look; source data appears only inside standard Dynamics entities
- add OOTB dashboards, combined Activities, system views, 50-row paging, contextual commands, record forms, case process, related records, accessible dialogs, and dirty-navigation protection
- isolate deterministic faults/replay/time controls under Service Management and correct task, case, Contact, Account, Email, and Connection lifecycle integrity

## Tests
- `node --test tests/d365_twin.test.mjs` (54 passed)
- `python3 -m pytest tests/test_generate_d365_data.py -q` (9 passed)
- module syntax, static HTTP assets, and diff checks passed