### PR TITLE
Recover D365 assets from poisoned service-worker caches

### DIFF
--- a/docs/d365/app.mjs
+++ b/docs/d365/app.mjs
@@ -4,7 +4,7 @@ import {
   createTwin,
   parsePath,
   runBuiltInScenario,
-} from "./twin-core.mjs";
+} from "./twin-core.mjs?v=6";
 import {
   PAGE_SIZE,
   SYSTEM_VIEWS,
@@ -39,7 +39,7 @@ import {
   transitionHistoryPrompt,
   transitionPatch,
   updateSelection,
-} from "./app-helpers.mjs";
+} from "./app-helpers.mjs?v=6";
 
 const API_ROOT = new URL("../api/data/v9.2/", import.meta.url);
 const RUNTIME_EPOCH = "2026-07-01T09:00:00.000Z";

--- a/docs/d365/index.html
+++ b/docs/d365/index.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light">
   <title>Dynamics 365 — Customer Service Hub</title>
-  <link rel="stylesheet" href="./d365.css">
-  <script type="module" src="./app.mjs"></script>
+  <link rel="stylesheet" href="./d365.css?v=6">
+  <script type="module" src="./app.mjs?v=6"></script>
 </head>
 <body>
   <header class="global-header">

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,7 +1,7 @@
 /* Rappterbook Service Worker — PWA offline support */
 
-const SHELL_CACHE = 'rb-shell-v5';
-const DATA_CACHE = 'rb-data-v5';
+const SHELL_CACHE = 'rb-shell-v6';
+const DATA_CACHE = 'rb-data-v6';
 
 const SHELL_ASSETS = [
   '/rappterbook/',
@@ -21,6 +21,13 @@ const PAGES = [
   '/rappterbook/os',
   '/rappterbook/weekend'
 ];
+
+function cacheSuccessful(cacheName, request, response) {
+  if (!response || !response.ok) return response;
+  const clone = response.clone();
+  caches.open(cacheName).then((cache) => cache.put(request, clone));
+  return response;
+}
 
 // Install: pre-cache app shell + key pages
 self.addEventListener('install', (event) => {
@@ -59,11 +66,7 @@ self.addEventListener('fetch', (event) => {
   if (url.hostname === 'raw.githubusercontent.com') {
     event.respondWith(
       fetch(event.request)
-        .then((response) => {
-          const clone = response.clone();
-          caches.open(DATA_CACHE).then((cache) => cache.put(event.request, clone));
-          return response;
-        })
+        .then((response) => cacheSuccessful(DATA_CACHE, event.request, response))
         .catch(() => caches.match(event.request))
     );
     return;
@@ -75,15 +78,23 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  // D365 shell and data — network-first so deploys cannot mix HTML and stale assets.
+  if (url.origin === self.location.origin
+      && (url.pathname.startsWith('/rappterbook/d365/')
+          || url.pathname.startsWith('/rappterbook/api/data/v9.2/'))) {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => cacheSuccessful(SHELL_CACHE, event.request, response))
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
   // Same-origin HTML — network-first so updates apply immediately
   if (url.origin === self.location.origin && (url.pathname.endsWith('/') || url.pathname.endsWith('.html'))) {
     event.respondWith(
       fetch(event.request)
-        .then((response) => {
-          const clone = response.clone();
-          caches.open(SHELL_CACHE).then((cache) => cache.put(event.request, clone));
-          return response;
-        })
+        .then((response) => cacheSuccessful(SHELL_CACHE, event.request, response))
         .catch(() => caches.match(event.request))
     );
     return;
@@ -94,9 +105,7 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       caches.match(event.request).then((cached) => {
         return cached || fetch(event.request).then((response) => {
-          const clone = response.clone();
-          caches.open(SHELL_CACHE).then((cache) => cache.put(event.request, clone));
-          return response;
+          return cacheSuccessful(SHELL_CACHE, event.request, response);
         });
       })
     );

--- a/tests/test_pwa.py
+++ b/tests/test_pwa.py
@@ -67,6 +67,28 @@ def test_service_worker_handles_raw_github():
     assert "raw.githubusercontent.com" in sw
 
 
+def test_service_worker_refreshes_d365_without_caching_failures():
+    """D365 deploys use network-first responses and never persist 4xx/5xx assets."""
+    sw = (DOCS_DIR / "sw.js").read_text()
+    assert "rb-shell-v6" in sw
+    assert "/rappterbook/d365/" in sw
+    assert "/rappterbook/api/data/v9.2/" in sw
+    assert "if (!response || !response.ok) return response;" in sw
+    d365_branch = sw.index("D365 shell and data")
+    generic_static_branch = sw.index("Same-origin static assets")
+    assert d365_branch < generic_static_branch
+
+
+def test_d365_shell_uses_versioned_assets():
+    """Versioned D365 URLs bypass any poisoned cache left by an older worker."""
+    html = (DOCS_DIR / "d365" / "index.html").read_text()
+    app = (DOCS_DIR / "d365" / "app.mjs").read_text()
+    assert 'href="./d365.css?v=6"' in html
+    assert 'src="./app.mjs?v=6"' in html
+    assert 'from "./twin-core.mjs?v=6"' in app
+    assert 'from "./app-helpers.mjs?v=6"' in app
+
+
 # --- Bundled HTML ---
 
 def test_html_has_manifest_link():


### PR DESCRIPTION
## Summary
- rotate the root service-worker caches and make D365 shell/API requests network-first
- cache only successful responses so deployment-time 404s cannot persist indefinitely
- version the D365 stylesheet and ESM dependency graph so existing poisoned caches recover immediately

## Tests
- `python3 -m pytest tests/test_pwa.py tests/test_generate_d365_data.py -q` (27 passed)
- `node --test tests/d365_twin.test.mjs` (54 passed)
- service-worker/module syntax and diff checks passed