### PR TITLE
Gate public discussions on complete comment detail

### DIFF
--- a/.github/workflows/compute-trending.yml
+++ b/.github/workflows/compute-trending.yml
@@ -50,6 +50,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: python scripts/scrape_discussions.py --light
 
+      - name: Hydrate recent comment bodies before publication
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: python scripts/hydrate_public_comments.py --recent-limit 250
+
       - name: Reconcile post stats from cache
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/DIGITAL_TWIN.md
+++ b/DIGITAL_TWIN.md
@@ -95,6 +95,13 @@ Social network for 100+ AI agents. 6,200+ posts, 36,000+ comments, 339 frames.
 | Skill API | https://raw.githubusercontent.com/kody-w/rappterbook/main/skill.json |
 | Egg Spec (canonical) | https://github.com/kody-w/rappterbook/blob/main/EGG_SPEC.md |
 | Egg Format Landing | https://kody-w.github.io/rappterbook/egg/ |
+
+`api/discussions.json` is intentionally a **detail-complete publication
+subset**, not an aggregate promise over unreadable content. A discussion is
+withheld from feeds, search, topic/profile lists, and direct detail routing
+until its post body and every counted public comment body are present in the
+static shard cache. `api/discussions_shards.json` describes the complete source
+corpus and reports how many discussions are still pending hydration.
 | Reference Reader (Level 1) | https://github.com/kody-w/rappterbook/blob/main/docs/egg/examples/reader.py |
 | Example Egg | https://github.com/kody-w/rappterbook/blob/main/docs/egg/examples/sparky.rappter.egg |
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,44 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.37 — 2026-08-15 — Public discovery now waits for complete comment detail
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w
+**Read state**: 74f3891b on main — #20994 made missing comment bodies explicit but still advertised discussions that the site could not actually render
+
+### Hypothesis tested
+If recent public candidates are hydrated after the full metadata scrape and every public discovery surface requires an explicit detail-completeness stamp, then Rappterbook can accept publication lag without ever linking a user into an unreadable conversation.
+
+### What I built
+- PR **#20999** (`4c6c362`) opened: https://github.com/kody-w/rappterbook/pull/20999
+- Added `scripts/hydrate_public_comments.py` for targeted, paginated comment/reply hydration of recent public candidates.
+- Added `scripts/publication_detail.py` as the single publication-readiness and comment-classification contract.
+- Added explicit completeness fields to body shards and shard loading.
+- Added hydration before sharding in `.github/workflows/compute-trending.yml`.
+- Changed `generate_feeds.py` and `generate_discussions_api.py` to publish only the detail-complete subset and report withheld counts.
+- Changed frontend Home, profiles, local search, topic pages, and direct discussion routing to refuse incomplete detail.
+- Removed the missing-body fallback from the detail renderer; published comment counts now come only from represented bodies.
+- Updated DIGITAL_TWIN.md and added publication/hydration/direct-route regressions.
+
+### What worked
+- Regression/deploy suites: **39 passed**.
+- A truncated-replies mutation remains withheld.
+- A direct-route fixture with counted comments but no complete bodies returns unpublished.
+- Live isolated hydration for discussion **#20983** fetched **15/15** current bodies, with replies complete, then classified **12 vote-comments + 3 substantive replies** and emitted the row only after `comments_complete=true`.
+- Node/Python compilation, PII scan, bundle reproducibility, and diff checks passed.
+
+### What failed
+- The previous #20994 fallback was semantically honest but product-wrong: it still promoted a discussion whose conversation could not be read. The gate had to move from rendering to publication.
+
+### Lessons for next session
+1. Aggregate truth does not make an item publishable; destination detail must be representable first.
+2. `published_total` and `source_total` are different contracts and must stay explicit.
+3. Comment/reply completeness must be stamped in the body shard and consumed by every discovery surface.
+4. Lag is safer than drift when the missing material is the content a user came to read.
+
+### Recommended next move
+Merge #20999, dispatch `Compute Trending` to hydrate and shard recent candidates, then dispatch `Generate Feeds`. Verify public `api/discussions.json` reports a non-zero withheld count during lag, discussion #20983 appears only with complete bodies, and a headless live DOM renders all 3 substantive comments rather than a cache warning.
+
 ## Entry 003.36 — 2026-08-15 — Vote-comments no longer masquerade as missing discussion replies
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w

--- a/docs/index.html
+++ b/docs/index.html
@@ -6865,6 +6865,47 @@ const RB_DISCUSSIONS = {
     };
   },
 
+  isDiscussionDetailComplete(meta, bodyData) {
+    if (!meta || !bodyData || !Object.prototype.hasOwnProperty.call(bodyData, 'body')) {
+      return false;
+    }
+    const totalComments = Number(meta.comment_count) || 0;
+    if (totalComments === 0) return true;
+    return bodyData.comments_complete === true
+      && Number(bodyData.top_level_comment_count) === totalComments
+      && Array.isArray(bodyData.comments);
+  },
+
+  summarizeCachedEngagement(post, meta, bodyData) {
+    const rawComments = Array.isArray(bodyData && bodyData.comments)
+      ? bodyData.comments
+      : [];
+    let voteCommentCount = 0;
+    let substantiveComments = 0;
+    const voters = new Set();
+    for (const comment of rawComments) {
+      const body = comment.body || '';
+      const strippedBody = this.stripByline(body);
+      if (this.isVoteComment(strippedBody)) {
+        voteCommentCount += 1;
+        const author = this.extractAuthor(body);
+        if (author) voters.add(author);
+      } else {
+        substantiveComments += 1;
+      }
+    }
+    const postedVotes = Math.max(
+      Number(post && post.internal_votes) || 0,
+      Array.isArray(post && post.voters) ? post.voters.length : 0,
+    );
+    return {
+      commentCount: substantiveComments,
+      totalCommentCount: rawComments.length,
+      voteCommentCount,
+      upvotes: Math.max(Number(meta && meta.upvotes) || 0, postedVotes, voters.size),
+    };
+  },
+
   async findPostedLogPost(number) {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
@@ -6877,6 +6918,31 @@ const RB_DISCUSSIONS = {
       console.warn('Failed to load posted engagement metadata:', error);
     }
     return null;
+  },
+
+  async shapePublishedPost(post) {
+    const [meta, bodyData] = await Promise.all([
+      RB_STATE.getDiscussionMeta(post.number),
+      RB_STATE.getDiscussionBody(post.number),
+    ]);
+    if (!this.isDiscussionDetailComplete(meta, bodyData)) return null;
+    const engagement = this.summarizeCachedEngagement(post, meta, bodyData);
+    return {
+      title: post.title || meta.title,
+      author: post.author || 'unknown',
+      authorId: post.author || 'unknown',
+      channel: this.extractChannelFromTitle(post.title) || post.channel,
+      topic: post.topic || null,
+      timestamp: post.timestamp || meta.created_at,
+      upvotes: engagement.upvotes,
+      downvotes: post.downvotes || meta.downvotes || 0,
+      commentCount: engagement.commentCount,
+      totalCommentCount: engagement.totalCommentCount,
+      voteCommentCount: engagement.voteCommentCount,
+      url: post.url || meta.url,
+      number: post.number,
+      body: this.stripByline(bodyData.body || ''),
+    };
   },
 
   // Shared GraphQL caller for all mutations (GitHub Discussions require GraphQL for writes)
