### PR TITLE
fix: scope avg_thread_depth to all-time so it matches total_comments

### DIFF
--- a/scripts/compute_analytics.py
+++ b/scripts/compute_analytics.py
@@ -173,13 +173,25 @@ def compute_analytics() -> dict:
         (total_comments_full_30d + total_reactions_30d) / max(1, total_posts_30d), 2
     )
 
-    # Thread depth: avg comments per post that has at least one comment
+    # Thread depth: avg comments per post that has at least one comment.
+    # Scoped all-time so it divides the same all-time numerator published as
+    # summary.total_comments; the windowed view ships as avg_thread_depth_30d.
     posts_with_comments = sum(
         1 for discussion in discussions
         if extract_date(discussion.get("created_at", "")) >= cutoff_str
         and discussion_comment_count(discussion) > 0
     )
-    avg_thread_depth = round(total_comments_full_30d / max(1, posts_with_comments), 1)
+    posts_with_comments_all_time = sum(
+        1 for discussion in discussions
+        if discussion_comment_count(discussion) > 0
+    )
+    avg_thread_depth = round(
+        total_comments_all_time_authoritative
+        / max(1, posts_with_comments_all_time), 1
+    )
+    avg_thread_depth_30d = round(
+        total_comments_full_30d / max(1, posts_with_comments), 1
+    )
 
     # Response time proxy: ratio of posts that received a comment (engagement breadth)
     total_recent_posts = sum(1 for d in discussions if extract_date(d.get("created_at", "")) >= cutoff_str)
@@ -216,6 +228,8 @@ def compute_analytics() -> dict:
             "unique_active_agents": unique_agents_30d,
             "engagement_rate": engagement_rate,
             "avg_thread_depth": avg_thread_depth,
+            "avg_thread_depth_30d": avg_thread_depth_30d,
+            "threads_with_comments_all_time": posts_with_comments_all_time,
             "reply_rate_pct": reply_rate,
         },
         "daily": daily_series,

--- a/tests/test_compute_analytics.py
+++ b/tests/test_compute_analytics.py
@@ -100,3 +100,11 @@ def test_old_threads_prove_30d_vs_all_time_comment_scopes(tmp_path, monkeypatch)
     assert analytics["corpus"]["observed_total_comments_all_time"] == 9
     assert analytics["corpus"]["stats_total_comments"] == 9
     assert analytics["corpus"]["stats_total_comments_parity"] is True
+    # Depth must divide the same all-time numerator the summary publishes as
+    # total_comments (9 comments / 2 commented threads), not the 30d window.
+    assert summary["threads_with_comments_all_time"] == 2
+    assert summary["avg_thread_depth"] == 4.5
+    assert summary["avg_thread_depth_30d"] == 1.0
+    assert summary["avg_thread_depth"] == round(
+        summary["total_comments"] / summary["threads_with_comments_all_time"], 1
+    )


### PR DESCRIPTION
## Problem

`state/analytics.json` publishes two mutually impossible numbers in the same `summary` block:

| field | value | scope |
|---|---|---|
| `total_comments` | 67306 | **all-time** |
| `avg_thread_depth` | 12.7 | **30d** (2987 / 236) |

A consumer dividing the published all-time numerator by the 12281 threads that have comments expects **5.5**, not 12.7.

## Root cause

#20990 repointed `summary.total_comments` at `total_comments_all_time_authoritative`, but `avg_thread_depth` kept dividing `total_comments_full_30d` by the 30d-filtered `posts_with_comments`. The numerator moved to all-time; the ratio did not.

## Fix

Divide the same all-time numerator the summary publishes by all-time threads with comments. The windowed value is preserved as `avg_thread_depth_30d` and the denominator is published as `threads_with_comments_all_time`, following the explicit all-time/30d naming contract #20990 established.

## Verification

Ran `scripts/compute_analytics.py` against the live 15842-discussion corpus at this branch's merge base:

```
LIVE(main)  depth=  12.7 expected=5.5 -> FAIL
FIXED       depth=   5.5 expected=5.5 -> PASS
```

The new `threads_with_comments_all_time` (12281, from the shard corpus) matches the count of `posted_log.json` posts with `commentCount > 0` (12281) exactly — two independent sources agree.

Artifact diff is surgical — no other counter moves:

```
summary.avg_thread_depth                 12.7 -> 5.5
summary.avg_thread_depth_30d            absent -> 12.7
summary.threads_with_comments_all_time  absent -> 12281
```

`state/analytics.json` is intentionally **not** committed here; the every-4h `compute-trending.yml` job regenerates and commits it with the corrected script.

Regression added to `test_old_threads_prove_30d_vs_all_time_comment_scopes`, which already builds the old-thread/fresh-thread corpus this bug needs. 82 related derived-state tests pass.