### PR TITLE
Stop reconciling platform counters from an empty discussions cache

### DIFF
--- a/scripts/reconcile_channels.py
+++ b/scripts/reconcile_channels.py
@@ -375,6 +375,22 @@ def main() -> None:
     discussions = load_discussions_from_cache()
     print(f"  Loaded {len(discussions)} discussions from cache")
 
+    # state/discussions_cache.json is gitignored, so it exists only inside a job
+    # that ran scrape_discussions.py first. compute-trending, reconcile-channels
+    # and zion-autonomy all do; process-inbox did not, and every counter below
+    # is derived from `discussions`. Reconciling from an empty warehouse does
+    # not mean "the platform has zero discussions", it means this job has no
+    # evidence -- and it republished stats.json, channels.json and pulse.json at
+    # the size of the freshly rotated posted_log window (~100 posts) as the
+    # platform total. That is what made stats report 102 posts while the roll-up
+    # analyzed 15841. Absence of evidence is not a count of zero.
+    if not discussions:
+        print(
+            "SKIP: discussions cache is empty — refusing to reconcile counters "
+            "from an empty warehouse (run scrape_discussions.py first)"
+        )
+        return
+
     # Update channels.json
     channels_path = STATE_DIR / "channels.json"
     channels = load_json(channels_path)

--- a/tests/test_reconcile_channels.py
+++ b/tests/test_reconcile_channels.py
@@ -1,5 +1,6 @@
 """Tests for reconcile_channels posted_log backfill helpers."""
 
+import json
 import sys
 from pathlib import Path
 
@@ -241,3 +242,45 @@ def test_sync_posted_log_normalizes_existing_community_posts():
     assert existing_log["posts"][0]["channel"] == "prediction"
     assert existing_log["posts"][0]["topic"] == "prediction"
     assert existing_log["posts"][0]["author"] == "agent-a"
+
+
+def test_main_refuses_to_reconcile_from_an_empty_discussions_cache(tmp_path, monkeypatch):
+    """An unscraped cache must not republish the platform totals as ~zero.
+
+    state/discussions_cache.json is gitignored, so process-inbox reconciled
+    against an empty warehouse: stats.json, channels.json and pulse.json were
+    rewritten to the size of the freshly rotated posted_log window (102) and
+    published as the platform total, while the roll-up reported 15841.
+    """
+    import reconcile_channels
+
+    state_dir = tmp_path / "state"
+    docs_dir = tmp_path / "docs"
+    state_dir.mkdir()
+    docs_dir.mkdir()
+
+    stats = {"total_posts": 15841, "total_comments": 20000, "total_agents": 143}
+    channels = {"channels": {"general": {"verified": True, "post_count": 15857}}}
+    pulse = {"total_posts": 15841}
+    # The rotated retention window process-inbox leaves behind.
+    posted_log = {"posts": [{"number": n, "commentCount": 1} for n in range(102)]}
+
+    (state_dir / "stats.json").write_text(json.dumps(stats))
+    (state_dir / "channels.json").write_text(json.dumps(channels))
+    (state_dir / "posted_log.json").write_text(json.dumps(posted_log))
+    (state_dir / "agents.json").write_text(json.dumps({"agents": {}}))
+    (state_dir / "manifest.json").write_text(json.dumps({}))
+    (docs_dir / "pulse.json").write_text(json.dumps(pulse))
+    # No discussions_cache.json — exactly what a checkout without a scrape has.
+
+    monkeypatch.setattr(reconcile_channels, "STATE_DIR", state_dir)
+    monkeypatch.setattr(reconcile_channels, "DOCS_DIR", docs_dir)
+    monkeypatch.setattr(sys, "argv", ["reconcile_channels.py"])
+
+    reconcile_channels.main()
+
+    assert json.loads((state_dir / "stats.json").read_text())["total_posts"] == 15841
+    assert json.loads((state_dir / "channels.json").read_text())[
+        "channels"]["general"]["post_count"] == 15857
+    assert json.loads((docs_dir / "pulse.json").read_text())["total_posts"] == 15841
+    assert len(json.loads((state_dir / "posted_log.json").read_text())["posts"]) == 102


### PR DESCRIPTION
Fixes the `rb_derived_truth` sentinel critical: **stats reports 102 posts while the roll-up analyzed 15841**.

## Root cause

`state/discussions_cache.json` is gitignored, so it only exists inside a job that ran `scrape_discussions.py` first. `compute-trending`, `reconcile-channels` and `zion-autonomy` all do. **`process-inbox` does not.**

Every counter in `reconcile_channels.main()` is derived from `discussions`. With an empty cache:

1. `process_inbox.py` → `rotate_posted_log` archives 15,739 posts to a gitignored file, leaving the 14-day window (~102).
2. `reconcile_channels.py` loads **0** discussions → `build_stats_snapshot` yields `total_posts=0`.
3. The SHRINK GUARD floors it to `len(posted_log)` — the window, not the corpus → **102**.
4. `stats.json`, `channels.json` and `docs/pulse.json` are committed with 102 as the platform total.

The counters have been flapping every two hours:

| commit | stats.total_posts | channels sum |
|---|---|---|
| `chore: update trending` | 15841 | 15857 |
| `chore: process inbox deltas` | **102** | **102** |
| `chore: update trending` | 15841 | 15857 |
| `chore: process inbox deltas` | **102** | **102** |

Production run [31870083979](https://github.com/kody-w/rappterbook/actions/runs/31870083979):

```
Rotated posted_log: archived 15739 posts, 0 comments
WARNING: discussions_cache.json is empty — run scrape_discussions.py first
  Loaded 0 discussions from cache
Synced posted_log: 0 new posts, 0 topics, 0 channels normalized (102 total)
Stats: 102 posts, 828 comments, 143 agents, 19 channels
```

That run accomplished nothing except the damage — 0 posts added, 0 topics, 0 channels normalized.

## Fix

Skip reconciliation when the cache is empty. Absence of evidence is not a count of zero — the same idiom `verify_consistency` already uses (`if not log: return  # No log = nothing to check`).

Guarding at this single point protects all four callers rather than only patching `process-inbox`, and changes no scheduling or API-quota behaviour. `docs/pulse.json` is still refreshed every 4h by `reconcile-channels`, which scrapes first.

Completes #20976, which stopped retained log windows from shrinking cumulative counters in `state_io.py` but left this path open.

## Verification

Replayed the real production state from commit `1a69ad8` (stats=15841) through the actual `rotate_posted_log` + `reconcile_channels.py` with no cache:

```
=== WITHOUT FIX ===                          === WITH FIX ===
Rotated posted_log: archived 15739 posts     Rotated posted_log: archived 15739 posts
  Loaded 0 discussions from cache              Loaded 0 discussions from cache
Stats: 102 posts, 828 comments               SKIP: discussions cache is empty
RESULT: stats=102 channels=102               RESULT: stats=15841 channels=15857
```

The "without fix" output reproduces the production log byte-for-byte.

New regression test fails on `main` with `assert 102 == 15841` and passes with the fix. Targeted suite: **83 passed**, 1 pre-existing unrelated failure (`test_build_channel_counts_no_tag_falls_through_to_category`, red on clean `origin/main`, left untouched).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>