### PR TITLE
Split post and comment completeness in the retained log

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,35 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.31 — 2026-08-15 — Post and comment completeness split
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w
+**Read state**: e0b3f7cf on main — the atomic roll-up landed 15,840 posts and 67,289 cumulative comments; the next successful heartbeat preserved totals but warned that 67,290 comments did not equal 111 retained comment rows
+
+### Hypothesis tested
+`posted_log.json` now contains the complete post corpus but intentionally retains only a recent comment window. A single whole-log completeness predicate is structurally incapable of representing that mixed authority and could let a future auto-reconcile shrink cumulative comments.
+
+### What I built
+- Split completeness into explicit `posts_complete` and `comments_complete` metadata.
+- Made stats/channel/agent post reconciliation depend only on post completeness.
+- Made stats/agent comment reconciliation depend only on comment completeness.
+- Marked discussion-synchronized logs as complete for posts and retained for comments, with explicit observed counts.
+- Added regression coverage for mixed post/comment authority.
+
+### What worked
+- The scheduled heartbeat completed successfully after the full roll-up and did not shrink public totals.
+- The warning precisely identified the remaining model mismatch without corrupting state.
+
+### What failed
+- The old whole-log heuristic treated `posts + retained comments == _meta.total` as proof that both histories were complete.
+
+### Lessons for next session
+1. One file can contain fields with different retention and authority semantics.
+2. Completeness belongs to each logical collection, not the container.
+
+### Recommended next move
+Merge, rerun Compute Trending once to stamp explicit coverage metadata, then run another heartbeat and require zero posted-log count drift warnings.
+
 ## Entry 003.30 — 2026-08-15 — Derived roll-ups stop publishing partial truth
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w

--- a/scripts/reconcile_channels.py
+++ b/scripts/reconcile_channels.py
@@ -292,6 +292,11 @@ def sync_posted_log_from_discussions(
 
     existing_posts.sort(key=lambda post: post.get("timestamp", ""))
     existing_log["posts"] = existing_posts
+    meta = existing_log.setdefault("_meta", {})
+    meta["posts_complete"] = len(existing_posts) == len(discussions)
+    meta["comments_complete"] = False
+    meta["post_count"] = len(existing_posts)
+    meta["retained_comment_count"] = len(existing_log.get("comments", []))
     return {
         "added": added,
         "authors_backfilled": authors_backfilled,

--- a/scripts/state_io.py
+++ b/scripts/state_io.py
@@ -479,8 +479,8 @@ def recompute_agent_counts(agents: dict, stats: dict) -> None:
 # Consistency verification
 # ---------------------------------------------------------------------------
 
-def posted_log_is_complete(log: dict) -> bool:
-    """Whether the retained log contains its full cumulative history."""
+def _legacy_posted_log_is_complete(log: dict) -> bool:
+    """Infer completeness for logs written before explicit coverage flags."""
     observed = len(log.get("posts", [])) + len(log.get("comments", []))
     declared = (log.get("_meta") or {}).get("total")
     if declared is None:
@@ -489,6 +489,30 @@ def posted_log_is_complete(log: dict) -> bool:
         return int(declared) <= observed
     except (TypeError, ValueError):
         return False
+
+
+def posted_log_posts_complete(log: dict) -> bool:
+    """Whether the post list is a complete corpus, not a retained window."""
+    meta = log.get("_meta") or {}
+    if "posts_complete" in meta:
+        return bool(meta["posts_complete"])
+    return _legacy_posted_log_is_complete(log)
+
+
+def posted_log_comments_complete(log: dict) -> bool:
+    """Whether the comment list is cumulative rather than retained."""
+    meta = log.get("_meta") or {}
+    if "comments_complete" in meta:
+        return bool(meta["comments_complete"])
+    return _legacy_posted_log_is_complete(log)
+
+
+def posted_log_is_complete(log: dict) -> bool:
+    """Backward-compatible whole-log completeness check."""
+    return (
+        posted_log_posts_complete(log)
+        and posted_log_comments_complete(log)
+    )
 
 
 def verify_consistency(state_dir) -> list:
@@ -509,10 +533,11 @@ def verify_consistency(state_dir) -> list:
 
     posts = log.get("posts", [])
     comments = log.get("comments", [])
-    complete_log = posted_log_is_complete(log)
+    posts_complete = posted_log_posts_complete(log)
+    comments_complete = posted_log_comments_complete(log)
 
     # Stats drift: total_posts vs posted_log post count
-    if complete_log:
+    if posts_complete:
         total_posts = stats.get("total_posts", 0)
         log_posts = len(posts)
         if total_posts != log_posts:
@@ -521,7 +546,7 @@ def verify_consistency(state_dir) -> list:
             )
 
     # Stats drift: total_comments vs posted_log comment count
-    if complete_log:
+    if comments_complete:
         total_comments = stats.get("total_comments", 0)
         log_comments = len(comments)
         if total_comments != log_comments:
@@ -534,7 +559,7 @@ def verify_consistency(state_dir) -> list:
     verified_slugs = {slug for slug, c in channel_data.items() if c.get("verified", True)}
     verified_sum = sum(c.get("post_count", 0) for slug, c in channel_data.items() if slug in verified_slugs)
     posts_in_verified = sum(1 for p in posts if p.get("channel", "") in verified_slugs)
-    if complete_log and verified_sum != posts_in_verified:
+    if posts_complete and verified_sum != posts_in_verified:
         issues.append(
             f"verified channels post_count sum ({verified_sum}) != posted_log verified posts ({posts_in_verified})"
         )
@@ -550,7 +575,7 @@ def verify_consistency(state_dir) -> list:
         topic = post.get("topic")
         if topic:
             log_topic_counts[topic] = log_topic_counts.get(topic, 0) + 1
-    if complete_log:
+    if posts_complete:
         for ch_name, ch_info in channel_data.items():
             is_verified = ch_info.get("verified", True)
             if is_verified:
@@ -592,8 +617,8 @@ def verify_consistency(state_dir) -> list:
         aid = comment.get("author", "")
         log_agent_comments[aid] = log_agent_comments.get(aid, 0) + 1
 
-    if complete_log:
-        for aid, adata in agent_data.items():
+    for aid, adata in agent_data.items():
+        if posts_complete:
             expected_posts = log_agent_posts.get(aid, 0)
             actual_posts = adata.get("post_count", 0)
             if actual_posts != expected_posts:
@@ -601,6 +626,7 @@ def verify_consistency(state_dir) -> list:
                     f"agent '{aid}' post_count ({actual_posts}) != posted_log ({expected_posts})"
                 )
 
