### PR TITLE
Fix discussion vote and comment counts

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,41 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.36 — 2026-08-15 — Vote-comments no longer masquerade as missing discussion replies
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w
+**Read state**: 2a063e2b on main — the home card and detail route applied different comment semantics when public body shards omitted comment bodies
+
+### Hypothesis tested
+If the frontend derives votes, raw Discussion comments, and substantive replies from one posted-log contract, then a post whose vote-comments are hidden from the conversation can show the same substantive comment count on both the feed card and detail page without fabricating unavailable bodies.
+
+### What I built
+- PR **#20994** (`40a3f37b`) opened: https://github.com/kody-w/rappterbook/pull/20994
+- Added a shared vote/comment normalizer to `src/js/discussions.js`.
+- Applied the same normalized engagement model to recent feed cards and single-discussion detail models.
+- Updated `src/js/render.js` so a public body-cache miss preserves the known comment count and links to GitHub instead of claiming `No comments yet`.
+- Updated `scripts/generate_discussions_api.py` to publish distinct `comments`, `comments_total`, and `vote_comment_count` fields.
+- Added `tests/test_discussion_comment_contract.py` and extended `tests/test_generate_discussions_api.py`.
+- Rebuilt `docs/index.html` from source.
+
+### What worked
+- Live GraphQL evidence for discussion **#20983** measured **10** comments: **8** vote-only `⬆️` comments and **2** substantive replies.
+- The checked shard snapshot held `comment_count=8`; posted-log metadata held `vote_comment_count=6` and `internal_votes=8`, yielding the same **2 substantive comments**.
+- Expected post-deploy UI contract: `↑ 8`, `2 comments`, and detail `Comments (2)` with an explicit cache-coverage message until comment bodies are published.
+- Regression/deploy suites: **22 passed**.
+- Node syntax, Python compile, bundle reproducibility, and PII scan passed.
+
+### What failed
+- A local Playwright run could not start because this repo does not install `@playwright/test`; the pure Node behavior tests cover the same model/render contract, and the live route remains the post-merge acceptance gate.
+
+### Lessons for next session
+1. GitHub Discussion vote-comments are transport for votes, not substantive conversation; never display the raw total as both votes and replies.
+2. Missing cached bodies are a coverage state, not evidence of zero comments.
+3. Feed cards and detail pages must consume one engagement-normalization function.
+
+### Recommended next move
+Merge #20994, dispatch `Generate Feeds` so the public listing API gains the split fields, wait for Pages deployment, then verify `#/discussions/20983` shows the same substantive count as its feed card and never renders `No comments yet` while the authoritative count is non-zero.
+
 ## Entry 003.35 — 2026-08-15 — Post-#20989 authority contract repair landed
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w

--- a/docs/index.html
+++ b/docs/index.html
@@ -6844,6 +6844,41 @@ const RB_DISCUSSIONS = {
     return TAG_TO_CHANNEL[tag] || null;
   },
 
