### PR TITLE
tick: move Auto Tick off the contended :00/:30 state-writer slots

### DIFF
--- a/.github/workflows/prompt-evolution-tick.yml
+++ b/.github/workflows/prompt-evolution-tick.yml
@@ -8,8 +8,14 @@ name: Self-Modifying Prompt — Auto Tick
 
 on:
   schedule:
-    # every 30 minutes
-    - cron: "*/30 * * * *"
+    # Every 30 minutes, offset to :11/:41. NOT "*/30": minutes :00 and :30 are
+    # the two most contended slots in the shared `state-writer` concurrency
+    # group (10 and 4 other state writers respectively, plus agent-heartbeat
+    # and overseer on their own */30). GitHub keeps only one *pending* run per
+    # group, so a tick landing on :00/:30 was routinely evicted before it was
+    # ever scheduled — cancelled with no jobs and no logs. Same reasoning as
+    # janitor.yml at :17 and cloud-brainstem.yml at :23.
+    - cron: "11,41 * * * *"
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
## Symptom

`rb_wf_starved` fires on **Self-Modifying Prompt — Auto Tick**: no success in its last 3 runs, one of them `cancelled`.

Run [31123191461](https://github.com/kody-w/rappterbook/actions/runs/31123191461) is the tell — it completed as `cancelled` with **zero jobs and no logs**. Nothing ran. It was evicted while still *pending*, before it was ever scheduled.

## Root cause: it is scheduled into the two busiest slots in the mutex

Auto Tick uses `*/30`, so it fires at **:00 and :30**. Those are the two most contended minutes in the shared `state-writer` concurrency group:

| minute | other `state-writer` workflows also scheduled |
|---:|---:|
| **:00** | **12** |
| **:30** | **4** |
| :11 | 0 |
| :41 | 0 |

`agent-heartbeat` and `overseer` are *also* `*/30`, so they collide with Auto Tick on **every single tick**, plus the 10-workflow pileup on the hour.

GitHub keeps only one **pending** run per concurrency group, and `cancel-in-progress: false` does **not** protect a run that has not started yet. The loser is silently discarded as `cancelled` rather than `failure`, which is why this starved quietly.

The effect is measurable: over the last ~19h Auto Tick ran **10 times out of 39 scheduled**, at irregular 1.4h–3.1h gaps instead of every 30 minutes.

## Why the group is not changed

Auto Tick writes `state/prompt_evolution.json` and `state/seeds.json`. Per AGENTS.md, state-writing workflows share `concurrency: group: state-writer`, so it **belongs** in the group and is left there — pulling it out would risk exactly the concurrent state writes the mutex exists to prevent. (That is the difference from #20874 / #20872, where `Static API` legitimately left the group because it only writes `docs/api/`.)

Only the cron is offset, which keeps serialization intact while removing the guaranteed collision.

## Change

```diff
-    # every 30 minutes
-    - cron: "*/30 * * * *"
+    - cron: "11,41 * * * *"
```

Cadence is still every 30 minutes. `:11` and `:41` are both empty — no other `state-writer` workflow is scheduled on either.

This is the technique the repo already uses and documents inline:
- `janitor.yml` — `'17 * * * *'  # hourly at :17 to avoid clashing with trending/feeds`
- `cloud-brainstem.yml` — `'23 * * * *'  # hourly at :23 — odd offset to avoid clashing with other crons`
- `reconcile-channels.yml` — `'45 */4 * * *'  # (offset from other workflows)`

## Verification

Workflow YAML parses, and the schedule was re-derived from the actual cron fields of all 23 `state-writer` workflows:

```
Auto Tick now fires at minutes: [11, 41]
  minute :11 -> co-scheduled state-writers: NONE (clear slot)
  minute :41 -> co-scheduled state-writers: NONE (clear slot)
busiest minutes overall: [(12, minute 0), (4, minute 30), (1, minute 45)]
```

> [!IMPORTANT]
> This cannot be proven by a CI run right now: GitHub Actions is in a **major outage** (runs are queuing or failing on `Failed to resolve action download info`), and a cron change only manifests on the next scheduled tick regardless. The evidence above is static analysis of the schedule, not a green run. Worth confirming after the incident clears that ticks land on :11/:41 and stop being cancelled.
