### PR TITLE
Make full discussion scrapes transport-safe

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,37 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.27 — 2026-08-14 — Full coverage needs bounded response size
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w
+**Read state**: 7b992b14 on main — the first uncapped Compute Trending run reached 11,000 discussions, then failed on a 2.2 MB GraphQL page with `http.client.IncompleteRead`
+
+### Hypothesis tested
+Removing the silent corpus cap was correct, but simply requesting twice as many of the same oversized pages was not operationally reliable. The light scrape should preserve full discussion coverage while omitting comment bodies it does not consume, retry partial HTTP reads, and merge sparse fresh fields into richer cached rows without erasing them.
+
+### What I built
+- Added `light=True` query shaping so the scheduled metadata scrape requests only `comments.totalCount`, not the first 100 comment bodies on every discussion.
+- Added `IncompleteRead` to the existing retry/backoff path.
+- Changed cache conflict resolution to merge fields per discussion, preserving `comment_authors` and other rich fields omitted by light mode.
+- Added tests for page-81 coverage, light query shape, rich-field preservation, and incomplete-read retry.
+
+### What worked
+- 42 focused derived-state tests pass.
+- The first uncapped live run proved the old cap was binding by progressing beyond 8,000 to 11,000 records before transport failure.
+- The retry test reproduces `IncompleteRead` and succeeds on the next response.
+- The cache-merge test proves a light refresh updates current metadata without deleting previously fetched comment-author detail.
+
+### What failed
+- The first live run did not publish state because the oversized response failed before cache write. No partial result was committed.
+
+### Lessons for next session
+1. Full coverage and unbounded response size are different decisions; paginate fully, but keep each page minimal.
+2. A “light” mode that still requests nested comment bodies is only light by label.
+3. Sparse refreshes must merge by field, not replace entire records, or reliability work becomes silent data loss.
+
+### Recommended next move
+Merge the follow-up and rerun Compute Trending. Verify the scrape reaches all GitHub discussions, then compare cache/trending/stats counts and analytics engagement fields. Run one ordinary state mutation afterward to prove the retained-log guard prevents counter shrink.
+
 ## Entry 003.26 — 2026-08-14 — Retained windows stop overwriting cumulative truth
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w

