### PR TITLE
fix(ci): stop Compute Trending being evicted from the state-writer queue

### DIFF
--- a/.github/workflows/compute-trending.yml
+++ b/.github/workflows/compute-trending.yml
@@ -6,7 +6,19 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: state-writer
+  # Was `state-writer`, shared with 24 other workflows. GitHub holds only ONE
+  # pending run per concurrency group: while the group is busy, the queued run
+  # is cancelled the instant the next one arrives. This job runs 12-21 min from
+  # :15, so the hourly Janitor at :17 kept landing on it while it was still
+  # queued and evicting it -- 4 of the last 8 runs were cancelled before a
+  # single step ran, freezing the roll-up (and the site computed from it) for
+  # 12h. Janitor's ":17 to avoid clashing with trending" offset cannot work
+  # when the job it must not clash with occupies the next 21 minutes.
+  # The shared queue is not what makes this safe: scripts/safe_commit.sh already
+  # rebases and retries concurrent pushes, and no other workflow writes
+  # trending.json, analytics.json, frame_echoes.json, seeds.json or
+  # cache_shards/. Only overlapping ITSELF needs guarding.
+  group: compute-trending
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Symptom

`rb_content_moving` paged at CRITICAL: **roll-up stale 12.0h**. `state/trending.json` last materialized `2026-08-14T13:55:54Z`.

No workflow was failing. Compute Trending simply never ran.

## Root cause

Four of the last eight Compute Trending runs were `cancelled` after 45-70s with **zero jobs started** — they were killed while still pending.

GitHub keeps only **one** pending run per concurrency group. `state-writer` is shared by **25 workflows**, so whenever the group is busy the queued run is cancelled the moment the next member arrives. Compute Trending is the longest job in the group (12-21 min) and the least frequent (every 4h), so it always queued — and was always evicted.

Every eviction was the hourly Janitor arriving **one second** before the cancellation:

| Compute Trending created | cancelled | Janitor created |
|---|---|---|
| 2026-08-13T21:03:12Z | 21:04:18Z | 21:04:17Z |
| 2026-08-14T17:11:10Z | 17:11:59Z | 17:11:58Z |
| 2026-08-14T20:45:23Z | 20:46:06Z | 20:46:05Z |
| 2026-08-15T01:49:13Z | 01:50:23Z | 01:50:22Z |

Janitor's `cron: '17 * * * *'  # hourly at :17 to avoid clashing with trending/feeds` encodes the right intent with an unworkable mechanism: a 2-minute offset in front of a 21-minute job.

## Fix

Give Compute Trending its own concurrency group — the pattern `generate-feeds`, `static-api`, `slop-cop` and `precompute-fleet` already use.

The shared queue was never what made concurrent state writes safe: `scripts/safe_commit.sh` rebases and retries them, which is its documented job. And no other workflow writes `trending.json`, `analytics.json`, `frame_echoes.json`, `seeds.json` or `cache_shards/` — Compute Trending is their sole writer. Shared files (`stats/channels/agents/posted_log`) remain covered by safe_commit's rebase-retry.

`cancel-in-progress: false` is kept so a run already doing work is never killed; with a 4h cadence and 21-min runtime, self-overlap is effectively impossible.

## Note (not fixed here)

The eviction is systemic, not unique to this workflow — over the last 2 days `Cloud Brainstem` lost 15/24 runs, `Janitor` 11/24, `Agent Heartbeat` 11/30 the same way. That is a broader scheduling question for the owner; this PR only restores the content roll-up that was paging.