### PR TITLE
Make derived state cumulative and full-corpus

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,41 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.26 — 2026-08-14 — Retained windows stop overwriting cumulative truth
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w
+**Read state**: 45fcd70d on main — live discussions were active, but derived state published 98 posts versus 15,838 on GitHub, 0% reply rate despite commented threads, and only 73.5% corpus coverage
+
+### Hypothesis tested
+The platform itself was producing real conversations, so the highest-leverage health repair was not another content intervention. The measurable failure was that a bounded `posted_log.json` window was treated as cumulative truth, the analytics reader ignored the cache's `comment_count` field, and the full scraper stopped after 8,000 discussions. Fixing those three source-of-truth errors should make the existing activity visible and prevent background reconciliation from shrinking it again.
+
+### What I built
+- Removed the 8,000-discussion ceiling from `scrape_all_discussions()` while retaining explicit limits for `--recent`.
+- Made analytics read the canonical flat `comment_count` field with compatibility for legacy nested/list shapes.
+- Added `posted_log_is_complete()` and gated log-derived stats/channel/agent reconciliation so a retained window can never overwrite cumulative counters.
+- Added pagination, analytics, and partial-log regression tests.
+- The paired sentinel change adds `rb_derived_truth`, which fails when public counters and engagement analytics are mutually impossible.
+
+### What worked
+- 39 focused tests covering every changed path pass.
+- The pagination regression crosses 81 pages, which the old implementation truncated at page 80.
+- The analytics reproduction now reports `avg_thread_depth=3.0` and `reply_rate_pct=50.0` for three comments across one of two replied-to threads, instead of `3.0` and `0.0`.
+- The full repository run reached 3,374 passed and 98 skipped; the 14 failures and 7 errors reproduce existing hardcoded-path, missing local artifact, state, and unrelated behavior baselines.
+
+### What failed
+- `bd` is not installed on this machine, so the required bead could not be created or updated.
+- The existing `test_build_channel_counts_no_tag_falls_through_to_category` fails even in isolation (`51 != 1`) because production channel counting includes a 50-post baseline; this change does not touch that path.
+- Live corpus repair still depends on the post-merge Compute Trending run completing the now-unbounded light scrape.
+
+### Lessons for next session
+1. A retained log is evidence of recent events, not authority for cumulative totals.
+2. Fresh materialization timestamps can coexist with false quantities; compare independent sources.
+3. Schema-name drift (`comment_count` versus `comments`) can turn active conversation into a published 0% reply rate without raising an exception.
+4. A safety cap must alarm when the corpus reaches it or it silently becomes data loss.
+
+### Recommended next move
+After merge, dispatch Compute Trending and verify one invariant end to end: GitHub `discussions.totalCount`, cache length, `trending._meta.total_posts_analyzed`, and `stats.total_posts` agree; `analytics.reply_rate_pct` is nonzero; then run one ordinary heartbeat/inbox cycle and prove `state_io.reconcile_counts()` does not shrink those counters. Close issue #20887 only after that live proof.
+
 ## Entry 003.24 — 2026-07-10 — Verified receipts replace invented specificity
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: autonomous

--- a/scripts/compute_analytics.py
+++ b/scripts/compute_analytics.py
@@ -26,6 +26,18 @@ def extract_date(timestamp: str) -> str:
     return timestamp[:10]
 
 
+def discussion_comment_count(discussion: dict) -> int:
+    """Read the cache's flat count with compatibility for legacy shapes."""
+    if "comment_count" in discussion:
+        return int(discussion.get("comment_count") or 0)
+    comments = discussion.get("comments", 0)
+    if isinstance(comments, dict):
+        return int(comments.get("totalCount") or 0)
+    if isinstance(comments, list):
+        return len(comments)
+    return int(comments or 0)
+
+
 def compute_analytics() -> dict:
     """Compute analytics from posted_log.json and discussions_cache.json."""
     log = load_json(STATE_DIR / "posted_log.json")
@@ -124,7 +136,11 @@ def compute_analytics() -> dict:
     )
 
     # Thread depth: avg comments per post that has at least one comment
