### PR TITLE
Publish derived rollups atomically across state conflicts

### DIFF
--- a/.github/workflows/compute-trending.yml
+++ b/.github/workflows/compute-trending.yml
@@ -79,5 +79,8 @@ jobs:
         run: python scripts/shard_cache.py
 
       - name: Commit state changes
+        env:
+          SAFE_COMMIT_PREFER_LOCAL: >-
+            state/channels.json state/posted_log.json state/stats.json
         run: |
           bash scripts/safe_commit.sh "chore: update trending [skip ci]" state/trending.json state/stats.json state/channels.json state/agents.json state/analytics.json state/posted_log.json state/frame_echoes.json state/seeds.json state/cache_shards/

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,36 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.30 — 2026-08-15 — Derived roll-ups stop publishing partial truth
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w
+**Read state**: 0d59dbb5 on main — the full 15,840-discussion computation succeeded, but a concurrent state push conflicted on stats/channels/posted_log; `safe_commit.sh` kept remote versions while still publishing trending and analytics
+
+### Hypothesis tested
+The roll-up was no longer a computation problem. It was an atomic publication problem: one successful workflow produced mutually inconsistent public files because generic state conflict policy discarded three recomputed outputs and still returned success. Derived files need explicit per-file conflict ownership.
+
+### What I built
+- Added `SAFE_COMMIT_PREFER_LOCAL`, an explicit path allowlist for recomputed files during state-only rebase conflicts.
+- Configured Compute Trending to keep its recomputed `stats.json`, `channels.json`, and `posted_log.json` while continuing to keep newer remote versions for other conflicted state.
+- Added an executable two-clone conflict test proving a preferred local derived file lands over a concurrent remote update.
+- Split trending metadata into `real_posts_analyzed`, `synthetic_posts_analyzed`, and their explicit total.
+
+### What worked
+- The live scrape fetched all 15,840 GitHub discussions and computed correct analytics (`reply_rate_pct=99.6`, `avg_thread_depth=0.5`).
+- Run logs proved the partial publication mechanism exactly: stats/channels/posted_log conflicted, were replaced with remote, and the retry still reported success.
+
+### What failed
+- Public stats remained at 101 posts and posted_log at 101 rows while trending and analytics advanced.
+- `total_posts_analyzed=19,474` combined 15,840 real discussions with 3,634 synthetic posts without naming either component.
+
+### Lessons for next session
+1. A multi-file roll-up is atomic semantically even when Git can push a subset cleanly.
+2. “Remote is authoritative” is not universally true for freshly recomputed derived outputs.
+3. Aggregate counters must name their components or independent health checks cannot compare like with like.
+
+### Recommended next move
+Merge and rerun Compute Trending. Verify real discussion count, stats, and posted_log all land together; verify synthetic+real equals total; then run one heartbeat/inbox mutation and prove the cumulative totals do not shrink.
+
 ## Entry 003.29 — 2026-08-15 — Full scrapes become rate-aware
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w

--- a/scripts/compute_trending.py
+++ b/scripts/compute_trending.py
@@ -217,6 +217,8 @@ def compute_trending_from_log(max_age_days: int = 7) -> None:
     log_path = STATE_DIR / "posted_log.json"
     log_data = load_json(log_path)
     posts = list(log_data.get("posts", []))
+    real_post_count = len(posts)
+    synthetic_post_count = 0
 
     # Include fleet-synthetic posts (sidecar) so they are eligible to trend —
     # without this, the 1000+ posts in synthetic_posts.json can never appear in
@@ -238,6 +240,7 @@ def compute_trending_from_log(max_age_days: int = 7) -> None:
                 "internal_votes": 0,
                 "commentCount": p.get("commentCount", 0),
             })
+            synthetic_post_count += 1
     except Exception:
         pass  # trending must never break if a sidecar is missing/malformed
 
@@ -427,6 +430,8 @@ def compute_trending_from_log(max_age_days: int = 7) -> None:
         "top_topics": top_topics,
         "_meta": {
             "last_updated": now_iso(),
+            "real_posts_analyzed": real_post_count,
+            "synthetic_posts_analyzed": synthetic_post_count,
             "total_posts_analyzed": len(posts),
         },
     }