--- a/scripts/scrape_discussions.py
+++ b/scripts/scrape_discussions.py
@@ -36,6 +36,7 @@ Usage:
 Requires: GITHUB_TOKEN env var.
 """
 import json
+import http.client
 import os
 import sys
 import time
@@ -71,7 +72,12 @@ def graphql(query: str, token: str, retries: int = 3) -> dict:
                     time.sleep(2 ** attempt * 5)
                     continue
                 return result
-        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+        except (
+            urllib.error.URLError,
+            urllib.error.HTTPError,
+            http.client.IncompleteRead,
+            TimeoutError,
+        ) as exc:
             if attempt < retries - 1:
                 wait = min(2 ** attempt * 10, 120)
                 print(f"  [retry] Request failed ({exc}), waiting {wait}s...")
@@ -80,12 +86,29 @@ def graphql(query: str, token: str, retries: int = 3) -> dict:
                 raise
 
 
-def scrape_all_discussions(token: str, limit: int | None = None) -> list[dict]:
+def scrape_all_discussions(
+    token: str,
+    limit: int | None = None,
+    light: bool = False,
+) -> list[dict]:
     """Fetch all discussions with reactions, comment counts, and metadata."""
     discussions: list[dict] = []
     cursor = None
     max_pages = ((limit + 99) // 100) if limit else None
     page = 0
+    comments_selection = (
+        "comments { totalCount }"
+        if light else
+        """comments(first: 100) {
+                            totalCount
+                            nodes {
+                                id
+                                body
+                                author { login }
+                                createdAt
+                            }
+                        }"""
+    )
 
     while max_pages is None or page < max_pages:
         after = f', after: "{cursor}"' if cursor else ""
@@ -103,15 +126,7 @@ def scrape_all_discussions(token: str, limit: int | None = None) -> list[dict]:
                         url
                         author {{ login }}
                         category {{ slug }}
-                        comments(first: 100) {{
-                            totalCount
-                            nodes {{
-                                id
-                                body
-                                author {{ login }}
-                                createdAt
-                            }}
-                        }}
+                        {comments_selection}
                         upvotes: reactions(content: THUMBS_UP) {{ totalCount }}
                         downvotes: reactions(content: THUMBS_DOWN) {{ totalCount }}
                     }}
@@ -136,7 +151,7 @@ def scrape_all_discussions(token: str, limit: int | None = None) -> list[dict]:
                 }
                 for c in comment_data.get("nodes", [])
             ]
-            discussions.append({
+            discussion = {
                 "number": node["number"],
                 "node_id": node.get("id", ""),
                 "title": node["title"],
@@ -149,8 +164,10 @@ def scrape_all_discussions(token: str, limit: int | None = None) -> list[dict]:
                 "upvotes": node.get("upvotes", {}).get("totalCount", 0),
                 "downvotes": node.get("downvotes", {}).get("totalCount", 0),
                 "comment_count": comment_data.get("totalCount", 0),
-                "comment_authors": comment_authors,
-            })
+            }
+            if not light:
+                discussion["comment_authors"] = comment_authors
+            discussions.append(discussion)
 
         if limit and len(discussions) >= limit:
             discussions = discussions[:limit]
@@ -438,9 +455,14 @@ def save_cache(discussions: list[dict], merge: bool = True) -> None:
     else:
         existing_by_num = {}
 
-    # New data wins on conflict (keyed by discussion number)
+    # New fields win on conflict. Fields omitted by a light scrape retain the
+    # richer value already present in the cache.
     new_by_num = {d["number"]: d for d in discussions}
-    existing_by_num.update(new_by_num)
+    for number, new_data in new_by_num.items():
+        existing_by_num[number] = {
+            **existing_by_num.get(number, {}),
+            **new_data,
+        }
 
     merged = sorted(existing_by_num.values(), key=lambda d: d["number"], reverse=True)
 
@@ -531,7 +553,7 @@ def main() -> None:
     else:
         mode = "light" if light else f"recent {limit}" if limit else "full"
         print(f"Scraping discussions ({mode} mode)...")
-        discussions = scrape_all_discussions(token, limit=limit)
+        discussions = scrape_all_discussions(token, limit=limit, light=light)
         print(f"  Fetched {len(discussions)} discussions")
         if not light:
             scrape_comment_bodies(discussions, token)

--- a/tests/test_scrape_discussions.py
+++ b/tests/test_scrape_discussions.py
@@ -1,4 +1,6 @@
 import sys
+import http.client
+import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -40,3 +42,88 @@ def test_full_scrape_follows_pagination_past_legacy_8000_cap(monkeypatch):
 
     assert len(discussions) == 81
     assert calls["count"] == 81
+
+
+def test_light_scrape_omits_comment_nodes(monkeypatch):
+    queries = []
+
+    def fake_graphql(query, token):
+        queries.append(query)
+        return {
+            "data": {
+                "repository": {
+                    "discussions": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [{
+                            "number": 1,
+                            "title": "Post",
+                            "body": "Body",
+                            "createdAt": "2026-08-14T00:00:00Z",
+                            "comments": {"totalCount": 5},
+                            "upvotes": {"totalCount": 1},
+                            "downvotes": {"totalCount": 0},
+                        }],
+                    }
+                }
+            }
+        }
+
+    monkeypatch.setattr(scrape_discussions, "graphql", fake_graphql)
+
+    discussions = scrape_discussions.scrape_all_discussions(
+        "token", light=True)
+
+    assert "comments { totalCount }" in queries[0]
+    assert "comments(first: 100)" not in queries[0]
+    assert "comment_authors" not in discussions[0]
+
+
+def test_light_merge_preserves_rich_cached_fields(tmp_path, monkeypatch):
+    cache = tmp_path / "discussions_cache.json"
+    cache.write_text(json.dumps({
+        "discussions": [{
+            "number": 1,
+            "title": "Old",
+            "comment_authors": [{"login": "agent-a"}],
+        }],
+    }))
+    monkeypatch.setattr(scrape_discussions, "CACHE_FILE", cache)
+    monkeypatch.setattr(scrape_discussions, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(scrape_discussions, "_fetch_origin_cache", lambda: {})
+
+    scrape_discussions.save_cache([{"number": 1, "title": "New"}])
+
+    merged = json.loads(cache.read_text())["discussions"][0]
+    assert merged["title"] == "New"
+    assert merged["comment_authors"] == [{"login": "agent-a"}]
+
+
+def test_graphql_retries_incomplete_reads(monkeypatch):
+    responses = [
+        http.client.IncompleteRead(b"{", 1),
+        json.dumps({"data": {"ok": True}}).encode(),
+    ]
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            value = responses.pop(0)
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+    monkeypatch.setattr(
+        scrape_discussions.urllib.request,
+        "urlopen",
+        lambda request, timeout: FakeResponse(),
+    )
+    monkeypatch.setattr(scrape_discussions.time, "sleep", lambda seconds: None)
+
+    result = scrape_discussions.graphql("query { viewer { login } }", "token")
+
+    assert result == {"data": {"ok": True}}


### PR DESCRIPTION
## What changed
- make scheduled light scrapes omit nested comment bodies while retaining full pagination
- retry `IncompleteRead` transport failures
- merge sparse refresh fields into rich cached rows instead of replacing them
- record the live failure and follow-up in the lab notebook

## Verification
- focused derived-state suite: 42 passed
- covers page 81, light query shape, rich-field preservation, and incomplete-read retry
- first uncapped live run reached 11,000 records before exposing the oversized-response failure