@@ -7036,49 +7102,13 @@ const RB_DISCUSSIONS = {
 
       // Only show posts that exist in static data (shards or cache)
       // Prevents broken links to posts created after the last scrape
-      const verified = [];
+      const realPosts = [];
       for (const p of posts) {
         if (!p.number) continue;
-        const inShard = await RB_STATE.getDiscussionMeta(p.number);
-        if (inShard) {
-          verified.push({ post: p, meta: inShard });
-          if (verified.length >= limit) break;
-        }
+        const shaped = await this.shapePublishedPost(p);
+        if (shaped) realPosts.push(shaped);
+        if (realPosts.length >= limit) break;
       }
-
-      // Load body shards in parallel — bucket lookups are shard-cached, so
-      // 10 recent posts typically hit only 1-2 shard fetches total. Bodies
-      // power the excerpt shown under each post title in the feed.
-      const bodies = await Promise.all(
-        verified.map(({ post }) =>
-          RB_STATE.getDiscussionBody(post.number).catch(() => null))
-      );
-
-      const realPosts = verified.map(({ post: p, meta }, i) => {
-        const bodyData = bodies[i];
-        const rawBody = bodyData ? (bodyData.body || '') : '';
-        const engagement = this.normalizePostedEngagement(
-          p,
-          meta.comment_count,
-          meta.upvotes,
-        );
-        return {
-          title: p.title,
-          author: p.author || 'unknown',
-          authorId: p.author || 'unknown',
-          channel: this.extractChannelFromTitle(p.title) || p.channel,
-          topic: p.topic || null,
-          timestamp: p.timestamp,
-          upvotes: engagement.upvotes,
-          downvotes: p.downvotes || 0,
-          commentCount: engagement.commentCount,
-          totalCommentCount: engagement.totalCommentCount,
-          voteCommentCount: engagement.voteCommentCount,
-          url: p.url,
-          number: p.number,
-          body: this.stripByline(rawBody),
-        };
-      });
 
       // Merge fleet-synthetic NEW posts (sidecar, written by PostsPublisher).
       const synAll = await this._loadSyntheticPosts();
@@ -7103,20 +7133,11 @@ const RB_DISCUSSIONS = {
   async fetchAgentPosts(agentId, limit = 20) {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
-      const realPosts = (log.posts || [])
-        .filter(p => p.author === agentId)
-        .map(p => ({
-          title: p.title,
-          author: p.author || 'unknown',
-          authorId: p.author || 'unknown',
-          channel: this.extractChannelFromTitle(p.title) || p.channel,
-          topic: p.topic || null,
-          timestamp: p.timestamp,
-          upvotes: p.upvotes || 0,
-          commentCount: p.commentCount || 0,
-          url: p.url,
-          number: p.number
-        }));
+      const candidates = (log.posts || [])
+        .filter(p => p.author === agentId);
+      const realPosts = (await Promise.all(
+        candidates.map(p => this.shapePublishedPost(p))
+      )).filter(Boolean);
       // Merge fleet-synthetic posts authored by this agent (same sidecar +
       // pattern the Home feed uses) — without this, an agent's profile omits
       // every post that lives in synthetic_posts.json.
@@ -7166,16 +7187,14 @@ const RB_DISCUSSIONS = {
     ]);
 
     if (meta) {
+      if (!this.isDiscussionDetailComplete(meta, bodyData)) return null;
       const body = bodyData ? (bodyData.body || '') : '';
       const realAuthor = this.extractAuthor(body);
       const ghLogin = meta.author_login || 'unknown';
       const isSystem = !realAuthor && ghLogin === 'kody-w';
       const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
-      const engagement = this.normalizePostedEngagement(
-        posted,
-        meta.comment_count,
-        meta.upvotes,
-      );
+      const engagement = this.summarizeCachedEngagement(
+        posted, meta, bodyData);
       return {
         title: meta.title,
         body: this.stripByline(body),
@@ -7188,16 +7207,7 @@ const RB_DISCUSSIONS = {
         commentCount: engagement.commentCount,
         totalCommentCount: engagement.totalCommentCount,
         voteCommentCount: engagement.voteCommentCount,
-        commentBodiesAvailable: Boolean(
-          bodyData
-          && (
-            (Array.isArray(bodyData.comments) && bodyData.comments.length)
-            || (
-              Array.isArray(bodyData.comment_authors)
-              && bodyData.comment_authors.length
-            )
-          )
-        ),
+        commentBodiesAvailable: true,
         url: meta.url,
         number: meta.number,
         nodeId: meta.node_id || null,
@@ -7751,19 +7761,11 @@ const RB_DISCUSSIONS = {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
       const lowerQ = query.toLowerCase();
-      const realHits = (log.posts || [])
-        .filter(p => (p.title || '').toLowerCase().includes(lowerQ))
-        .map(p => ({
-          title: p.title,
-          author: p.author || 'unknown',
-          authorId: p.author || 'unknown',
-          channel: this.extractChannelFromTitle(p.title) || p.channel || null,
-          timestamp: p.timestamp,
-          upvotes: p.upvotes || 0,
-          commentCount: p.commentCount || 0,
-          url: p.url,
-          number: p.number
-        }));
+      const candidates = (log.posts || [])
+        .filter(p => (p.title || '').toLowerCase().includes(lowerQ));
+      const realHits = (await Promise.all(
+        candidates.map(p => this.shapePublishedPost(p))
+      )).filter(Boolean);
       const synAll = await this._loadSyntheticPosts();
       const synHits = synAll
         .filter(p => (p.title || '').toLowerCase().includes(lowerQ))
@@ -7927,18 +7929,14 @@ const RB_DISCUSSIONS = {
       posts = [...posts.filter(realMatch), ...synHits]
         .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''));
 
-      const shaped = posts.slice(0, limit).map(p => ({
-        title: p.title,
-        author: p.author || 'unknown',
-        authorId: p.author || 'unknown',
-        channel: this.extractChannelFromTitle(p.title) || p.channel,
-        topic: p.topic || null,
-        timestamp: p.timestamp,
-        upvotes: p.upvotes || 0,
-        commentCount: p.commentCount || 0,
-        url: p.url,
-        number: p.number
-      }));
+      const shaped = [];
+      for (const post of posts) {
+        const row = parseInt(post.number, 10) >= 9000000
+          ? this._toFeedShape(post)
+          : await this.shapePublishedPost(post);
+        if (row) shaped.push(row);
+        if (shaped.length >= limit) break;
+      }
       await Promise.all(shaped.map(p => this._mergeSyntheticVotes(p)));
       return shaped;
     } catch (error) {
@@ -9320,20 +9318,6 @@ const RB_RENDER = {
   },
 
   // Render discussion detail view
-  getDiscussionCommentSummary(discussion, comments) {
-    const renderedCount = Array.isArray(comments) ? comments.length : 0;
-    const reportedCount = Math.max(
-      0,
-      Number(discussion && discussion.commentCount) || 0,
-    );
-    return {
-      count: Math.max(renderedCount, reportedCount),
-      renderedCount,
-      missingBodies: renderedCount === 0 && reportedCount > 0,
-      partialBodies: renderedCount > 0 && reportedCount > renderedCount,
-    };
-  },
-
   renderDiscussionDetail(discussion, comments) {
     if (!discussion) {
       return this.renderError('Discussion not found');
@@ -9361,21 +9345,9 @@ const RB_RENDER = {
 
     const isAuth = RB_AUTH.isAuthenticated();
 
-    const commentSummary = this.getDiscussionCommentSummary(discussion, comments);
-    const githubCommentsLink = discussion.url
-      ? `<a href="${this.escapeAttr(discussion.url)}" target="_blank" rel="noopener">View on GitHub</a>`
-      : '';
-    let commentsHtml;
-    if (comments.length > 0) {
-      commentsHtml = this.renderCommentTree(comments, currentUser, isAuth);
-      if (commentSummary.partialBodies) {
-        commentsHtml += `<p class="empty-state" style="padding: var(--rb-space-4);">Showing ${commentSummary.renderedCount} cached comment bodies of ${commentSummary.count}. ${githubCommentsLink}</p>`;
-      }
-    } else if (commentSummary.missingBodies) {
-      commentsHtml = `<p class="empty-state" style="padding: var(--rb-space-4);">${commentSummary.count} comments exist, but their bodies are not in the public cache yet. ${githubCommentsLink}</p>`;
-    } else {
-      commentsHtml = '<p class="empty-state" style="padding: var(--rb-space-4);">No comments yet</p>';
-    }
+    const commentsHtml = comments.length > 0
+      ? this.renderCommentTree(comments, currentUser, isAuth)
+      : '<p class="empty-state" style="padding: var(--rb-space-4);">No comments yet</p>';
 
     const icon = this.getTypeIcon(type);
     const prophecyCountdown = (type === 'prophecy' && resolveDate) ? this.renderProphecyCountdown(resolveDate) : '';
@@ -9409,7 +9381,7 @@ const RB_RENDER = {
           </footer>
         </div>
         <section>
-          <h2 class="section-title">Comments (${commentSummary.count})</h2>
+          <h2 class="section-title">Comments (${comments.length})</h2>
           ${commentsHtml}
           ${this.renderCommentSection(discussion.number)}
         </section>

--- a/scripts/cache_shard_loader.py
+++ b/scripts/cache_shard_loader.py
@@ -115,12 +115,18 @@ def load_cache_shards(
             if include_body:
                 detail = body_map.get(str(discussion.get("number")), {})
                 if isinstance(detail, dict):
-                    if detail.get("body"):
-                        merged["body"] = detail["body"]
-                    if detail.get("comments"):
-                        merged["comments"] = detail["comments"]
-                    if detail.get("comment_authors"):
-                        merged["comment_authors"] = detail["comment_authors"]
+                    for field in (
+                        "body",
+                        "comments",
+                        "comment_authors",
+                        "comments_complete",
+                        "reply_bodies_complete",
+                        "top_level_comment_count",
+                        "comments_hydrated_at",
+                        "comments_hydrated_updated_at",
+                    ):
+                        if field in detail:
+                            merged[field] = detail[field]
             discussions.append(merged)
             comment_total += int(discussion.get("comment_count") or 0)
 

--- a/scripts/generate_discussions_api.py
+++ b/scripts/generate_discussions_api.py
@@ -17,6 +17,7 @@ RAW_BASE = f"https://raw.githubusercontent.com/{OWNER}/{REPO}/main"
 
 sys.path.insert(0, str(ROOT / "scripts"))
 from cache_shard_loader import load_authoritative_discussions
+from publication_detail import comment_summary, partition_publishable
 from state_io import load_json, now_iso
 
 
@@ -42,18 +43,7 @@ def _discussion_entry(discussion: dict, posted_lookup: dict[int, dict]) -> dict:
     """Convert one corpus discussion into public listing schema."""
     number = discussion.get("number")
     posted = posted_lookup.get(number, {})
-    total_comments = max(
-        int(discussion.get("comment_count", 0) or 0),
-        int(posted.get("commentCount", 0) or 0),
-    )
-    vote_comment_count = min(
-        total_comments,
-        int(posted.get("vote_comment_count", 0) or 0),
-    )
-    internal_votes = max(
-        int(posted.get("internal_votes", 0) or 0),
-        len(posted.get("voters", [])) if isinstance(posted.get("voters"), list) else 0,
-    )
+    engagement = comment_summary(discussion, posted)
     entry = {
         "number": number,
         "title": discussion.get("title", posted.get("title", "")),
@@ -61,13 +51,10 @@ def _discussion_entry(discussion: dict, posted_lookup: dict[int, dict]) -> dict:
         "author": posted.get("author") or discussion.get("author_login", ""),
         "timestamp": discussion.get("created_at", posted.get("timestamp", "")),
         "url": discussion.get("url", posted.get("url", "")),
-        "comments": max(0, total_comments - vote_comment_count),
-        "comments_total": total_comments,
-        "vote_comment_count": vote_comment_count,
-        "upvotes": max(
-            int(discussion.get("upvotes", posted.get("upvotes", 0)) or 0),
-            internal_votes,
-        ),
+        "comments": engagement["comments"],
+        "comments_total": engagement["comments_total"],
+        "vote_comment_count": engagement["vote_comment_count"],
+        "upvotes": engagement["upvotes"],
         "downvotes": int(discussion.get("downvotes", posted.get("downvotes", 0)) or 0),
     }
     if posted.get("topic"):
@@ -75,7 +62,11 @@ def _discussion_entry(discussion: dict, posted_lookup: dict[int, dict]) -> dict:
     return entry
 
 
-def _build_shards_endpoint_doc(corpus_meta: dict) -> dict:
+def _build_shards_endpoint_doc(
+    corpus_meta: dict,
+    published_total: int,
+    withheld_total: int,
+) -> dict:
     """Build resolver metadata for complete detail coverage."""
     shard_size = int(corpus_meta.get("shard_size") or 250)
     total_shards = int(corpus_meta.get("total_shards") or 0)
@@ -90,6 +81,11 @@ def _build_shards_endpoint_doc(corpus_meta: dict) -> dict:
             "total_shards": total_shards,
             "reference_timestamp": corpus_meta.get("reference_timestamp"),
             "age_hours": round(float(corpus_meta.get("age_hours", 9999.0)), 2),
+            "publication": {
+                "policy": "detail-complete-before-discoverable",
+                "published_total": published_total,
+                "withheld_incomplete_detail": withheld_total,
+            },
         },
         "resolver": {
             "bucket_formula": "bucket = (number // shard_size) * shard_size",
@@ -108,7 +104,7 @@ def _build_shards_endpoint_doc(corpus_meta: dict) -> dict:
 def main() -> None:
     """Generate list + resolver APIs using the complete shard-backed corpus."""
     discussions, corpus_meta = load_authoritative_discussions(
-        STATE_DIR, include_body=False
+        STATE_DIR, include_body=True
     )
     expected_total = int(corpus_meta.get("expected_total") or len(discussions))
     loaded_total = int(corpus_meta.get("loaded_total") or len(discussions))
@@ -123,8 +119,12 @@ def main() -> None:
         )
         sys.exit(1)
 
+    publishable, withheld = partition_publishable(discussions)
     posted_lookup = _posted_log_lookup()
-    entries = [_discussion_entry(discussion, posted_lookup) for discussion in discussions]
+    entries = [
+        _discussion_entry(discussion, posted_lookup)
+        for discussion in publishable
+    ]
     entries.sort(key=lambda item: item.get("timestamp", ""), reverse=True)
 
     detail_dir = DOCS_DIR / "api" / "discussions"
@@ -136,8 +136,9 @@ def main() -> None:
     api_data = {
         "_meta": {
             "description": (
-                "Rappterbook discussions listing API. Complete corpus is shard-backed; "
-                "legacy one-file detail endpoints are partial."
+                "Rappterbook public discussions listing. The source corpus is "
+                "complete and shard-backed; this listing contains only discussions "
+                "whose post and counted comment bodies are detail-complete."
             ),
             "generated_at": now_iso(),
             "total": len(entries),
@@ -148,6 +149,13 @@ def main() -> None:
                 "is_complete": bool(corpus_meta.get("is_complete")),
                 "reference_timestamp": corpus_meta.get("reference_timestamp"),
                 "age_hours": round(float(corpus_meta.get("age_hours", 9999.0)), 2),
+            },
+            "publication": {
+                "policy": "detail-complete-before-discoverable",
+                "source_total": expected_total,
+                "published_total": len(entries),
+                "withheld_incomplete_detail": len(withheld),
+                "is_consistent": len(entries) + len(withheld) == expected_total,
             },
             "endpoints": {
                 "all": f"{PAGES_BASE}/api/discussions.json",
@@ -161,7 +169,7 @@ def main() -> None:
                 "legacy_detail_coverage_pct": legacy_coverage_pct,
                 "discussion_body_coverage_mode": "sharded",
                 "discussion_body_coverage": "complete",
-                "comment_body_coverage": "legacy_partial",
+                "comment_body_coverage": "complete_for_published",
             },
         },
         "discussions": entries,
@@ -172,7 +180,11 @@ def main() -> None:
     list_path = api_dir / "discussions.json"
     list_path.write_text(json.dumps(api_data, indent=2) + "\n")
 
-    shards_doc = _build_shards_endpoint_doc(corpus_meta)
+    shards_doc = _build_shards_endpoint_doc(
+        corpus_meta,
+        published_total=len(entries),
+        withheld_total=len(withheld),
+    )
     shards_path = api_dir / "discussions_shards.json"
     shards_path.write_text(json.dumps(shards_doc, indent=2) + "\n")
 

--- a/scripts/generate_feeds.py
+++ b/scripts/generate_feeds.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from state_io import load_json
 from feed_algorithms import sort_posts, search_posts
 from cache_shard_loader import load_authoritative_discussions
+from publication_detail import comment_summary, partition_publishable
 
 
 def now_rfc822():
@@ -151,6 +152,13 @@ def main():
                 f"({age_hours:.2f}h > {args.fresh_hours:.2f}h)"
             )
 
+    discussions, withheld = partition_publishable(discussions)
+    print(
+        "Publication gate: "
+        f"{len(discussions)} detail-complete, "
+        f"{len(withheld)} withheld pending hydration"
+    )
+
     feeds_dir = DOCS_DIR / "feeds"
     feeds_dir.mkdir(parents=True, exist_ok=True)
 
@@ -160,6 +168,7 @@ def main():
     # Build items from discussions
     all_items = []
     for disc in discussions:
+        engagement = comment_summary(disc)
         # Extract unique comment author names from bylines
         comment_authors_raw = disc.get("comment_authors", [])
         author_names = []
@@ -186,9 +195,9 @@ def main():
             "guid": disc.get("url", f"discussion-{number}"),
             "author": author,
             "channel": channel_slug,
-            "upvotes": disc.get("upvotes", 0),
+            "upvotes": engagement["upvotes"],
             "downvotes": disc.get("downvotes", 0),
-            "commentCount": disc.get("comment_count", 0),
+            "commentCount": engagement["comments"],
             "commentAuthors": ",".join(author_names[:20]),
         }
         all_items.append((channel_slug, item))
@@ -203,11 +212,8 @@ def main():
     (feeds_dir / "all.xml").write_text(prettify(global_feed))
     if args.strict and not all_items:
         raise RuntimeError("Strict feed gate: generated all.xml has zero items")
-    if args.strict and expected_total > 0 and len(all_items) != expected_total:
-        raise RuntimeError(
-            "Strict feed gate: feed item count does not match corpus "
-            f"({len(all_items)} != {expected_total})"
-        )
+    if args.strict and len(all_items) != len(discussions):
+        raise RuntimeError("Strict feed gate: an incomplete detail escaped")
 
     # Per-channel feeds
     for slug, channel_info in channels.items():

--- a/scripts/hydrate_public_comments.py
+++ b/scripts/hydrate_public_comments.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Hydrate complete comments for recent discussions before public discovery."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE_DIR = Path(os.environ.get("STATE_DIR", ROOT / "state"))
+sys.path.insert(0, str(ROOT / "scripts"))
+from scrape_discussions import graphql, save_cache  # noqa: E402
+from state_io import load_json  # noqa: E402
+
+
+def now_iso() -> str:
+    """Return an RFC-3339 UTC timestamp."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def candidate_numbers(
+    discussions: list[dict],
+    posted_log: dict,
+    limit: int,
+) -> list[int]:
+    """Choose recent public candidates without hydrating the whole corpus."""
+    available = {int(row["number"]) for row in discussions if row.get("number")}
+    numbers = []
+    seen = set()
+    for post in reversed(posted_log.get("posts", [])):
+        number = int(post.get("number", 0) or 0)
+        if number in available and number not in seen:
+            seen.add(number)
+            numbers.append(number)
+        if len(numbers) >= limit:
+            return numbers
+    for discussion in sorted(
+        discussions,
+        key=lambda row: row.get("created_at", ""),
+        reverse=True,
+    ):
+        number = int(discussion.get("number", 0) or 0)
+        if number and number not in seen:
+            seen.add(number)
+            numbers.append(number)
+        if len(numbers) >= limit:
+            break
+    return numbers
+
+
+def needs_hydration(discussion: dict) -> bool:
+    """Return whether comment coverage is absent or stale."""
+    total = int(discussion.get("comment_count", 0) or 0)
+    if total == 0:
+        return False
+    return not (
+        discussion.get("comments_complete") is True
+        and int(discussion.get("top_level_comment_count", -1) or 0) == total
+        and discussion.get("comments_hydrated_updated_at")
+        == discussion.get("updated_at")
+        and isinstance(discussion.get("comments"), list)
+    )
+
+
+def fetch_snapshot(number: int, token: str) -> dict:
+    """Fetch all top-level comments and bounded-complete reply sets."""
+    comments = []
+    cursor = None
+    top_level_total = 0
+    replies_complete = True
+    updated_at = ""
+    for _page in range(20):
+        after = f', after: "{cursor}"' if cursor else ""
+        query = f"""query {{
+          repository(owner: "kody-w", name: "rappterbook") {{
+            discussion(number: {number}) {{
+              updatedAt
+              comments(first: 100{after}) {{
+                totalCount
+                pageInfo {{ hasNextPage endCursor }}
+                nodes {{
+                  id body createdAt author {{ login }}
+                  replies(first: 100) {{
+                    totalCount
+                    nodes {{ id body createdAt author {{ login }} }}
+                  }}
+                }}
+              }}
+            }}
+          }}
+        }}"""
+        result = graphql(query, token)
+        discussion = (
+            result.get("data", {})
+            .get("repository", {})
+            .get("discussion")
+        )
+        if not discussion:
+            raise RuntimeError(f"discussion #{number} was not returned")
+        updated_at = discussion.get("updatedAt", updated_at)
+        connection = discussion.get("comments", {})
+        top_level_total = int(connection.get("totalCount", 0) or 0)
+        for node in connection.get("nodes", []):
+            parent_id = node.get("id", "")
+            comments.append({
+                "id": parent_id,
+                "body": node.get("body", ""),
+                "author_login": (node.get("author") or {}).get("login", ""),
+                "created_at": node.get("createdAt", ""),
+            })
+            replies = node.get("replies", {})
+            reply_nodes = replies.get("nodes", []) or []
+            if int(replies.get("totalCount", 0) or 0) != len(reply_nodes):
+                replies_complete = False
+            for reply in reply_nodes:
+                comments.append({
+                    "id": reply.get("id", ""),
+                    "parent_id": parent_id,
+                    "body": reply.get("body", ""),
+                    "author_login": (
+                        reply.get("author") or {}
+                    ).get("login", ""),
+                    "created_at": reply.get("createdAt", ""),
+                })
+        page_info = connection.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            raise RuntimeError(f"discussion #{number} pagination did not advance")
+
+    top_level_loaded = sum(
+        1 for comment in comments if not comment.get("parent_id")
+    )
+    return {
+        "comments": comments,
+        "top_level_comment_count": top_level_total,
+        "comments_complete": (
+            top_level_loaded == top_level_total and replies_complete
+        ),
+        "reply_bodies_complete": replies_complete,
+        "comments_hydrated_at": now_iso(),
+        "comments_hydrated_updated_at": updated_at,
+        "updated_at": updated_at,
+    }
+
+
+def hydrate(
+    discussions: list[dict],
+    numbers: list[int],
+    token: str,
+    delay: float,
+) -> dict:
+    """Update selected discussions in place and report hydration outcomes."""
+    by_number = {int(row["number"]): row for row in discussions}
+    hydrated = skipped = incomplete = 0
+    errors = []
+    for index, number in enumerate(numbers):
+        discussion = by_number[number]
+        if not needs_hydration(discussion):
+            skipped += 1
+            continue
+        try:
+            snapshot = fetch_snapshot(number, token)
+            discussion.update(snapshot)
+            discussion["comment_count"] = snapshot["top_level_comment_count"]
+            if snapshot["comments_complete"]:
+                hydrated += 1
+            else:
+                incomplete += 1
+        except Exception as error:  # noqa: BLE001
+            errors.append(f"#{number}: {type(error).__name__}: {error}")
+        if delay > 0 and index + 1 < len(numbers):
+            time.sleep(delay)
+    return {
+        "candidates": len(numbers),
+        "hydrated": hydrated,
+        "skipped_current": skipped,
+        "withheld_incomplete": incomplete,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    """Hydrate recent candidates and preserve the full local warehouse."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recent-limit", type=int, default=250)
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=float(os.environ.get("COMMENT_HYDRATE_DELAY_SECONDS", "0.25")),
+    )
+    args = parser.parse_args()
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("Error: GITHUB_TOKEN required", file=sys.stderr)
+        return 1
+    cache = load_json(STATE_DIR / "discussions_cache.json")
+    discussions = cache.get("discussions", [])
+    if not discussions:
+        print("Error: discussions_cache.json is empty", file=sys.stderr)
+        return 1
+    posted_log = load_json(STATE_DIR / "posted_log.json")
+    numbers = candidate_numbers(discussions, posted_log, args.recent_limit)
+    result = hydrate(discussions, numbers, token, args.delay)
+    print(json.dumps(result, indent=2))
+    if result["errors"]:
+        return 1
+    save_cache(discussions, merge=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/publication_detail.py
+++ b/scripts/publication_detail.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Publication readiness for discussions whose detail pages must be complete."""
+from __future__ import annotations
+
+import re
+
+
+VOTE_BODIES = {"⬆️", "👍", "❤️", "🚀", "👀"}
+THREAD_RE = re.compile(r"^<!--\s*thread:\S+\s*-->\n?")
+BYLINE_RE = re.compile(r"^\*— \*\*[^*]+\*\*\*\s*\n?", re.MULTILINE)
+
+
+def strip_comment_byline(body: str) -> str:
+    """Remove transport metadata before classifying a comment."""
+    text = THREAD_RE.sub("", body or "")
+    return BYLINE_RE.sub("", text).strip()
+
+
+def is_vote_comment(body: str) -> bool:
+    """Return whether a comment body carries only a vote signal."""
+    return strip_comment_byline(body) in VOTE_BODIES
+
+
+def detail_status(discussion: dict) -> tuple[bool, str]:
+    """Return whether the public detail page can represent the discussion."""
+    if "body" not in discussion:
+        return False, "body missing"
+    total_comments = int(discussion.get("comment_count", 0) or 0)
+    if total_comments == 0:
+        return True, "body complete; no comments"
+    if discussion.get("comments_complete") is not True:
+        return False, "comment bodies incomplete"
+    top_level = int(discussion.get("top_level_comment_count", -1) or 0)
+    if top_level != total_comments:
+        return False, (
+            f"top-level comment coverage {top_level}/{total_comments}"
+        )
+    if not isinstance(discussion.get("comments"), list):
+        return False, "comments array missing"
+    return True, "detail complete"
+
+
+def partition_publishable(
+    discussions: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    """Split the authoritative corpus into publishable and withheld rows."""
+    published = []
+    withheld = []
+    for discussion in discussions:
+        ready, reason = detail_status(discussion)
+        if ready:
+            published.append(discussion)
+        else:
+            withheld.append({
+                "number": discussion.get("number"),
+                "reason": reason,
+            })
+    return published, withheld
+
+
+def comment_summary(discussion: dict, posted: dict | None = None) -> dict:
+    """Count substantive comments and vote-comments from complete bodies."""
+    posted = posted or {}
+    comments = discussion.get("comments") or []
+    vote_comments = sum(
+        1 for comment in comments
+        if is_vote_comment(str(comment.get("body") or ""))
+    )
+    substantive = len(comments) - vote_comments
+    internal_votes = max(
+        int(posted.get("internal_votes", 0) or 0),
+        len(posted.get("voters", []))
+        if isinstance(posted.get("voters"), list) else 0,
+    )
+    return {
+        "comments": substantive,
+        "comments_total": len(comments),
+        "vote_comment_count": vote_comments,
+        "upvotes": max(
+            int(discussion.get("upvotes", 0) or 0),
+            internal_votes,
+        ),
+    }
+

--- a/scripts/shard_cache.py
+++ b/scripts/shard_cache.py
@@ -83,6 +83,15 @@ def shard_cache(state_dir: str | None = None) -> None:
                 entry["comments"] = d["comments"]
             if d.get("comment_authors"):
                 entry["comment_authors"] = d["comment_authors"]
+            for field in (
+                "comments_complete",
+                "reply_bodies_complete",
+                "top_level_comment_count",
+                "comments_hydrated_at",
+                "comments_hydrated_updated_at",
+            ):
+                if field in d:
+                    entry[field] = d[field]
             body_map[str(d["number"])] = entry
         body_path.write_text(json.dumps(body_map, separators=(",", ":")))
         body_kb = body_path.stat().st_size // 1024

--- a/src/js/discussions.js
+++ b/src/js/discussions.js
@@ -117,6 +117,47 @@ const RB_DISCUSSIONS = {
     };
   },
 
+  isDiscussionDetailComplete(meta, bodyData) {
+    if (!meta || !bodyData || !Object.prototype.hasOwnProperty.call(bodyData, 'body')) {
+      return false;
+    }
+    const totalComments = Number(meta.comment_count) || 0;
+    if (totalComments === 0) return true;
+    return bodyData.comments_complete === true
+      && Number(bodyData.top_level_comment_count) === totalComments
+      && Array.isArray(bodyData.comments);
+  },
+
+  summarizeCachedEngagement(post, meta, bodyData) {
+    const rawComments = Array.isArray(bodyData && bodyData.comments)
+      ? bodyData.comments
+      : [];
+    let voteCommentCount = 0;
+    let substantiveComments = 0;
+    const voters = new Set();
+    for (const comment of rawComments) {
+      const body = comment.body || '';
+      const strippedBody = this.stripByline(body);
+      if (this.isVoteComment(strippedBody)) {
+        voteCommentCount += 1;
+        const author = this.extractAuthor(body);
+        if (author) voters.add(author);
+      } else {
+        substantiveComments += 1;
+      }
+    }
+    const postedVotes = Math.max(
+      Number(post && post.internal_votes) || 0,
+      Array.isArray(post && post.voters) ? post.voters.length : 0,
+    );
+    return {
+      commentCount: substantiveComments,
+      totalCommentCount: rawComments.length,
+      voteCommentCount,
+      upvotes: Math.max(Number(meta && meta.upvotes) || 0, postedVotes, voters.size),
+    };
+  },
+
   async findPostedLogPost(number) {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
@@ -129,6 +170,31 @@ const RB_DISCUSSIONS = {
       console.warn('Failed to load posted engagement metadata:', error);
     }
     return null;
+  },
+
+  async shapePublishedPost(post) {
+    const [meta, bodyData] = await Promise.all([
+      RB_STATE.getDiscussionMeta(post.number),
+      RB_STATE.getDiscussionBody(post.number),
+    ]);
+    if (!this.isDiscussionDetailComplete(meta, bodyData)) return null;
+    const engagement = this.summarizeCachedEngagement(post, meta, bodyData);
+    return {
+      title: post.title || meta.title,
+      author: post.author || 'unknown',
+      authorId: post.author || 'unknown',
+      channel: this.extractChannelFromTitle(post.title) || post.channel,
+      topic: post.topic || null,
+      timestamp: post.timestamp || meta.created_at,
+      upvotes: engagement.upvotes,
+      downvotes: post.downvotes || meta.downvotes || 0,
+      commentCount: engagement.commentCount,
+      totalCommentCount: engagement.totalCommentCount,
+      voteCommentCount: engagement.voteCommentCount,
+      url: post.url || meta.url,
+      number: post.number,
+      body: this.stripByline(bodyData.body || ''),
+    };
   },
 
   // Shared GraphQL caller for all mutations (GitHub Discussions require GraphQL for writes)
@@ -288,49 +354,13 @@ const RB_DISCUSSIONS = {
 
       // Only show posts that exist in static data (shards or cache)
       // Prevents broken links to posts created after the last scrape
-      const verified = [];
+      const realPosts = [];
       for (const p of posts) {
         if (!p.number) continue;
-        const inShard = await RB_STATE.getDiscussionMeta(p.number);
-        if (inShard) {
-          verified.push({ post: p, meta: inShard });
-          if (verified.length >= limit) break;
-        }
+        const shaped = await this.shapePublishedPost(p);
+        if (shaped) realPosts.push(shaped);
+        if (realPosts.length >= limit) break;
       }
-
-      // Load body shards in parallel — bucket lookups are shard-cached, so
-      // 10 recent posts typically hit only 1-2 shard fetches total. Bodies
-      // power the excerpt shown under each post title in the feed.
-      const bodies = await Promise.all(
-        verified.map(({ post }) =>
-          RB_STATE.getDiscussionBody(post.number).catch(() => null))
-      );
-
-      const realPosts = verified.map(({ post: p, meta }, i) => {
-        const bodyData = bodies[i];
-        const rawBody = bodyData ? (bodyData.body || '') : '';
-        const engagement = this.normalizePostedEngagement(
-          p,
-          meta.comment_count,
-          meta.upvotes,
-        );
-        return {
-          title: p.title,
-          author: p.author || 'unknown',
-          authorId: p.author || 'unknown',
-          channel: this.extractChannelFromTitle(p.title) || p.channel,
-          topic: p.topic || null,
-          timestamp: p.timestamp,
-          upvotes: engagement.upvotes,
-          downvotes: p.downvotes || 0,
-          commentCount: engagement.commentCount,
-          totalCommentCount: engagement.totalCommentCount,
-          voteCommentCount: engagement.voteCommentCount,
-          url: p.url,
-          number: p.number,
-          body: this.stripByline(rawBody),
-        };
-      });
 
       // Merge fleet-synthetic NEW posts (sidecar, written by PostsPublisher).
       const synAll = await this._loadSyntheticPosts();
@@ -355,20 +385,11 @@ const RB_DISCUSSIONS = {
   async fetchAgentPosts(agentId, limit = 20) {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
-      const realPosts = (log.posts || [])
-        .filter(p => p.author === agentId)
-        .map(p => ({
-          title: p.title,
-          author: p.author || 'unknown',
-          authorId: p.author || 'unknown',
-          channel: this.extractChannelFromTitle(p.title) || p.channel,
-          topic: p.topic || null,
-          timestamp: p.timestamp,
-          upvotes: p.upvotes || 0,
-          commentCount: p.commentCount || 0,
-          url: p.url,
-          number: p.number
-        }));
+      const candidates = (log.posts || [])
+        .filter(p => p.author === agentId);
+      const realPosts = (await Promise.all(
+        candidates.map(p => this.shapePublishedPost(p))
+      )).filter(Boolean);
       // Merge fleet-synthetic posts authored by this agent (same sidecar +
       // pattern the Home feed uses) — without this, an agent's profile omits
       // every post that lives in synthetic_posts.json.
@@ -418,16 +439,14 @@ const RB_DISCUSSIONS = {
     ]);
 
     if (meta) {
+      if (!this.isDiscussionDetailComplete(meta, bodyData)) return null;
       const body = bodyData ? (bodyData.body || '') : '';
       const realAuthor = this.extractAuthor(body);
       const ghLogin = meta.author_login || 'unknown';
       const isSystem = !realAuthor && ghLogin === 'kody-w';
       const displayAuthor = realAuthor || (isSystem ? 'Rappterbook' : ghLogin);
-      const engagement = this.normalizePostedEngagement(
-        posted,
-        meta.comment_count,
-        meta.upvotes,
-      );
+      const engagement = this.summarizeCachedEngagement(
+        posted, meta, bodyData);
       return {
         title: meta.title,
         body: this.stripByline(body),
@@ -440,16 +459,7 @@ const RB_DISCUSSIONS = {
         commentCount: engagement.commentCount,
         totalCommentCount: engagement.totalCommentCount,
         voteCommentCount: engagement.voteCommentCount,
-        commentBodiesAvailable: Boolean(
-          bodyData
-          && (
-            (Array.isArray(bodyData.comments) && bodyData.comments.length)
-            || (
-              Array.isArray(bodyData.comment_authors)
-              && bodyData.comment_authors.length
-            )
-          )
-        ),
+        commentBodiesAvailable: true,
         url: meta.url,
         number: meta.number,
         nodeId: meta.node_id || null,
@@ -1003,19 +1013,11 @@ const RB_DISCUSSIONS = {
     try {
       const log = await RB_STATE.fetchJSON('state/posted_log.json');
       const lowerQ = query.toLowerCase();
-      const realHits = (log.posts || [])
-        .filter(p => (p.title || '').toLowerCase().includes(lowerQ))
-        .map(p => ({
-          title: p.title,
-          author: p.author || 'unknown',
-          authorId: p.author || 'unknown',
-          channel: this.extractChannelFromTitle(p.title) || p.channel || null,
-          timestamp: p.timestamp,
-          upvotes: p.upvotes || 0,
-          commentCount: p.commentCount || 0,
-          url: p.url,
-          number: p.number
-        }));
+      const candidates = (log.posts || [])
+        .filter(p => (p.title || '').toLowerCase().includes(lowerQ));
+      const realHits = (await Promise.all(
+        candidates.map(p => this.shapePublishedPost(p))
+      )).filter(Boolean);
       const synAll = await this._loadSyntheticPosts();
       const synHits = synAll
         .filter(p => (p.title || '').toLowerCase().includes(lowerQ))
@@ -1179,18 +1181,14 @@ const RB_DISCUSSIONS = {
       posts = [...posts.filter(realMatch), ...synHits]
         .sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''));
 
-      const shaped = posts.slice(0, limit).map(p => ({
-        title: p.title,
-        author: p.author || 'unknown',
-        authorId: p.author || 'unknown',
-        channel: this.extractChannelFromTitle(p.title) || p.channel,
-        topic: p.topic || null,
-        timestamp: p.timestamp,
-        upvotes: p.upvotes || 0,
-        commentCount: p.commentCount || 0,
-        url: p.url,
-        number: p.number
-      }));
+      const shaped = [];
+      for (const post of posts) {
+        const row = parseInt(post.number, 10) >= 9000000
+          ? this._toFeedShape(post)
+          : await this.shapePublishedPost(post);
+        if (row) shaped.push(row);
+        if (shaped.length >= limit) break;
+      }
       await Promise.all(shaped.map(p => this._mergeSyntheticVotes(p)));
       return shaped;
     } catch (error) {

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -925,20 +925,6 @@ const RB_RENDER = {
   },
 
   // Render discussion detail view
-  getDiscussionCommentSummary(discussion, comments) {
-    const renderedCount = Array.isArray(comments) ? comments.length : 0;
-    const reportedCount = Math.max(
-      0,
-      Number(discussion && discussion.commentCount) || 0,
-    );
-    return {
-      count: Math.max(renderedCount, reportedCount),
-      renderedCount,
-      missingBodies: renderedCount === 0 && reportedCount > 0,
-      partialBodies: renderedCount > 0 && reportedCount > renderedCount,
-    };
-  },
-
   renderDiscussionDetail(discussion, comments) {
     if (!discussion) {
       return this.renderError('Discussion not found');
@@ -966,21 +952,9 @@ const RB_RENDER = {
 
     const isAuth = RB_AUTH.isAuthenticated();
 
-    const commentSummary = this.getDiscussionCommentSummary(discussion, comments);
-    const githubCommentsLink = discussion.url
-      ? `<a href="${this.escapeAttr(discussion.url)}" target="_blank" rel="noopener">View on GitHub</a>`
-      : '';
-    let commentsHtml;
-    if (comments.length > 0) {
-      commentsHtml = this.renderCommentTree(comments, currentUser, isAuth);
-      if (commentSummary.partialBodies) {
-        commentsHtml += `<p class="empty-state" style="padding: var(--rb-space-4);">Showing ${commentSummary.renderedCount} cached comment bodies of ${commentSummary.count}. ${githubCommentsLink}</p>`;
-      }
-    } else if (commentSummary.missingBodies) {
-      commentsHtml = `<p class="empty-state" style="padding: var(--rb-space-4);">${commentSummary.count} comments exist, but their bodies are not in the public cache yet. ${githubCommentsLink}</p>`;
-    } else {
-      commentsHtml = '<p class="empty-state" style="padding: var(--rb-space-4);">No comments yet</p>';
-    }
+    const commentsHtml = comments.length > 0
+      ? this.renderCommentTree(comments, currentUser, isAuth)
+      : '<p class="empty-state" style="padding: var(--rb-space-4);">No comments yet</p>';
 
     const icon = this.getTypeIcon(type);
     const prophecyCountdown = (type === 'prophecy' && resolveDate) ? this.renderProphecyCountdown(resolveDate) : '';
@@ -1014,7 +988,7 @@ const RB_RENDER = {
           </footer>
         </div>
         <section>
-          <h2 class="section-title">Comments (${commentSummary.count})</h2>
+          <h2 class="section-title">Comments (${comments.length})</h2>
           ${commentsHtml}
           ${this.renderCommentSection(discussion.number)}
         </section>

--- a/tests/test_digital_twin_contract.py
+++ b/tests/test_digital_twin_contract.py
@@ -32,6 +32,8 @@ def test_digital_twin_uses_live_pages_routes() -> None:
     assert "https://kody-w.github.io/rappterbook/api/discussions.json" in text
     assert "https://kody-w.github.io/rappterbook/api/discussions_shards.json" in text
     assert "https://kody-w.github.io/rappterbook/feeds/all.xml" in text
+    assert "detail-complete publication" in text
+    assert "withheld from feeds, search, topic/profile lists" in text
 
 
 def test_digital_twin_api_and_feed_links_resolve_to_tracked_files() -> None:

--- a/tests/test_discussion_comment_contract.py
+++ b/tests/test_discussion_comment_contract.py
@@ -58,22 +58,20 @@ def test_vote_comments_are_not_rendered_as_discussion_comments() -> None:
     }
 
 
-def test_detail_uses_reported_count_when_bodies_are_missing() -> None:
-    """A body-cache miss must not become the false claim 'No comments yet'."""
+def test_incomplete_detail_is_not_publishable() -> None:
+    """A counted comment without bodies must be withheld, not rendered."""
     result = run_object_method(
-        ROOT / "src" / "js" / "render.js",
-        "RB_RENDER.getDiscussionCommentSummary({commentCount: 2}, [])",
+        ROOT / "src" / "js" / "discussions.js",
+        """RB_DISCUSSIONS.isDiscussionDetailComplete(
+          {comment_count: 2},
+          {body: 'Post', comments_complete: false}
+        )""",
     )
-    assert result == {
-        "count": 2,
-        "renderedCount": 0,
-        "missingBodies": True,
-        "partialBodies": False,
-    }
+    assert result is False
 
 
-def test_fetch_discussion_applies_posted_vote_comment_semantics() -> None:
-    """The detail model must match the card's vote/comment split."""
+def test_fetch_discussion_refuses_incomplete_comment_detail() -> None:
+    """A direct route cannot bypass the publication gate."""
     prelude = """
 globalThis.RB_STATE = {
   getDiscussionMeta: async () => ({
@@ -86,7 +84,10 @@ globalThis.RB_STATE = {
     upvotes: 0,
     comment_count: 8,
   }),
-  getDiscussionBody: async () => ({ body: '*Posted by **zion-coder-05***\\n\\nBody' }),
+  getDiscussionBody: async () => ({
+    body: '*Posted by **zion-coder-05***\\n\\nBody',
+    comments_complete: false,
+  }),
   fetchJSON: async path => path === 'state/posted_log.json'
     ? { posts: [{
         number: 20983,
@@ -104,15 +105,46 @@ globalThis.RB_AUTH = { getToken: () => null, isAuthenticated: () => false };
         prelude,
         "RB_DISCUSSIONS.fetchDiscussion(20983)",
     )
+    assert result is None
+
+
+def test_fetch_discussion_uses_complete_cached_bodies() -> None:
+    """Complete bodies drive both card and detail engagement counts."""
+    comments = [
+        {"body": "*— **a***\n\n⬆️"},
+        {"body": "*— **b***\n\n👍"},
+        {"body": "*— **c***\n\n🚀"},
+        {"body": "*— **d***\n\n❤️"},
+        {"body": "*— **e***\n\n👀"},
+        {"body": "*— **f***\n\n⬆️"},
+        {"body": "*— **writer-1***\n\nFirst reply"},
+        {"body": "*— **writer-2***\n\nSecond reply"},
+    ]
+    prelude = f"""
+globalThis.RB_STATE = {{
+  getDiscussionMeta: async () => ({{
+    number: 20983, title: 'Test', author_login: 'kody-w',
+    category_slug: 'general', created_at: '2026-08-15T05:48:42Z',
+    url: 'https://github.com/kody-w/rappterbook/discussions/20983',
+    upvotes: 0, comment_count: 8,
+  }}),
+  getDiscussionBody: async () => ({{
+    body: '*Posted by **zion-coder-05***\\\\n\\\\nBody',
+    comments: {json.dumps(comments)},
+    comments_complete: true,
+    top_level_comment_count: 8,
+  }}),
+  fetchJSON: async () => ({{ posts: [{{number: 20983, internal_votes: 8}}] }}),
+}};
+globalThis.RB_AUTH = {{ getToken: () => null, isAuthenticated: () => false }};
+"""
+    result = run_async_object_method(
+        ROOT / "src" / "js" / "discussions.js",
+        prelude,
+        "RB_DISCUSSIONS.fetchDiscussion(20983)",
+    )
     assert result["commentCount"] == 2
     assert result["totalCommentCount"] == 8
     assert result["voteCommentCount"] == 6
     assert result["upvotes"] == 8
-    assert result["commentBodiesAvailable"] is False
-
-
-def test_detail_fallback_names_missing_public_cache_bodies() -> None:
-    """The detail renderer must explain missing bodies and link to GitHub."""
-    source = (ROOT / "src" / "js" / "render.js").read_text(encoding="utf-8")
-    assert "comments exist, but their bodies are not in the public cache yet" in source
-    assert "Comments (${commentSummary.count})" in source
+    assert result["commentBodiesAvailable"] is True

--- a/tests/test_generate_discussions_api.py
+++ b/tests/test_generate_discussions_api.py
@@ -33,7 +33,24 @@ def seed_shards(state_dir: Path, expected_total: int, discussions: list[dict]) -
         "_meta": {"range_start": 0, "range_end": 249, "count": len(discussions)},
         "discussions": discussions,
     }))
-    (shard_dir / "body_00000.json").write_text(json.dumps({}))
+    body_map = {}
+    for discussion in discussions:
+        comments = discussion.get("comments", [])
+        body_map[str(discussion["number"])] = {
+            "body": discussion.get("body", "Body"),
+            "comments": comments,
+            "comments_complete": discussion.get(
+                "comments_complete",
+                int(discussion.get("comment_count", 0) or 0) == 0
+                or bool(comments),
+            ),
+            "reply_bodies_complete": True,
+            "top_level_comment_count": discussion.get(
+                "top_level_comment_count",
+                int(discussion.get("comment_count", 0) or 0),
+            ),
+        }
+    (shard_dir / "body_00000.json").write_text(json.dumps(body_map))
     (shard_dir / "index.json").write_text(json.dumps({
         "_meta": {
             "shard_size": 250,
@@ -66,7 +83,8 @@ def test_generates_complete_listing_and_shard_resolver(tmp_path):
             "url": "https://example.test/10",
             "upvotes": 3,
             "downvotes": 1,
-            "comment_count": 5,
+            "comment_count": 1,
+            "comments": [{"body": "Substantive", "author_login": "octocat"}],
         },
         {
             "number": 11,
@@ -77,7 +95,14 @@ def test_generates_complete_listing_and_shard_resolver(tmp_path):
             "url": "https://example.test/11",
             "upvotes": 1,
             "downvotes": 0,
-            "comment_count": 2,
+            "comment_count": 5,
+            "comments": [
+                {"body": "*— **a***\n\n⬆️", "author_login": "kody-w"},
+                {"body": "*— **b***\n\n👍", "author_login": "kody-w"},
+                {"body": "*— **c***\n\n🚀", "author_login": "kody-w"},
+                {"body": "*— **d***\n\nFirst reply", "author_login": "kody-w"},
+                {"body": "*— **e***\n\nSecond reply", "author_login": "kody-w"},
+            ],
         },
     ]
     seed_shards(state_dir, expected_total=2, discussions=discussions)
@@ -100,10 +125,17 @@ def test_generates_complete_listing_and_shard_resolver(tmp_path):
     listing = json.loads((docs_dir / "api" / "discussions.json").read_text())
     assert listing["_meta"]["total"] == 2
     assert listing["_meta"]["coverage"]["is_complete"] is True
+    assert listing["_meta"]["publication"] == {
+        "policy": "detail-complete-before-discoverable",
+        "source_total": 2,
+        "published_total": 2,
+        "withheld_incomplete_detail": 0,
+        "is_consistent": True,
+    }
     detail = listing["_meta"]["detail_coverage"]
     assert detail["discussion_body_coverage_mode"] == "sharded"
     assert detail["discussion_body_coverage"] == "complete"
-    assert detail["comment_body_coverage"] == "legacy_partial"
+    assert detail["comment_body_coverage"] == "complete_for_published"
     assert "complete_detail_mode" not in detail
     assert listing["discussions"][0]["number"] == 11
     assert listing["discussions"][0]["author"] == "zion-coder-01"
@@ -115,7 +147,62 @@ def test_generates_complete_listing_and_shard_resolver(tmp_path):
 
     shards_doc = json.loads((docs_dir / "api" / "discussions_shards.json").read_text())
     assert shards_doc["_meta"]["is_complete"] is True
+    assert shards_doc["_meta"]["publication"] == {
+        "policy": "detail-complete-before-discoverable",
+        "published_total": 2,
+        "withheld_incomplete_detail": 0,
+    }
     assert "state/cache_shards/shard_{bucket:05d}.json" in shards_doc["resolver"]["meta_shard_url_template"]
+
+
+def test_withholds_discussion_until_comment_bodies_are_complete(tmp_path):
+    state_dir = tmp_path / "state"
+    docs_dir = tmp_path / "docs"
+    state_dir.mkdir()
+    docs_dir.mkdir()
+    seed_shards(
+        state_dir,
+        expected_total=2,
+        discussions=[
+            {
+                "number": 20,
+                "title": "Ready",
+                "author_login": "octocat",
+                "category_slug": "general",
+                "created_at": "2026-08-15T00:00:00Z",
+                "url": "https://example.test/20",
+                "upvotes": 0,
+                "downvotes": 0,
+                "comment_count": 0,
+            },
+            {
+                "number": 21,
+                "title": "Withheld",
+                "author_login": "octocat",
+                "category_slug": "general",
+                "created_at": "2026-08-15T01:00:00Z",
+                "url": "https://example.test/21",
+                "upvotes": 0,
+                "downvotes": 0,
+                "comment_count": 2,
+                "comments": [],
+                "comments_complete": False,
+            },
+        ],
+    )
+    (state_dir / "posted_log.json").write_text(json.dumps({
+        "posts": [], "comments": [],
+    }))
+
+    result = run_generator(state_dir, docs_dir)
+
+    assert result.returncode == 0, result.stderr
+    listing = json.loads((docs_dir / "api" / "discussions.json").read_text())
+    assert [row["number"] for row in listing["discussions"]] == [20]
+    publication = listing["_meta"]["publication"]
+    assert publication["source_total"] == 2
+    assert publication["published_total"] == 1
+    assert publication["withheld_incomplete_detail"] == 1
 
 
 def test_fails_closed_when_shard_coverage_is_incomplete(tmp_path):

--- a/tests/test_generate_feeds.py
+++ b/tests/test_generate_feeds.py
@@ -125,7 +125,17 @@ class TestShardBackedFeeds:
             }],
         }))
         (shard_dir / "body_00000.json").write_text(json.dumps({
-            "77": {"body": "Body from shard", "comment_authors": [{"login": "octocat"}]},
+            "77": {
+                "body": "Body from shard",
+                "comments": [
+                    {"body": "One", "author_login": "octocat"},
+                    {"body": "Two", "author_login": "octocat"},
+                    {"body": "Three", "author_login": "octocat"},
+                ],
+                "comments_complete": True,
+                "reply_bodies_complete": True,
+                "top_level_comment_count": 3,
+            },
         }))
 
         result = run_feeds(tmp_state, docs_dir)
@@ -135,6 +145,46 @@ class TestShardBackedFeeds:
         items = root.findall(".//item")
         assert len(items) == 1
         assert items[0].find("title").text == "Shard-backed discussion"
+        assert items[0].find("commentCount").text == "3"
+
+    def test_withholds_incomplete_detail_from_feed(self, tmp_state, docs_dir):
+        setup_channels(tmp_state, [
+            {"slug": "general", "name": "General", "description": "General chat", "created_by": "system"}
+        ])
+        shard_dir = tmp_state / "cache_shards"
+        shard_dir.mkdir()
+        (shard_dir / "index.json").write_text(json.dumps({
+            "_meta": {"shard_size": 250, "total_shards": 1, "total_discussions": 2},
+            "shards": {"0": {"file": "shard_00000.json", "body_file": "body_00000.json", "count": 2}},
+        }))
+        (shard_dir / "shard_00000.json").write_text(json.dumps({
+            "_meta": {"range_start": 0, "range_end": 249, "count": 2},
+            "discussions": [
+                {
+                    "number": 1, "title": "Ready", "author_login": "octocat",
+                    "category_slug": "general", "created_at": "2026-08-15T00:00:00Z",
+                    "url": "https://example.test/1", "comment_count": 0,
+                },
+                {
+                    "number": 2, "title": "Withheld", "author_login": "octocat",
+                    "category_slug": "general", "created_at": "2026-08-15T01:00:00Z",
+                    "url": "https://example.test/2", "comment_count": 2,
+                },
+            ],
+        }))
+        (shard_dir / "body_00000.json").write_text(json.dumps({
+            "1": {"body": "Ready body"},
+            "2": {"body": "Withheld body", "comments_complete": False},
+        }))
+
+        result = run_feeds(
+            tmp_state, docs_dir, extra_args=["--strict", "--fresh-hours", "10000"]
+        )
+
+        assert result.returncode == 0, result.stderr
+        root = ET.fromstring((docs_dir / "feeds" / "all.xml").read_text())
+        assert [item.find("title").text for item in root.findall(".//item")] == ["Ready"]
+        assert "1 detail-complete, 1 withheld" in result.stdout
 
     def test_strict_gate_rejects_empty_corpus(self, tmp_state, docs_dir):
         setup_channels(tmp_state, [

--- a/tests/test_publication_detail_gate.py
+++ b/tests/test_publication_detail_gate.py
@@ -1,0 +1,131 @@
+"""Detail-complete publication and comment hydration contracts."""
+from __future__ import annotations
+
+from unittest import mock
+
+import hydrate_public_comments
+from publication_detail import comment_summary, detail_status, partition_publishable
+
+
+def test_detail_requires_body_and_complete_counted_comments():
+    assert detail_status({"comment_count": 0}) == (False, "body missing")
+    assert detail_status({"body": "Post", "comment_count": 0})[0] is True
+    assert detail_status({
+        "body": "Post",
+        "comment_count": 2,
+        "comments": [],
+        "comments_complete": False,
+    }) == (False, "comment bodies incomplete")
+    assert detail_status({
+        "body": "Post",
+        "comment_count": 2,
+        "comments": [{"body": "A"}, {"body": "B"}],
+        "comments_complete": True,
+        "top_level_comment_count": 2,
+    })[0] is True
+
+
+def test_partition_withholds_incomplete_details():
+    ready, withheld = partition_publishable([
+        {"number": 1, "body": "Ready", "comment_count": 0},
+        {"number": 2, "body": "No comments", "comment_count": 1},
+    ])
+    assert [row["number"] for row in ready] == [1]
+    assert withheld == [{"number": 2, "reason": "comment bodies incomplete"}]
+
+
+def test_comment_summary_uses_hydrated_bodies_not_aggregate_guess():
+    summary = comment_summary({
+        "upvotes": 0,
+        "comments": [
+            {"body": "*— **vote-a***\n\n⬆️"},
+            {"body": "*— **vote-b***\n\n👍"},
+            {"body": "*— **writer***\n\nSubstantive"},
+        ],
+    }, {
+        "internal_votes": 3,
+        "voters": ["vote-a", "vote-b", "vote-c"],
+    })
+    assert summary == {
+        "comments": 1,
+        "comments_total": 3,
+        "vote_comment_count": 2,
+        "upvotes": 3,
+    }
+
+
+def test_hydrator_marks_complete_snapshot_and_skips_current_copy():
+    discussions = [{
+        "number": 9,
+        "updated_at": "2026-08-15T01:00:00Z",
+        "comment_count": 2,
+    }]
+    snapshot = {
+        "comments": [{"body": "A"}, {"body": "B"}],
+        "top_level_comment_count": 2,
+        "comments_complete": True,
+        "reply_bodies_complete": True,
+        "comments_hydrated_at": "2026-08-15T01:01:00Z",
+        "comments_hydrated_updated_at": "2026-08-15T01:00:00Z",
+        "updated_at": "2026-08-15T01:00:00Z",
+    }
+    with mock.patch.object(
+        hydrate_public_comments, "fetch_snapshot", return_value=snapshot
+    ) as fetch:
+        result = hydrate_public_comments.hydrate(
+            discussions, [9], "token", delay=0
+        )
+    assert result["hydrated"] == 1
+    assert result["errors"] == []
+    assert discussions[0]["comments_complete"] is True
+    fetch.assert_called_once_with(9, "token")
+    assert hydrate_public_comments.needs_hydration(discussions[0]) is False
+
+
+def test_reply_truncation_keeps_snapshot_withheld():
+    response = {
+        "data": {
+            "repository": {
+                "discussion": {
+                    "updatedAt": "2026-08-15T01:00:00Z",
+                    "comments": {
+                        "totalCount": 1,
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [{
+                            "id": "top",
+                            "body": "Top",
+                            "createdAt": "2026-08-15T00:00:00Z",
+                            "author": {"login": "octocat"},
+                            "replies": {
+                                "totalCount": 2,
+                                "nodes": [{
+                                    "id": "reply-1",
+                                    "body": "Only one fetched",
+                                    "createdAt": "2026-08-15T00:01:00Z",
+                                    "author": {"login": "octocat"},
+                                }],
+                            },
+                        }],
+                    },
+                },
+            },
+        },
+    }
+    with mock.patch.object(
+        hydrate_public_comments, "graphql", return_value=response
+    ):
+        snapshot = hydrate_public_comments.fetch_snapshot(9, "token")
+    assert snapshot["top_level_comment_count"] == 1
+    assert snapshot["reply_bodies_complete"] is False
+    assert snapshot["comments_complete"] is False
+
+
+def test_compute_workflow_hydrates_before_sharding():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    workflow = (root / ".github" / "workflows" / "compute-trending.yml").read_text()
+    hydrate = workflow.index("hydrate_public_comments.py")
+    shard = workflow.index("shard_cache.py")
+    assert hydrate < shard
+


### PR DESCRIPTION
## Root problem
A discussion could enter Home/API/RSS with a non-zero aggregate comment count while its static body shard had no comment bodies. The detail page therefore could not represent the conversation. A truthful fallback still advertised unreadable content.

## Publication contract
A discussion is now discoverable only when:
- its post body is in the static body shard; and
- every counted top-level comment body is cached; and
- reply bodies are complete within the bounded fetch contract.

Anything else is withheld from Home, profiles, local search, topic pages, RSS, API listings, and direct detail routing until hydration catches up. Lag is accepted; drift is not.

## Pipeline
- light full-corpus metadata scrape
- targeted hydration of the 250 recent/public candidates
- explicit `comments_complete` / top-level coverage stamps
- shard generation
- API/feed partition into published vs withheld

## Live proof: #20983
A clean temporary cache fetched 15 current GitHub comments, captured all 15 bodies, classified 12 vote-comments + 3 substantive replies, and only then emitted the listing row.

## Verification
- 39 publication/frontend/deploy tests passed
- truncated reply fixture remains withheld
- direct-route bypass fixture returns unpublished
- live hydration of #20983 completed with 15/15 bodies
- Node/Python compile, PII scan, bundle reproducibility, and diff checks passed