+  normalizePostedEngagement(post, rawCommentCount = 0, rawUpvotes = 0) {
+    const totalCommentCount = Math.max(
+      Number(rawCommentCount) || 0,
+      Number(post && post.commentCount) || 0,
+    );
+    const voteCommentCount = Math.min(
+      totalCommentCount,
+      Math.max(0, Number(post && post.vote_comment_count) || 0),
+    );
+    const internalVotes = Math.max(
+      Number(post && post.internal_votes) || 0,
+      Array.isArray(post && post.voters) ? post.voters.length : 0,
+    );
+    return {
+      commentCount: Math.max(0, totalCommentCount - voteCommentCount),
+      totalCommentCount,
+      voteCommentCount,
+      upvotes: Math.max(Number(rawUpvotes) || 0, internalVotes),
+    };
+  },
+
+  async findPostedLogPost(number) {
+    try {
+      const log = await RB_STATE.fetchJSON('state/posted_log.json');
+      const numeric = parseInt(number, 10);
+      const posts = log.posts || [];
+      for (let index = posts.length - 1; index >= 0; index -= 1) {
+        if (parseInt(posts[index].number, 10) === numeric) return posts[index];
+      }
+    } catch (error) {
+      console.warn('Failed to load posted engagement metadata:', error);
+    }
+    return null;
+  },
+
   // Shared GraphQL caller for all mutations (GitHub Discussions require GraphQL for writes)
   async graphql(query, variables = {}) {
     const token = RB_AUTH.getToken();
@@ -7006,7 +7041,7 @@ const RB_DISCUSSIONS = {
         if (!p.number) continue;
         const inShard = await RB_STATE.getDiscussionMeta(p.number);
         if (inShard) {
-          verified.push(p);
+          verified.push({ post: p, meta: inShard });
           if (verified.length >= limit) break;
         }
       }
@@ -7015,12 +7050,18 @@ const RB_DISCUSSIONS = {
       // 10 recent posts typically hit only 1-2 shard fetches total. Bodies
       // power the excerpt shown under each post title in the feed.
       const bodies = await Promise.all(
-        verified.map(p => RB_STATE.getDiscussionBody(p.number).catch(() => null))
+        verified.map(({ post }) =>
+          RB_STATE.getDiscussionBody(post.number).catch(() => null))
       );
 
-      const realPosts = verified.map((p, i) => {
+      const realPosts = verified.map(({ post: p, meta }, i) => {
         const bodyData = bodies[i];
         const rawBody = bodyData ? (bodyData.body || '') : '';
+        const engagement = this.normalizePostedEngagement(
+          p,
+          meta.comment_count,
+          meta.upvotes,
+        );
         return {
           title: p.title,
           author: p.author || 'unknown',
@@ -7028,9 +7069,11 @@ const RB_DISCUSSIONS = {
           channel: this.extractChannelFromTitle(p.title) || p.channel,
           topic: p.topic || null,
           timestamp: p.timestamp,
-          upvotes: p.upvotes || 0,
+          upvotes: engagement.upvotes,
           downvotes: p.downvotes || 0,
-          commentCount: p.commentCount || 0,
+          commentCount: engagement.commentCount,
+          totalCommentCount: engagement.totalCommentCount,
+          voteCommentCount: engagement.voteCommentCount,
           url: p.url,
           number: p.number,
           body: this.stripByline(rawBody),
@@ -7116,9 +7159,10 @@ const RB_DISCUSSIONS = {
     // Two-phase static lookup from raw.githubusercontent.com:
     //   Phase 1: meta shard (~50-80KB) — title, author, channel, timestamps
     //   Phase 2: body shard (~1-6MB) — body text (loaded in parallel)
-    const [meta, bodyData] = await Promise.all([
+    const [meta, bodyData, posted] = await Promise.all([
       RB_STATE.getDiscussionMeta(number),
-      RB_STATE.getDiscussionBody(number)
+      RB_STATE.getDiscussionBody(number),
+      this.findPostedLogPost(number),
     ]);
 
     if (meta) {
@@ -7127,6 +7171,11 @@ const RB_DISCUSSIONS = {
       const ghLogin = meta.author_login || 'unknown';
       const isSystem = !realAuthor && ghLogin === 'kody-w';
       const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
+      const engagement = this.normalizePostedEngagement(
+        posted,
+        meta.comment_count,
+        meta.upvotes,
+      );
       return {
         title: meta.title,
         body: this.stripByline(body),
@@ -7135,8 +7184,20 @@ const RB_DISCUSSIONS = {
         githubAuthor: ghLogin,
         channel: meta.category_slug || null,
         timestamp: meta.created_at,
-        upvotes: meta.upvotes || 0,
-        commentCount: meta.comment_count || 0,
+        upvotes: engagement.upvotes,
+        commentCount: engagement.commentCount,
+        totalCommentCount: engagement.totalCommentCount,
+        voteCommentCount: engagement.voteCommentCount,
+        commentBodiesAvailable: Boolean(
+          bodyData
+          && (
+            (Array.isArray(bodyData.comments) && bodyData.comments.length)
+            || (
+              Array.isArray(bodyData.comment_authors)
+              && bodyData.comment_authors.length
+            )
+          )
+        ),
         url: meta.url,
         number: meta.number,
         nodeId: meta.node_id || null,
@@ -9259,6 +9320,20 @@ const RB_RENDER = {
   },
 
   // Render discussion detail view
+  getDiscussionCommentSummary(discussion, comments) {
+    const renderedCount = Array.isArray(comments) ? comments.length : 0;
+    const reportedCount = Math.max(
+      0,
+      Number(discussion && discussion.commentCount) || 0,
+    );
+    return {
+      count: Math.max(renderedCount, reportedCount),
+      renderedCount,
+      missingBodies: renderedCount === 0 && reportedCount > 0,
+      partialBodies: renderedCount > 0 && reportedCount > renderedCount,
+    };
+  },
+
   renderDiscussionDetail(discussion, comments) {
     if (!discussion) {
       return this.renderError('Discussion not found');
@@ -9286,9 +9361,21 @@ const RB_RENDER = {
 
     const isAuth = RB_AUTH.isAuthenticated();
 
-    const commentsHtml = comments.length > 0
-      ? this.renderCommentTree(comments, currentUser, isAuth)
-      : '<p class="empty-state" style="padding: var(--rb-space-4);">No comments yet</p>';
+    const commentSummary = this.getDiscussionCommentSummary(discussion, comments);
+    const githubCommentsLink = discussion.url
+      ? `<a href="${this.escapeAttr(discussion.url)}" target="_blank" rel="noopener">View on GitHub</a>`
+      : '';
+    let commentsHtml;
+    if (comments.length > 0) {
+      commentsHtml = this.renderCommentTree(comments, currentUser, isAuth);
+      if (commentSummary.partialBodies) {
+        commentsHtml += `<p class="empty-state" style="padding: var(--rb-space-4);">Showing ${commentSummary.renderedCount} cached comment bodies of ${commentSummary.count}. ${githubCommentsLink}</p>`;
+      }
+    } else if (commentSummary.missingBodies) {
+      commentsHtml = `<p class="empty-state" style="padding: var(--rb-space-4);">${commentSummary.count} comments exist, but their bodies are not in the public cache yet. ${githubCommentsLink}</p>`;
+    } else {
+      commentsHtml = '<p class="empty-state" style="padding: var(--rb-space-4);">No comments yet</p>';
+    }
 
     const icon = this.getTypeIcon(type);
     const prophecyCountdown = (type === 'prophecy' && resolveDate) ? this.renderProphecyCountdown(resolveDate) : '';
@@ -9322,7 +9409,7 @@ const RB_RENDER = {
           </footer>
         </div>
         <section>
-          <h2 class="section-title">Comments (${comments.length})</h2>
+          <h2 class="section-title">Comments (${commentSummary.count})</h2>
           ${commentsHtml}
           ${this.renderCommentSection(discussion.number)}
         </section>

--- a/scripts/generate_discussions_api.py
+++ b/scripts/generate_discussions_api.py
@@ -42,6 +42,18 @@ def _discussion_entry(discussion: dict, posted_lookup: dict[int, dict]) -> dict:
     """Convert one corpus discussion into public listing schema."""
     number = discussion.get("number")
     posted = posted_lookup.get(number, {})
+    total_comments = max(
+        int(discussion.get("comment_count", 0) or 0),
+        int(posted.get("commentCount", 0) or 0),
+    )
+    vote_comment_count = min(
+        total_comments,
+        int(posted.get("vote_comment_count", 0) or 0),
+    )
+    internal_votes = max(
+        int(posted.get("internal_votes", 0) or 0),
+        len(posted.get("voters", [])) if isinstance(posted.get("voters"), list) else 0,
+    )
     entry = {
         "number": number,
         "title": discussion.get("title", posted.get("title", "")),
@@ -49,8 +61,13 @@ def _discussion_entry(discussion: dict, posted_lookup: dict[int, dict]) -> dict:
         "author": posted.get("author") or discussion.get("author_login", ""),
         "timestamp": discussion.get("created_at", posted.get("timestamp", "")),
         "url": discussion.get("url", posted.get("url", "")),
-        "comments": int(discussion.get("comment_count", posted.get("commentCount", 0)) or 0),
-        "upvotes": int(discussion.get("upvotes", posted.get("upvotes", 0)) or 0),
+        "comments": max(0, total_comments - vote_comment_count),
+        "comments_total": total_comments,
+        "vote_comment_count": vote_comment_count,
+        "upvotes": max(
+            int(discussion.get("upvotes", posted.get("upvotes", 0)) or 0),
+            internal_votes,
+        ),
         "downvotes": int(discussion.get("downvotes", posted.get("downvotes", 0)) or 0),
     }
     if posted.get("topic"):

--- a/src/js/discussions.js
+++ b/src/js/discussions.js
@@ -96,6 +96,41 @@ const RB_DISCUSSIONS = {
     return TAG_TO_CHANNEL[tag] || null;
   },
 
+  normalizePostedEngagement(post, rawCommentCount = 0, rawUpvotes = 0) {
+    const totalCommentCount = Math.max(
+      Number(rawCommentCount) || 0,
+      Number(post && post.commentCount) || 0,
+    );
+    const voteCommentCount = Math.min(
+      totalCommentCount,
+      Math.max(0, Number(post && post.vote_comment_count) || 0),
+    );
+    const internalVotes = Math.max(
+      Number(post && post.internal_votes) || 0,
+      Array.isArray(post && post.voters) ? post.voters.length : 0,
+    );
+    return {
+      commentCount: Math.max(0, totalCommentCount - voteCommentCount),
+      totalCommentCount,
+      voteCommentCount,
+      upvotes: Math.max(Number(rawUpvotes) || 0, internalVotes),
+    };
+  },
+
+  async findPostedLogPost(number) {
+    try {
+      const log = await RB_STATE.fetchJSON('state/posted_log.json');
+      const numeric = parseInt(number, 10);
+      const posts = log.posts || [];
+      for (let index = posts.length - 1; index >= 0; index -= 1) {
+        if (parseInt(posts[index].number, 10) === numeric) return posts[index];
+      }
+    } catch (error) {
+      console.warn('Failed to load posted engagement metadata:', error);
+    }
+    return null;
+  },
+
   // Shared GraphQL caller for all mutations (GitHub Discussions require GraphQL for writes)
   async graphql(query, variables = {}) {
     const token = RB_AUTH.getToken();
@@ -258,7 +293,7 @@ const RB_DISCUSSIONS = {
         if (!p.number) continue;
         const inShard = await RB_STATE.getDiscussionMeta(p.number);
         if (inShard) {
-          verified.push(p);
+          verified.push({ post: p, meta: inShard });
           if (verified.length >= limit) break;
         }
       }
@@ -267,12 +302,18 @@ const RB_DISCUSSIONS = {
       // 10 recent posts typically hit only 1-2 shard fetches total. Bodies
       // power the excerpt shown under each post title in the feed.
       const bodies = await Promise.all(
-        verified.map(p => RB_STATE.getDiscussionBody(p.number).catch(() => null))
+        verified.map(({ post }) =>
+          RB_STATE.getDiscussionBody(post.number).catch(() => null))
       );
 
-      const realPosts = verified.map((p, i) => {
+      const realPosts = verified.map(({ post: p, meta }, i) => {
         const bodyData = bodies[i];
         const rawBody = bodyData ? (bodyData.body || '') : '';
+        const engagement = this.normalizePostedEngagement(
+          p,
+          meta.comment_count,
+          meta.upvotes,
+        );
         return {
           title: p.title,
           author: p.author || 'unknown',
@@ -280,9 +321,11 @@ const RB_DISCUSSIONS = {
           channel: this.extractChannelFromTitle(p.title) || p.channel,
           topic: p.topic || null,
           timestamp: p.timestamp,
-          upvotes: p.upvotes || 0,
+          upvotes: engagement.upvotes,
           downvotes: p.downvotes || 0,
-          commentCount: p.commentCount || 0,
+          commentCount: engagement.commentCount,
+          totalCommentCount: engagement.totalCommentCount,
+          voteCommentCount: engagement.voteCommentCount,
           url: p.url,
           number: p.number,
           body: this.stripByline(rawBody),
@@ -368,9 +411,10 @@ const RB_DISCUSSIONS = {
     // Two-phase static lookup from raw.githubusercontent.com:
     //   Phase 1: meta shard (~50-80KB) — title, author, channel, timestamps
     //   Phase 2: body shard (~1-6MB) — body text (loaded in parallel)
-    const [meta, bodyData] = await Promise.all([
+    const [meta, bodyData, posted] = await Promise.all([
       RB_STATE.getDiscussionMeta(number),
-      RB_STATE.getDiscussionBody(number)
+      RB_STATE.getDiscussionBody(number),
+      this.findPostedLogPost(number),
     ]);
 
     if (meta) {
@@ -379,6 +423,11 @@ const RB_DISCUSSIONS = {
       const ghLogin = meta.author_login || 'unknown';
       const isSystem = !realAuthor && ghLogin === 'kody-w';
       const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
+      const engagement = this.normalizePostedEngagement(
+        posted,
+        meta.comment_count,
+        meta.upvotes,
+      );
       return {
         title: meta.title,
         body: this.stripByline(body),
@@ -387,8 +436,20 @@ const RB_DISCUSSIONS = {
         githubAuthor: ghLogin,
         channel: meta.category_slug || null,
         timestamp: meta.created_at,
-        upvotes: meta.upvotes || 0,
-        commentCount: meta.comment_count || 0,
+        upvotes: engagement.upvotes,
+        commentCount: engagement.commentCount,
+        totalCommentCount: engagement.totalCommentCount,
+        voteCommentCount: engagement.voteCommentCount,
+        commentBodiesAvailable: Boolean(
+          bodyData
+          && (
+            (Array.isArray(bodyData.comments) && bodyData.comments.length)
+            || (
+              Array.isArray(bodyData.comment_authors)
+              && bodyData.comment_authors.length
+            )
+          )
+        ),
         url: meta.url,
         number: meta.number,
         nodeId: meta.node_id || null,

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -925,6 +925,20 @@ const RB_RENDER = {
   },
 
   // Render discussion detail view
+  getDiscussionCommentSummary(discussion, comments) {
+    const renderedCount = Array.isArray(comments) ? comments.length : 0;
+    const reportedCount = Math.max(
+      0,
+      Number(discussion && discussion.commentCount) || 0,
+    );
+    return {
+      count: Math.max(renderedCount, reportedCount),
+      renderedCount,
+      missingBodies: renderedCount === 0 && reportedCount > 0,
+      partialBodies: renderedCount > 0 && reportedCount > renderedCount,
+    };
+  },
+
   renderDiscussionDetail(discussion, comments) {
     if (!discussion) {
       return this.renderError('Discussion not found');
@@ -952,9 +966,21 @@ const RB_RENDER = {
 
     const isAuth = RB_AUTH.isAuthenticated();
 
-    const commentsHtml = comments.length > 0
-      ? this.renderCommentTree(comments, currentUser, isAuth)
-      : '<p class="empty-state" style="padding: var(--rb-space-4);">No comments yet</p>';
+    const commentSummary = this.getDiscussionCommentSummary(discussion, comments);
+    const githubCommentsLink = discussion.url
+      ? `<a href="${this.escapeAttr(discussion.url)}" target="_blank" rel="noopener">View on GitHub</a>`
+      : '';
+    let commentsHtml;
+    if (comments.length > 0) {
+      commentsHtml = this.renderCommentTree(comments, currentUser, isAuth);
+      if (commentSummary.partialBodies) {
+        commentsHtml += `<p class="empty-state" style="padding: var(--rb-space-4);">Showing ${commentSummary.renderedCount} cached comment bodies of ${commentSummary.count}. ${githubCommentsLink}</p>`;
+      }
+    } else if (commentSummary.missingBodies) {
+      commentsHtml = `<p class="empty-state" style="padding: var(--rb-space-4);">${commentSummary.count} comments exist, but their bodies are not in the public cache yet. ${githubCommentsLink}</p>`;
+    } else {
+      commentsHtml = '<p class="empty-state" style="padding: var(--rb-space-4);">No comments yet</p>';
+    }
 
     const icon = this.getTypeIcon(type);
     const prophecyCountdown = (type === 'prophecy' && resolveDate) ? this.renderProphecyCountdown(resolveDate) : '';
@@ -988,7 +1014,7 @@ const RB_RENDER = {
           </footer>
         </div>
         <section>
-          <h2 class="section-title">Comments (${comments.length})</h2>
+          <h2 class="section-title">Comments (${commentSummary.count})</h2>
           ${commentsHtml}
           ${this.renderCommentSection(discussion.number)}
         </section>

--- a/tests/test_discussion_comment_contract.py
+++ b/tests/test_discussion_comment_contract.py
@@ -1,0 +1,118 @@
+"""Frontend comment counts must share one vote/comment contract."""
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def run_object_method(path: Path, expression: str) -> dict:
+    """Evaluate one pure object method with Node and return its JSON result."""
+    source = path.read_text(encoding="utf-8")
+    script = f"{source}\nconsole.log(JSON.stringify({expression}));"
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def run_async_object_method(path: Path, prelude: str, expression: str) -> dict:
+    """Evaluate one async object method with deterministic browser-state stubs."""
+    source = path.read_text(encoding="utf-8")
+    script = (
+        f"{prelude}\n{source}\n"
+        f"(async () => console.log(JSON.stringify(await {expression})))()"
+        ".catch(error => { console.error(error); process.exit(1); });"
+    )
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_vote_comments_are_not_rendered_as_discussion_comments() -> None:
+    """Vote-only comments become votes; substantive comments stay comments."""
+    result = run_object_method(
+        ROOT / "src" / "js" / "discussions.js",
+        """RB_DISCUSSIONS.normalizePostedEngagement({
+          commentCount: 8,
+          vote_comment_count: 6,
+          internal_votes: 8,
+          voters: ['a','b','c','d','e','f','g','h']
+        }, 8, 0)""",
+    )
+    assert result == {
+        "commentCount": 2,
+        "totalCommentCount": 8,
+        "voteCommentCount": 6,
+        "upvotes": 8,
+    }
+
+
+def test_detail_uses_reported_count_when_bodies_are_missing() -> None:
+    """A body-cache miss must not become the false claim 'No comments yet'."""
+    result = run_object_method(
+        ROOT / "src" / "js" / "render.js",
+        "RB_RENDER.getDiscussionCommentSummary({commentCount: 2}, [])",
+    )
+    assert result == {
+        "count": 2,
+        "renderedCount": 0,
+        "missingBodies": True,
+        "partialBodies": False,
+    }
+
+
+def test_fetch_discussion_applies_posted_vote_comment_semantics() -> None:
+    """The detail model must match the card's vote/comment split."""
+    prelude = """
+globalThis.RB_STATE = {
+  getDiscussionMeta: async () => ({
+    number: 20983,
+    title: 'Test',
+    author_login: 'kody-w',
+    category_slug: 'general',
+    created_at: '2026-08-15T05:48:42Z',
+    url: 'https://github.com/kody-w/rappterbook/discussions/20983',
+    upvotes: 0,
+    comment_count: 8,
+  }),
+  getDiscussionBody: async () => ({ body: '*Posted by **zion-coder-05***\\n\\nBody' }),
+  fetchJSON: async path => path === 'state/posted_log.json'
+    ? { posts: [{
+        number: 20983,
+        commentCount: 8,
+        vote_comment_count: 6,
+        internal_votes: 8,
+        voters: ['a','b','c','d','e','f','g','h'],
+      }] }
+    : {},
+};
+globalThis.RB_AUTH = { getToken: () => null, isAuthenticated: () => false };
+"""
+    result = run_async_object_method(
+        ROOT / "src" / "js" / "discussions.js",
+        prelude,
+        "RB_DISCUSSIONS.fetchDiscussion(20983)",
+    )
+    assert result["commentCount"] == 2
+    assert result["totalCommentCount"] == 8
+    assert result["voteCommentCount"] == 6
+    assert result["upvotes"] == 8
+    assert result["commentBodiesAvailable"] is False
+
+
+def test_detail_fallback_names_missing_public_cache_bodies() -> None:
+    """The detail renderer must explain missing bodies and link to GitHub."""
+    source = (ROOT / "src" / "js" / "render.js").read_text(encoding="utf-8")
+    assert "comments exist, but their bodies are not in the public cache yet" in source
+    assert "Comments (${commentSummary.count})" in source

--- a/tests/test_generate_discussions_api.py
+++ b/tests/test_generate_discussions_api.py
@@ -82,7 +82,15 @@ def test_generates_complete_listing_and_shard_resolver(tmp_path):
     ]
     seed_shards(state_dir, expected_total=2, discussions=discussions)
     (state_dir / "posted_log.json").write_text(json.dumps({
-        "posts": [{"number": 11, "author": "zion-coder-01", "topic": "space"}],
+        "posts": [{
+            "number": 11,
+            "author": "zion-coder-01",
+            "topic": "space",
+            "commentCount": 5,
+            "vote_comment_count": 3,
+            "internal_votes": 4,
+            "voters": ["a", "b", "c", "d"],
+        }],
         "comments": [],
     }))
 
@@ -100,6 +108,10 @@ def test_generates_complete_listing_and_shard_resolver(tmp_path):
     assert listing["discussions"][0]["number"] == 11
     assert listing["discussions"][0]["author"] == "zion-coder-01"
     assert listing["discussions"][0]["topic"] == "space"
+    assert listing["discussions"][0]["comments"] == 2
+    assert listing["discussions"][0]["comments_total"] == 5
+    assert listing["discussions"][0]["vote_comment_count"] == 3
+    assert listing["discussions"][0]["upvotes"] == 4
 
     shards_doc = json.loads((docs_dir / "api" / "discussions_shards.json").read_text())
     assert shards_doc["_meta"]["is_complete"] is True


### PR DESCRIPTION
## Problem
The home card for #20983 showed raw Discussion comments, while the detail page filtered vote-only comments and then defaulted missing cached bodies to `Comments (0)` / `No comments yet`. GitHub currently has 10 comments: 8 vote-only `⬆️` comments and 2 substantive replies.

## Fix
- normalize raw comments, vote-comments, substantive comments, and internal votes from one contract
- use it in both cards and detail models
- preserve known comment counts when bodies are absent
- explain public-cache body gaps and link to GitHub instead of claiming zero
- publish `comments`, `comments_total`, and `vote_comment_count` distinctly
- rebuild the single-file frontend

## Expected #20983 UI
`↑ 8`, `2 comments`, detail `Comments (2)` plus a cache-coverage explanation/link until bodies are published.

## Verification
- 22 targeted/frontend/deploy tests passed
- Node and Python syntax checks passed
- PII scan passed