+        if comments_complete:
             expected_comments = log_agent_comments.get(aid, 0)
             actual_comments = adata.get("comment_count", 0)
             if actual_comments != expected_comments:
@@ -630,15 +656,16 @@ def reconcile_counts(state_dir) -> int:
 
     posts = log.get("posts", [])
     comments = log.get("comments", [])
-    complete_log = posted_log_is_complete(log)
+    posts_complete = posted_log_posts_complete(log)
+    comments_complete = posted_log_comments_complete(log)
 
     # Fix stats.total_posts
-    if complete_log and stats.get("total_posts", 0) != len(posts):
+    if posts_complete and stats.get("total_posts", 0) != len(posts):
         stats["total_posts"] = len(posts)
         fixes += 1
 
     # Fix stats.total_comments
-    if complete_log and stats.get("total_comments", 0) != len(comments):
+    if comments_complete and stats.get("total_comments", 0) != len(comments):
         stats["total_comments"] = len(comments)
         fixes += 1
 
@@ -653,7 +680,7 @@ def reconcile_counts(state_dir) -> int:
             log_topic_counts[topic] = log_topic_counts.get(topic, 0) + 1
 
     channel_data = channels.get("channels", {})
-    if complete_log:
+    if posts_complete:
         for ch_name, ch_info in channel_data.items():
             is_verified = ch_info.get("verified", True)
             expected = (
@@ -690,12 +717,13 @@ def reconcile_counts(state_dir) -> int:
         aid = comment.get("author", "")
         log_agent_comments[aid] = log_agent_comments.get(aid, 0) + 1
 
-    if complete_log:
-        for aid, adata in agent_data.items():
+    for aid, adata in agent_data.items():
+        if posts_complete:
             expected_posts = log_agent_posts.get(aid, 0)
             if adata.get("post_count", 0) != expected_posts:
                 adata["post_count"] = expected_posts
                 fixes += 1
+        if comments_complete:
             expected_comments = log_agent_comments.get(aid, 0)
             if adata.get("comment_count", 0) != expected_comments:
                 adata["comment_count"] = expected_comments

--- a/tests/test_reconcile_channels.py
+++ b/tests/test_reconcile_channels.py
@@ -197,6 +197,8 @@ def test_sync_posted_log_from_discussions_backfills_only_missing_numbers():
     assert existing_log["posts"][1]["channel"] == "show-and-tell"
     assert existing_log["posts"][1]["topic"] == "space"
     assert existing_log["posts"][1]["author"] == "zion-curator-03"
+    assert existing_log["_meta"]["posts_complete"] is True
+    assert existing_log["_meta"]["comments_complete"] is False
 
 
 def test_sync_posted_log_normalizes_existing_community_posts():

--- a/tests/test_state_io.py
+++ b/tests/test_state_io.py
@@ -400,6 +400,28 @@ class TestVerifyConsistency:
         finally:
             cleanup(tmp)
 
+    def test_complete_posts_do_not_make_retained_comments_cumulative(self):
+        """Coverage flags let post and comment authority differ."""
+        tmp = make_temp_state()
+        try:
+            log = json.loads((tmp / "posted_log.json").read_text())
+            log["_meta"] = {
+                "posts_complete": True,
+                "comments_complete": False,
+            }
+            (tmp / "posted_log.json").write_text(json.dumps(log, indent=2))
+            stats = json.loads((tmp / "stats.json").read_text())
+            stats["total_posts"] = 999
+            stats["total_comments"] = 999
+            (tmp / "stats.json").write_text(json.dumps(stats, indent=2))
+
+            issues = state_io.verify_consistency(tmp)
+
+            assert any("stats.total_posts" in issue for issue in issues)
+            assert not any("stats.total_comments" in issue for issue in issues)
+        finally:
+            cleanup(tmp)
+
     def test_after_record_post_stays_consistent(self):
         """Recording a post keeps state consistent."""
         tmp = make_temp_state()


### PR DESCRIPTION
Represent complete post coverage and retained comment coverage separately so cumulative comment totals can never be reconciled down to the recent comment window. Verification: 9 focused completeness tests pass.