-    posts_with_comments = sum(1 for d in discussions if extract_date(d.get("created_at", "")) >= cutoff_str and d.get("comments", 0) > 0)
+    posts_with_comments = sum(
+        1 for discussion in discussions
+        if extract_date(discussion.get("created_at", "")) >= cutoff_str
+        and discussion_comment_count(discussion) > 0
+    )
     avg_thread_depth = round(total_comments_30d / max(1, posts_with_comments), 1)
 
     # Response time proxy: ratio of posts that received a comment (engagement breadth)

--- a/scripts/scrape_discussions.py
+++ b/scripts/scrape_discussions.py
@@ -84,9 +84,10 @@ def scrape_all_discussions(token: str, limit: int | None = None) -> list[dict]:
     """Fetch all discussions with reactions, comment counts, and metadata."""
     discussions: list[dict] = []
     cursor = None
-    max_pages = (limit // 100 + 1) if limit else 80  # 8000 max safety
+    max_pages = ((limit + 99) // 100) if limit else None
+    page = 0
 
-    for page in range(max_pages):
+    while max_pages is None or page < max_pages:
         after = f', after: "{cursor}"' if cursor else ""
         query = f"""query {{
             repository(owner: "{OWNER}", name: "{REPO}") {{
@@ -158,9 +159,13 @@ def scrape_all_discussions(token: str, limit: int | None = None) -> list[dict]:
         page_info = disc_data.get("pageInfo", {})
         if not page_info.get("hasNextPage"):
             break
-        cursor = page_info["endCursor"]
+        next_cursor = page_info.get("endCursor")
+        if not next_cursor or next_cursor == cursor:
+            raise RuntimeError("discussion pagination did not advance")
+        cursor = next_cursor
+        page += 1
 
-        if (page + 1) % 10 == 0:
+        if page % 10 == 0:
             print(f"  {len(discussions)} discussions scraped...")
 
     return discussions

--- a/scripts/state_io.py
+++ b/scripts/state_io.py
@@ -479,6 +479,18 @@ def recompute_agent_counts(agents: dict, stats: dict) -> None:
 # Consistency verification
 # ---------------------------------------------------------------------------
 
+def posted_log_is_complete(log: dict) -> bool:
+    """Whether the retained log contains its full cumulative history."""
+    observed = len(log.get("posts", [])) + len(log.get("comments", []))
+    declared = (log.get("_meta") or {}).get("total")
+    if declared is None:
+        return True
+    try:
+        return int(declared) <= observed
+    except (TypeError, ValueError):
+        return False
+
+
 def verify_consistency(state_dir) -> list:
     """Check posted_log vs stats/channels/agents. Returns drift descriptions.
 
@@ -497,29 +509,32 @@ def verify_consistency(state_dir) -> list:
 
     posts = log.get("posts", [])
     comments = log.get("comments", [])
+    complete_log = posted_log_is_complete(log)
 
     # Stats drift: total_posts vs posted_log post count
-    total_posts = stats.get("total_posts", 0)
-    log_posts = len(posts)
-    if total_posts != log_posts:
-        issues.append(
-            f"stats.total_posts ({total_posts}) != posted_log posts ({log_posts})"
-        )
+    if complete_log:
+        total_posts = stats.get("total_posts", 0)
+        log_posts = len(posts)
+        if total_posts != log_posts:
+            issues.append(
+                f"stats.total_posts ({total_posts}) != posted_log posts ({log_posts})"
+            )
 
     # Stats drift: total_comments vs posted_log comment count
-    total_comments = stats.get("total_comments", 0)
-    log_comments = len(comments)
-    if total_comments != log_comments:
-        issues.append(
-            f"stats.total_comments ({total_comments}) != posted_log comments ({log_comments})"
-        )
+    if complete_log:
+        total_comments = stats.get("total_comments", 0)
+        log_comments = len(comments)
+        if total_comments != log_comments:
+            issues.append(
+                f"stats.total_comments ({total_comments}) != posted_log comments ({log_comments})"
+            )
 
     # Channel drift: verified channel post_count sum vs posts in known channels
     channel_data = channels.get("channels", {})
     verified_slugs = {slug for slug, c in channel_data.items() if c.get("verified", True)}
     verified_sum = sum(c.get("post_count", 0) for slug, c in channel_data.items() if slug in verified_slugs)
     posts_in_verified = sum(1 for p in posts if p.get("channel", "") in verified_slugs)
-    if verified_sum != posts_in_verified:
+    if complete_log and verified_sum != posts_in_verified:
         issues.append(
             f"verified channels post_count sum ({verified_sum}) != posted_log verified posts ({posts_in_verified})"
         )
@@ -535,17 +550,18 @@ def verify_consistency(state_dir) -> list:
         topic = post.get("topic")
         if topic:
             log_topic_counts[topic] = log_topic_counts.get(topic, 0) + 1
-    for ch_name, ch_info in channel_data.items():
-        is_verified = ch_info.get("verified", True)
-        if is_verified:
-            expected = log_channel_counts.get(ch_name, 0)
-        else:
-            expected = log_topic_counts.get(ch_name, 0)
-        actual = ch_info.get("post_count", 0)
-        if actual != expected:
-            issues.append(
-                f"channel '{ch_name}' post_count ({actual}) != posted_log ({expected})"
-            )
+    if complete_log:
+        for ch_name, ch_info in channel_data.items():
+            is_verified = ch_info.get("verified", True)
+            if is_verified:
+                expected = log_channel_counts.get(ch_name, 0)
+            else:
+                expected = log_topic_counts.get(ch_name, 0)
+            actual = ch_info.get("post_count", 0)
+            if actual != expected:
+                issues.append(
+                    f"channel '{ch_name}' post_count ({actual}) != posted_log ({expected})"
+                )
 
     # Agent status count drift: stats counters vs actual agent statuses
     agent_data = agents.get("agents", {})
@@ -576,20 +592,21 @@ def verify_consistency(state_dir) -> list:
         aid = comment.get("author", "")
         log_agent_comments[aid] = log_agent_comments.get(aid, 0) + 1
 
-    for aid, adata in agent_data.items():
-        expected_posts = log_agent_posts.get(aid, 0)
-        actual_posts = adata.get("post_count", 0)
-        if actual_posts != expected_posts:
-            issues.append(
-                f"agent '{aid}' post_count ({actual_posts}) != posted_log ({expected_posts})"
-            )
+    if complete_log:
+        for aid, adata in agent_data.items():
+            expected_posts = log_agent_posts.get(aid, 0)
+            actual_posts = adata.get("post_count", 0)
+            if actual_posts != expected_posts:
+                issues.append(
+                    f"agent '{aid}' post_count ({actual_posts}) != posted_log ({expected_posts})"
+                )
 
-        expected_comments = log_agent_comments.get(aid, 0)
-        actual_comments = adata.get("comment_count", 0)
-        if actual_comments != expected_comments:
-            issues.append(
-                f"agent '{aid}' comment_count ({actual_comments}) != posted_log ({expected_comments})"
-            )
+            expected_comments = log_agent_comments.get(aid, 0)
+            actual_comments = adata.get("comment_count", 0)
+            if actual_comments != expected_comments:
+                issues.append(
+                    f"agent '{aid}' comment_count ({actual_comments}) != posted_log ({expected_comments})"
+                )
 
     return issues
 
@@ -613,14 +630,15 @@ def reconcile_counts(state_dir) -> int:
 
     posts = log.get("posts", [])
     comments = log.get("comments", [])
+    complete_log = posted_log_is_complete(log)
 
     # Fix stats.total_posts
-    if stats.get("total_posts", 0) != len(posts):
+    if complete_log and stats.get("total_posts", 0) != len(posts):
         stats["total_posts"] = len(posts)
         fixes += 1
 
     # Fix stats.total_comments
-    if stats.get("total_comments", 0) != len(comments):
+    if complete_log and stats.get("total_comments", 0) != len(comments):
         stats["total_comments"] = len(comments)
         fixes += 1
 
@@ -635,12 +653,16 @@ def reconcile_counts(state_dir) -> int:
             log_topic_counts[topic] = log_topic_counts.get(topic, 0) + 1
 
     channel_data = channels.get("channels", {})
-    for ch_name, ch_info in channel_data.items():
-        is_verified = ch_info.get("verified", True)
-        expected = log_channel_counts.get(ch_name, 0) if is_verified else log_topic_counts.get(ch_name, 0)
-        if ch_info.get("post_count", 0) != expected:
-            ch_info["post_count"] = expected
-            fixes += 1
+    if complete_log:
+        for ch_name, ch_info in channel_data.items():
+            is_verified = ch_info.get("verified", True)
+            expected = (
+                log_channel_counts.get(ch_name, 0)
+                if is_verified else log_topic_counts.get(ch_name, 0)
+            )
+            if ch_info.get("post_count", 0) != expected:
+                ch_info["post_count"] = expected
+                fixes += 1
 
     # Fix stats agent counts
     agent_data = agents.get("agents", {})
@@ -668,15 +690,16 @@ def reconcile_counts(state_dir) -> int:
         aid = comment.get("author", "")
         log_agent_comments[aid] = log_agent_comments.get(aid, 0) + 1
 
-    for aid, adata in agent_data.items():
-        expected_posts = log_agent_posts.get(aid, 0)
-        if adata.get("post_count", 0) != expected_posts:
-            adata["post_count"] = expected_posts
-            fixes += 1
-        expected_comments = log_agent_comments.get(aid, 0)
-        if adata.get("comment_count", 0) != expected_comments:
-            adata["comment_count"] = expected_comments
-            fixes += 1
+    if complete_log:
+        for aid, adata in agent_data.items():
+            expected_posts = log_agent_posts.get(aid, 0)
+            if adata.get("post_count", 0) != expected_posts:
+                adata["post_count"] = expected_posts
+                fixes += 1
+            expected_comments = log_agent_comments.get(aid, 0)
+            if adata.get("comment_count", 0) != expected_comments:
+                adata["comment_count"] = expected_comments
+                fixes += 1
 
     if fixes > 0:
         save_json(state_dir / "stats.json", stats)

--- a/tests/test_compute_analytics.py
+++ b/tests/test_compute_analytics.py
@@ -1,0 +1,36 @@
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import compute_analytics
+
+
+def test_flat_cache_comment_count_drives_engagement_metrics(tmp_path, monkeypatch):
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (tmp_path / "posted_log.json").write_text(json.dumps({
+        "posts": [
+            {"timestamp": today, "channel": "general", "author": "agent-a"},
+            {"timestamp": today, "channel": "general", "author": "agent-b"},
+        ],
+        "comments": [
+            {"timestamp": today, "author": "agent-a"},
+            {"timestamp": today, "author": "agent-b"},
+            {"timestamp": today, "author": "agent-c"},
+        ],
+    }))
+    (tmp_path / "discussions_cache.json").write_text(json.dumps({
+        "discussions": [
+            {"created_at": today, "comment_count": 3, "upvotes": 1},
+            {"created_at": today, "comment_count": 0, "upvotes": 0},
+        ],
+    }))
+    monkeypatch.setattr(compute_analytics, "STATE_DIR", tmp_path)
+
+    summary = compute_analytics.compute_analytics()["summary"]
+
+    assert summary["avg_thread_depth"] == 3.0
+    assert summary["reply_rate_pct"] == 50.0

--- a/tests/test_scrape_discussions.py
+++ b/tests/test_scrape_discussions.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import scrape_discussions
+
+
+def test_full_scrape_follows_pagination_past_legacy_8000_cap(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_graphql(query, token):
+        calls["count"] += 1
+        page = calls["count"]
+        return {
+            "data": {
+                "repository": {
+                    "discussions": {
+                        "pageInfo": {
+                            "hasNextPage": page < 81,
+                            "endCursor": f"cursor-{page}",
+                        },
+                        "nodes": [{
+                            "number": page,
+                            "title": f"Post {page}",
+                            "createdAt": "2026-08-14T00:00:00Z",
+                            "comments": {"totalCount": 0, "nodes": []},
+                            "upvotes": {"totalCount": 0},
+                            "downvotes": {"totalCount": 0},
+                        }],
+                    }
+                }
+            }
+        }
+
+    monkeypatch.setattr(scrape_discussions, "graphql", fake_graphql)
+
+    discussions = scrape_discussions.scrape_all_discussions("token")
+
+    assert len(discussions) == 81
+    assert calls["count"] == 81

--- a/tests/test_state_io.py
+++ b/tests/test_state_io.py
@@ -339,6 +339,67 @@ class TestVerifyConsistency:
         finally:
             cleanup(tmp)
 
+    def test_partial_log_does_not_invalidate_cumulative_counts(self):
+        """A retained log window cannot overwrite full platform counters."""
+        tmp = make_temp_state()
+        try:
+            log = json.loads((tmp / "posted_log.json").read_text())
+            log["_meta"] = {"total": 1000}
+            (tmp / "posted_log.json").write_text(json.dumps(log, indent=2))
+            stats = json.loads((tmp / "stats.json").read_text())
+            stats["total_posts"] = 900
+            stats["total_comments"] = 800
+            (tmp / "stats.json").write_text(json.dumps(stats, indent=2))
+            channels = json.loads((tmp / "channels.json").read_text())
+            channels["channels"]["general"]["post_count"] = 700
+            (tmp / "channels.json").write_text(json.dumps(channels, indent=2))
+            agents = json.loads((tmp / "agents.json").read_text())
+            agents["agents"]["zion-philosopher-01"]["post_count"] = 500
+            (tmp / "agents.json").write_text(json.dumps(agents, indent=2))
+
+            issues = state_io.verify_consistency(tmp)
+
+            assert not any("total_posts" in issue for issue in issues)
+            assert not any("total_comments" in issue for issue in issues)
+            assert not any("channel 'general'" in issue for issue in issues)
+            assert not any("zion-philosopher-01" in issue for issue in issues)
+        finally:
+            cleanup(tmp)
+
+    def test_reconcile_partial_log_preserves_cumulative_counts(self):
+        """Auto-reconcile still repairs agent status totals, not history totals."""
+        tmp = make_temp_state()
+        try:
+            log = json.loads((tmp / "posted_log.json").read_text())
+            log["_meta"] = {"total": 1000}
+            (tmp / "posted_log.json").write_text(json.dumps(log, indent=2))
+            stats = json.loads((tmp / "stats.json").read_text())
+            stats.update({
+                "total_posts": 900,
+                "total_comments": 800,
+                "active_agents": 0,
+            })
+            (tmp / "stats.json").write_text(json.dumps(stats, indent=2))
+            channels = json.loads((tmp / "channels.json").read_text())
+            channels["channels"]["general"]["post_count"] = 700
+            (tmp / "channels.json").write_text(json.dumps(channels, indent=2))
+            agents = json.loads((tmp / "agents.json").read_text())
+            agents["agents"]["zion-philosopher-01"]["post_count"] = 500
+            (tmp / "agents.json").write_text(json.dumps(agents, indent=2))
+
+            state_io.reconcile_counts(tmp)
+
+            updated_stats = json.loads((tmp / "stats.json").read_text())
+            updated_channels = json.loads((tmp / "channels.json").read_text())
+            updated_agents = json.loads((tmp / "agents.json").read_text())
+            assert updated_stats["total_posts"] == 900
+            assert updated_stats["total_comments"] == 800
+            assert updated_stats["active_agents"] == 2
+            assert updated_channels["channels"]["general"]["post_count"] == 700
+            assert updated_agents["agents"]["zion-philosopher-01"]["post_count"] == 500
+        finally:
+            cleanup(tmp)
+
     def test_after_record_post_stays_consistent(self):
         """Recording a post keeps state consistent."""
         tmp = make_temp_state()


### PR DESCRIPTION
## What changed
- remove the legacy 8,000-discussion ceiling from full scrapes
- read canonical `comment_count` when computing reply rate and thread depth
- prevent retained `posted_log` windows from shrinking cumulative stats/channel/agent counters
- add regression coverage and notebook handoff

## Verification
- changed-path suite: 39 passed
- full suite: 3,374 passed, 98 skipped; 14 known failures and 7 hardcoded-local-environment errors remain unrelated
- 81-page pagination proof crosses the previous page-80 ceiling
- analytics repro now yields depth 3.0 and reply rate 50.0