### PR TITLE
Un-starve the prompt tick; it was cancelled 30/30 before a job ever existed

### DIFF
--- a/.github/workflows/prompt-evolution-tick.yml
+++ b/.github/workflows/prompt-evolution-tick.yml
@@ -8,8 +8,20 @@ name: Self-Modifying Prompt — Auto Tick
 
 on:
   schedule:
-    # every 30 minutes
-    - cron: "*/30 * * * *"
+    # Every 30 minutes, offset to :08/:38 rather than */30.
+    #
+    # */30 fires at :00 and :30 -- the same instants as agent-heartbeat and
+    # overseer, which are also */30, on top of the 15 workflows at :00. All
+    # three land in the state-writer group in the SAME SECOND (observed
+    # 09:53:17 and 09:53:18). GitHub keeps at most one *pending* run per
+    # concurrency group, so of three simultaneous arrivals one runs, one
+    # waits, and the rest are evicted before a job is ever created. This
+    # workflow lost that race 30 times running.
+    #
+    # Same offset convention as janitor (:17), cloud-brainstem (:23) and
+    # reconcile-channels (:45). The group is only busy ~10 min/hour; the
+    # collision was simultaneous arrival, not saturation.
+    - cron: "8,38 * * * *"
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
## What was failing

`Self-Modifying Prompt — Auto Tick` has not succeeded in **30 consecutive runs** (2026-08-09T09:07Z → 2026-08-10T10:54Z). Every one was `cancelled` with **zero jobs ever created** — killed before scheduling rather than failing — so no failure-based check ever went red.

Over its last 100 runs it is **16 success / 83 cancelled / 1 failure**. It was never healthy; it was winning a race about 16% of the time.

## Root cause

`cron: "*/30 * * * *"` fires at `:00` and `:30` — the same two instants as **agent-heartbeat** and **overseer**, which are also `*/30`, on top of the **15 workflows** that fire at `:00`. All of them share `concurrency: group: state-writer`.

GitHub keeps at most **one pending run per concurrency group**. Of N simultaneous arrivals, one runs, one waits, and the rest are evicted. The arrivals are *literally* simultaneous because identical cron expressions are dispatched in a single batch:

```
09:53:17  Self-Modifying Prompt — Auto Tick  -> cancelled
09:53:18  Agent Heartbeat                    -> cancelled
10:53:09  Zion Autonomy                      -> cancelled
10:54:06  Self-Modifying Prompt — Auto Tick  -> cancelled   (10:55 Heartbeat won)
```

## Why not the Static API remedy (#20872)

Same starvation, different correct fix. Static API writes `docs/api/v1/` only, so it could be firewalled **out** of the mutex. This job commits `state/prompt_evolution.json` and `state/seeds.json` — a genuine state writer — and AGENTS.md is explicit:

> All workflows use `concurrency: group: state-writer` to serialize, but safe_commit.sh is the safety net. **Never bypass it in workflows.**

The group stays. What changes is arrival time.

## The fix

`8,38 * * * *` — same 30-minute cadence, moved off the shared instants. This follows the offset convention already used **and commented** elsewhere in this repo:

| workflow | cron | existing comment |
|---|---|---|
| janitor | `17 * * * *` | "to avoid clashing with trending/feeds" |
| cloud-brainstem | `23 * * * *` | "odd offset to avoid clashing with other crons" |
| reconcile-channels | `45 */4 * * *` | "offset from other workflows" |
| twin-author | `37 */2 * * *` | — |

`:08` and `:38` are unused by all 43 workflows. The group is only busy ~10 min/hour (seven runs of 1–2 min), so this was **collision, not saturation** — decorrelating arrival is sufficient. A lone overlap is absorbed by the pending slot; only a *third* simultaneous arrival evicts.

## Verification

Verified against `origin/main` that the job body is healthy, so this yields a **green** run and not merely a non-cancelled red one:

- Experiment is at frame **100/100**, so the `Check experiment is active` gate sets `active=false` and the job exits 0 without touching state.
- `prompt_evolution_tracker.py status` exits 0.
- All 43 workflows still parse; `check_no_conflict_markers.py` passes.

A scheduled run at the new offset will be observed before this is called fixed.

## Note for the owner (not changed here)

`agent-heartbeat` and `overseer` remain on `*/30` and still collide with each other — they merely win often enough not to trip the starvation check. Worth offsetting one of them too, but that is outside the smallest fix for this failure.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>