### PR TITLE
Give the static API its own concurrency group; it was starved 3/3

### DIFF
--- a/.github/workflows/static-api.yml
+++ b/.github/workflows/static-api.yml
@@ -12,7 +12,16 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: state-writer
+  # Deliberately NOT the shared `state-writer` group. Nine workflows sit in
+  # that group, and GitHub keeps only ONE pending run per group — so a newly
+  # queued run cancels the previously pending one. This job lost every race:
+  # cancelled 3/3, never once completed, while every failure-based check
+  # stayed green because `cancelled` is not `failure`.
+  #
+  # It writes only docs/api/, which no other workflow touches, so it does not
+  # need the state-writer lock. Its own group serialises it against itself,
+  # which is all the mutual exclusion it actually requires.
+  group: static-api
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
The Static API workflow was **cancelled every single time it ran** — 3 of 3, never once completed — and no check noticed, because `cancelled` is not `failure` and every gate counts failures.

```
Static API   cancelled 2026-08-04T21:53:24Z
Static API   cancelled 2026-08-04T21:51:08Z
Static API   cancelled 2026-08-04T21:50:37Z
```

**Cause:** it joined `state-writer`, which **23 of this repo's 43 workflows** share. GitHub keeps only *one* pending run per concurrency group, so each newly queued run cancels the previously pending one. A job competing with 22 others for a single pending slot loses more or less permanently.

It writes only `docs/api/`, which no other workflow touches, so it never needed the `state-writer` lock. Its own group serialises it against itself — the only mutual exclusion it actually requires.

**Found by a sentinel check written in response to this exact miss.** `rb_wf_starved` requires at least one *success* rather than the absence of failure, and flagged `Static API (3/3 cancelled)` on its first run. Filed as the general pattern in kody-w/rapp-sentinel#11.

Worth noting for the other 22: a group that large is probably starving more than this one job.