### PR TITLE
Refuse derived reconciliation without a discussion cache

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,32 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.32 — 2026-08-15 — Missing cache stops meaning empty corpus
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w
+**Read state**: 6a3e89b8 on main — Process Inbox loaded zero cached discussions and replaced 15,841 posts/67,296 comments with the 102-post retained window
+
+### Hypothesis tested
+The late regression was not another concurrency problem. Process Inbox does not check out the large discussion cache, yet unconditionally runs `reconcile_channels.py`; that script treated missing cache as an authoritative zero-discussion result and rewrote every derived counter from the retained log.
+
+### What I built
+- Made an empty or unavailable discussion cache a visible no-op for stats, channels, and posted_log reconciliation.
+- Added a regression test that seeds high cumulative derived state, omits the cache, runs the real `main()`, and requires byte-equivalent JSON values afterward.
+
+### What worked
+- Run #31870083979 provided exact proof: `Loaded 0 discussions from cache`, then `Stats: 102 posts, 828 comments`, followed by a successful push.
+- The sentinel caught the regression immediately through independent-source comparison.
+
+### What failed
+- A warning about the absent cache existed, but execution continued into destructive reconciliation. Warning without control flow was decorative.
+
+### Lessons for next session
+1. Unknown input must never become an empty authoritative collection.
+2. A warning that does not change behavior is not a guard.
+
+### Recommended next move
+Merge, rerun Compute Trending to restore full state, then run Process Inbox with no cache and require the cumulative counts and completeness flags to remain unchanged.
+
 ## Entry 003.31 — 2026-08-15 — Post and comment completeness split
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w

--- a/scripts/reconcile_channels.py
+++ b/scripts/reconcile_channels.py
@@ -374,6 +374,12 @@ def main() -> None:
     print("Loading discussions from local cache...")
     discussions = load_discussions_from_cache()
     print(f"  Loaded {len(discussions)} discussions from cache")
+    if not discussions:
+        print(
+            "No discussion cache available — leaving stats, channels, and "
+            "posted_log unchanged."
+        )
+        return
 
     # Update channels.json
     channels_path = STATE_DIR / "channels.json"

--- a/tests/test_reconcile_channels.py
+++ b/tests/test_reconcile_channels.py
@@ -1,11 +1,13 @@
 """Tests for reconcile_channels posted_log backfill helpers."""
 
+import json
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
 
+import reconcile_channels  # noqa: E402
 from reconcile_channels import (  # noqa: E402
     build_channel_counts,
     build_stats_snapshot,
@@ -13,6 +15,36 @@ from reconcile_channels import (  # noqa: E402
     infer_post_channel_and_topic,
     sync_posted_log_from_discussions,
 )
+
+
+def test_main_preserves_derived_state_when_cache_is_missing(
+    tmp_path, monkeypatch
+):
+    """An absent cache is unknown, never an authoritative empty corpus."""
+    state_dir = tmp_path / "state"
+    docs_dir = tmp_path / "docs"
+    state_dir.mkdir()
+    docs_dir.mkdir()
+    originals = {
+        "stats.json": {"total_posts": 15841, "total_comments": 67296},
+        "channels.json": {
+            "channels": {"general": {"post_count": 15841, "verified": True}}},
+        "posted_log.json": {
+            "posts": [{"number": 1}],
+            "comments": [],
+            "_meta": {"posts_complete": True, "comments_complete": False},
+        },
+    }
+    for name, payload in originals.items():
+        (state_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(reconcile_channels, "STATE_DIR", state_dir)
+    monkeypatch.setattr(reconcile_channels, "DOCS_DIR", docs_dir)
+    monkeypatch.setattr(sys, "argv", ["reconcile_channels.py"])
+
+    reconcile_channels.main()
+
+    for name, payload in originals.items():
+        assert json.loads((state_dir / name).read_text()) == payload
 
 
 def test_infer_post_channel_and_topic_keeps_verified_category_and_topic():


### PR DESCRIPTION
Treat missing discussion cache as unknown and leave cumulative stats/channels/posted_log unchanged. Verification: the real main() regression test plus completeness tests pass.