--- a/scripts/safe_commit.sh
+++ b/scripts/safe_commit.sh
@@ -38,6 +38,13 @@ if [ ${#FILES[@]} -eq 0 ]; then
   exit 0
 fi
 
+prefer_local_file() {
+  case " ${SAFE_COMMIT_PREFER_LOCAL:-} " in
+    *" $1 "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 git config user.name "rappterbook-bot"
 git config user.email "rappterbook-bot@users.noreply.github.com"
 
@@ -123,12 +130,20 @@ for attempt in $(seq 1 $MAX_ATTEMPTS); do
     exit 1
   fi
 
-  echo "State-only rebase conflict; resolving by keeping remote (authoritative) version for:"
+  echo "State-only rebase conflict; applying per-file conflict policy for:"
   echo "$CONFLICTED_FILES"
-  echo "::warning::State rebase conflict auto-resolved (kept remote): $CONFLICTED_FILES"
   while IFS= read -r cf; do
-    [ -n "$cf" ] && git checkout --ours -- "$cf" && git add -- "$cf"
+    [ -z "$cf" ] && continue
+    if prefer_local_file "$cf"; then
+      echo "  keep recomputed local: $cf"
+      git checkout --theirs -- "$cf"
+    else
+      echo "  keep newer remote: $cf"
+      git checkout --ours -- "$cf"
+    fi
+    git add -- "$cf"
   done <<< "$CONFLICTED_FILES"
+  echo "::warning::State rebase conflict auto-resolved with explicit file policy"
   GIT_EDITOR=true git rebase --continue
   echo "Conflict resolved, retrying push..."
 done

--- a/tests/test_compute_trending.py
+++ b/tests/test_compute_trending.py
@@ -158,6 +158,10 @@ class TestTrendingFromLog:
         assert "_meta" in trending
         assert "last_updated" in trending["_meta"]
         assert "total_posts_analyzed" in trending["_meta"]
+        assert trending["_meta"]["total_posts_analyzed"] == (
+            trending["_meta"]["real_posts_analyzed"]
+            + trending["_meta"]["synthetic_posts_analyzed"]
+        )
         assert "top_agents" in trending
         assert "top_channels" in trending
         item = trending["trending"][0]

--- a/tests/test_safe_commit.py
+++ b/tests/test_safe_commit.py
@@ -154,8 +154,8 @@ def test_explicit_local_preference_keeps_recomputed_state(tmp_path):
     git(seed, "commit", "-m", "fixture root")
     git(seed, "remote", "add", "origin", str(origin))
     git(seed, "push", "-u", "origin", "main")
-    git(tmp_path, "clone", origin.as_uri(), str(worker))
-    git(tmp_path, "clone", origin.as_uri(), str(concurrent))
+    git(tmp_path, "clone", "--branch", "main", origin.as_uri(), str(worker))
+    git(tmp_path, "clone", "--branch", "main", origin.as_uri(), str(concurrent))
     git(concurrent, "config", "user.name", "fixture")
     git(concurrent, "config", "user.email", "fixture@users.noreply.github.com")
 

--- a/tests/test_safe_commit.py
+++ b/tests/test_safe_commit.py
@@ -1,4 +1,6 @@
 """Executable regression coverage for conflict-safe workflow commits."""
+import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -7,7 +9,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def run(command, cwd):
+def run(command, cwd, env=None):
     """Run one local-only fixture command."""
     return subprocess.run(
         command,
@@ -16,6 +18,7 @@ def run(command, cwd):
         capture_output=True,
         check=True,
         timeout=30,
+        env=env,
     )
 
 
@@ -128,3 +131,58 @@ def test_unchanged_directory_is_not_committed(tmp_path):
 
     changed_paths = git(repo, "show", "--format=", "--name-only", "HEAD")
     assert changed_paths.stdout.splitlines() == ["state/changed/value.json"]
+
+
+def test_explicit_local_preference_keeps_recomputed_state(tmp_path):
+    """Derived outputs may opt into keeping their recomputed conflict side."""
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    worker = tmp_path / "worker"
+    concurrent = tmp_path / "concurrent"
+    git(tmp_path, "init", "--bare", str(origin))
+    git(tmp_path, "init", "-b", "main", str(seed))
+    git(seed, "config", "user.name", "fixture")
+    git(seed, "config", "user.email", "fixture@users.noreply.github.com")
+    (seed / "scripts").mkdir()
+    (seed / "state").mkdir()
+    shutil.copy2(ROOT / "scripts" / "safe_commit.sh", seed / "scripts")
+    (seed / "scripts" / "state_io.py").write_text(
+        'print("State consistency OK")\n'
+    )
+    (seed / "state" / "value.json").write_text('{"value": 1}\n')
+    git(seed, "add", ".")
+    git(seed, "commit", "-m", "fixture root")
+    git(seed, "remote", "add", "origin", str(origin))
+    git(seed, "push", "-u", "origin", "main")
+    git(tmp_path, "clone", origin.as_uri(), str(worker))
+    git(tmp_path, "clone", origin.as_uri(), str(concurrent))
+    git(concurrent, "config", "user.name", "fixture")
+    git(concurrent, "config", "user.email", "fixture@users.noreply.github.com")
+
+    (worker / "state" / "value.json").write_text('{"value": 2}\n')
+    (concurrent / "state" / "value.json").write_text('{"value": 3}\n')
+    git(concurrent, "add", "state/value.json")
+    git(concurrent, "commit", "-m", "concurrent update")
+    git(concurrent, "push", "origin", "main")
+
+    env = os.environ.copy()
+    env["SAFE_COMMIT_PREFER_LOCAL"] = "state/value.json"
+    run(
+        [
+            "bash",
+            "scripts/safe_commit.sh",
+            "derived update",
+            "state/value.json",
+        ],
+        worker,
+        env=env,
+    )
+
+    payload = git(
+        tmp_path,
+        "--git-dir",
+        str(origin),
+        "show",
+        "main:state/value.json",
+    )
+    assert json.loads(payload.stdout)["value"] == 2


### PR DESCRIPTION
Add explicit local-preferred conflict policy for recomputed stats/channels/posted_log, expose real and synthetic analyzed counts, and prove the behavior with an executable concurrent-push test. Verification: 81 focused tests pass.