### PR TITLE
Pace full discussion scrapes through secondary limits

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,34 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.29 — 2026-08-15 — Full scrapes become rate-aware
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w
+**Read state**: ad1b19ec on main — the transport-light full scrape still hit intermittent GitHub HTTP 403 secondary throttles and exhausted its 10s/20s retries around 11,000 discussions
+
+### Hypothesis tested
+The token still had more than 4,500 of 5,000 GraphQL points remaining, so the failure was secondary throttling, not primary quota exhaustion. A scraper that deliberately traverses 159 pages must pace requests and wait outside a 403 abuse window rather than retrying twice inside it.
+
+### What I built
+- Added a configurable 0.75-second page delay for full pagination.
+- Increased request retries to five.
+- Added 403-aware cooldown handling with a minimum 60-second wait and `Retry-After` support.
+- Added regression coverage for the secondary-limit wait contract.
+
+### What worked
+- The prior run again reached 11,000 discussions, proving response size was fixed and the remaining failure was rate behavior.
+- Local GraphQL budget inspection showed 4,533 points remaining, ruling out primary exhaustion.
+
+### What failed
+- The third live run still aborted before cache write because repeated 403 responses outlived the old 10s/20s retry window.
+
+### Lessons for next session
+1. Secondary throttling is temporal, not quota-based; retry timing must match the failure class.
+2. Long pagination jobs should pace proactively instead of depending entirely on reactive backoff.
+
+### Recommended next move
+Merge and rerun Compute Trending. If GitHub still throttles, record response headers in the retry log and honor the exact reset signal; otherwise verify all derived-state invariants and one post-materialization mutation.
+
 ## Entry 003.28 — 2026-08-15 — Cooldown no-ops stop aborting materialization
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w

--- a/scripts/scrape_discussions.py
+++ b/scripts/scrape_discussions.py
@@ -51,7 +51,20 @@ REPO = "rappterbook"
 CACHE_FILE = STATE_DIR / "discussions_cache.json"
 
 
-def graphql(query: str, token: str, retries: int = 3) -> dict:
+def retry_wait_seconds(exc: Exception, attempt: int) -> int:
+    """Back off long enough to leave GitHub's secondary-rate window."""
+    wait = min(2 ** attempt * 10, 120)
+    if isinstance(exc, urllib.error.HTTPError) and exc.code == 403:
+        retry_after = (exc.headers or {}).get("Retry-After", "0")
+        try:
+            wait = max(wait, int(retry_after))
+        except (TypeError, ValueError):
+            pass
+        wait = max(wait, 60)
+    return wait
+
+
+def graphql(query: str, token: str, retries: int = 5) -> dict:
     """Execute a GitHub GraphQL query with retry and backoff."""
     data = json.dumps({"query": query}).encode()
     req = urllib.request.Request(
@@ -79,7 +92,7 @@ def graphql(query: str, token: str, retries: int = 3) -> dict:
             TimeoutError,
         ) as exc:
             if attempt < retries - 1:
-                wait = min(2 ** attempt * 10, 120)
+                wait = retry_wait_seconds(exc, attempt)
                 print(f"  [retry] Request failed ({exc}), waiting {wait}s...")
                 time.sleep(wait)
             else:
@@ -96,6 +109,7 @@ def scrape_all_discussions(
     cursor = None
     max_pages = ((limit + 99) // 100) if limit else None
     page = 0
+    page_delay = float(os.environ.get("SCRAPE_PAGE_DELAY_SECONDS", "0.75"))
     comments_selection = (
         "comments { totalCount }"
         if light else
@@ -181,6 +195,8 @@ def scrape_all_discussions(
             raise RuntimeError("discussion pagination did not advance")
         cursor = next_cursor
         page += 1
+        if page_delay > 0:
+            time.sleep(page_delay)
 
         if page % 10 == 0:
             print(f"  {len(discussions)} discussions scraped...")

--- a/tests/test_scrape_discussions.py
+++ b/tests/test_scrape_discussions.py
@@ -11,6 +11,7 @@ import scrape_discussions
 
 def test_full_scrape_follows_pagination_past_legacy_8000_cap(monkeypatch):
     calls = {"count": 0}
+    monkeypatch.setenv("SCRAPE_PAGE_DELAY_SECONDS", "0")
 
     def fake_graphql(query, token):
         calls["count"] += 1
@@ -127,3 +128,15 @@ def test_graphql_retries_incomplete_reads(monkeypatch):
     result = scrape_discussions.graphql("query { viewer { login } }", "token")
 
     assert result == {"data": {"ok": True}}
+
+
+def test_secondary_rate_limit_waits_at_least_a_minute():
+    error = scrape_discussions.urllib.error.HTTPError(
+        "https://api.github.com/graphql",
+        403,
+        "Forbidden",
+        {"Retry-After": "75"},
+        None,
+    )
+
+    assert scrape_discussions.retry_wait_seconds(error, 0) == 75


### PR DESCRIPTION
Add proactive page pacing, five retries, and 403-aware cooldown handling with Retry-After support. Verification: 56 focused tests pass, including the secondary-limit wait contract.