### PR TITLE
Finish the prose-issue fix that only landed in the script (#20867)

### DIFF
--- a/.github/workflows/process-issues.yml
+++ b/.github/workflows/process-issues.yml
@@ -69,12 +69,24 @@ jobs:
       - name: Process issue
         id: process
         if: steps.request.outputs.state == 'new'
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           cat "$GITHUB_EVENT_PATH" | python scripts/process_issues.py
+          # A prose issue is not a failed delta (#20867): process_issues.py
+          # exits 0 and writes nothing. The queue steps below must skip, not
+          # fail, or every bug report and critique turns this workflow red.
+          if [ -f "state/inbox/issue-${ISSUE_NUMBER}.json" ]; then
+            echo "delta=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "delta=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit durable queue entry
         id: commit
-        if: steps.request.outputs.state == 'new'
+        if: >-
+          steps.request.outputs.state == 'new' &&
+          steps.process.outputs.delta == 'true'
         run: |
           delta="state/inbox/issue-${{ github.event.issue.number }}.json"
           test -f "$delta"
@@ -86,7 +98,8 @@ jobs:
 
       - name: Post queued receipt
         if: >-
-          steps.request.outputs.state == 'new' ||
+          (steps.request.outputs.state == 'new' &&
+           steps.process.outputs.delta == 'true') ||
           steps.request.outputs.state == 'queued'
         uses: actions/github-script@v7
         env:
@@ -141,7 +154,8 @@ jobs:
       - name: Dispatch inbox processing
         id: dispatch
         if: >-
-          steps.request.outputs.state == 'new' ||
+          (steps.request.outputs.state == 'new' &&
+           steps.process.outputs.delta == 'true') ||
           steps.request.outputs.state == 'queued' ||
           steps.request.outputs.state == 'pending'
         continue-on-error: true

--- a/tests/test_process_issues.py
+++ b/tests/test_process_issues.py
@@ -133,7 +133,10 @@ class TestInvalidIssues:
             "issue": {
                 "number": 1,
                 "title": "broken",
-                "body": "this is not json",
+                # Looks like a delta and fails to parse: the author meant to
+                # submit one, so this is a real error. Prose with no JSON at
+                # all is a different case — see test_prose_issue_exits_0.
+                "body": '{"action": "heartbeat", "payload": {}',
                 "user": {"login": "test", "id": 1001},
                 "labels": []
             }
@@ -142,6 +145,28 @@ class TestInvalidIssues:
         assert result.returncode == 1
         inbox_files = list((tmp_state / "inbox").glob("*.json"))
         assert len(inbox_files) == 0
+
+    def test_prose_issue_exits_0(self, tmp_state):
+        """A bug report is not a failed delta (#20867).
+
+        docs/JOINING.md invites outsiders to file critiques. If prose exits 1,
+        every critique turns Process Issues red and a genuinely broken delta
+        becomes indistinguishable from someone writing a paragraph. The
+        workflow gates its queue steps on the absence of a delta file, so this
+        pair — exit 0 AND nothing written — is load-bearing.
+        """
+        event = {
+            "issue": {
+                "number": 2,
+                "title": "The roll-up publishes a count that matches no real quantity",
+                "body": "this is not json",
+                "user": {"login": "test", "id": 1001},
+                "labels": []
+            }
+        }
+        result = run_issues(event, tmp_state)
+        assert result.returncode == 0, result.stderr
+        assert list((tmp_state / "inbox").glob("*.json")) == []
 
     def test_missing_required_fields_exits_1(self, tmp_state):
         event = make_issue_event("register_agent", {

--- a/tests/test_process_issues_workflow_contract.py
+++ b/tests/test_process_issues_workflow_contract.py
@@ -1,0 +1,62 @@
+"""Contract tests: a prose Issue must not turn Process Issues red.
+
+`scripts/process_issues.py` deliberately exits 0 and writes no delta when an
+Issue body is prose rather than JSON (#20867 — "A prose issue is not a failed
+delta"). That fix only covered the script. The workflow still required the
+delta file unconditionally, so every bug report and outsider critique kept
+failing the run — the exact outcome #20867 set out to prevent.
+
+These tests pin the other half of that contract: every step that assumes a
+delta was queued must be gated on the delta actually existing.
+"""
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = ROOT / ".github" / "workflows" / "process-issues.yml"
+
+DELTA_GATE = "steps.process.outputs.delta == 'true'"
+
+# Steps that only make sense when a delta was written. Committing one, telling
+# the author it is queued, or dispatching inbox processing are all lies (or
+# hard failures) when the Issue was prose.
+QUEUE_DEPENDENT_STEPS = {
+    "Commit durable queue entry",
+    "Post queued receipt",
+    "Dispatch inbox processing",
+}
+
+
+def _steps():
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["process"]["steps"]
+
+
+def test_process_step_reports_whether_a_delta_was_written():
+    """The gate needs a signal, and only the process step can produce it."""
+    process = next(s for s in _steps() if s.get("name") == "Process issue")
+    assert process.get("id") == "process"
+    run = process.get("run", "")
+    assert "delta=true" in run and "delta=false" in run, (
+        "Process issue must publish a 'delta' output so later steps can tell "
+        "a queued action from a prose Issue"
+    )
+
+
+def test_queue_dependent_steps_are_gated_on_the_delta():
+    for step in _steps():
+        if step.get("name") not in QUEUE_DEPENDENT_STEPS:
+            continue
+        condition = " ".join(str(step.get("if", "")).split())
+        assert DELTA_GATE in condition, (
+            f"{step['name']!r} runs without checking that a delta was queued; "
+            "a prose Issue would fail or produce a false receipt"
+        )
+
+
+def test_every_queue_dependent_step_is_covered():
+    """Guard the guard: renaming a step must not silently drop its gate."""
+    names = {s.get("name") for s in _steps()}
+    missing = QUEUE_DEPENDENT_STEPS - names
+    assert not missing, f"queue-dependent steps disappeared or were renamed: {missing}"


### PR DESCRIPTION
## Root cause

`scripts/process_issues.py` exits 0 and writes no delta when an Issue body is prose rather than JSON — deliberately, per #20867: *"this workflow's red/green must mean 'the write path works', not 'somebody filed a bug report'."*

That fix only covered the script. The `Commit durable queue entry` step added earlier by #20684 still ran `test -f "$delta"` unconditionally, so a prose Issue passed `Process issue` and failed the very next step.

**Six of the seven most recent Process Issues failures are prose Issues.** The sentinel reports the workflow as 100% failing.

## Reproduction

```
$ cat event-21020.json | STATE_DIR=/tmp/repro python3 scripts/process_issues.py
No state delta in this issue (prose body) — nothing to queue.
SCRIPT_EXIT=0
$ test -f /tmp/repro/inbox/issue-21020.json
TEST_F_EXIT=1   # -> workflow step fails -> RED run
```

## Fix

`Process issue` publishes a `delta` output; the three steps that assume a delta was queued are gated on it. Without the gate on `Post queued receipt`, a prose Issue also got a **false QUEUED receipt** with an empty commit SHA.

## Also fixed (same incomplete change)

`test_invalid_json_exits_1` asserted exit 1 for `"this is not json"` — which #20867 reclassified as prose — so **the suite has been red on main since**. It now submits a body that looks like a delta and fails to parse. A new test pins the prose contract the workflow gate depends on.

## Verification

- `tests/test_process_issues_workflow_contract.py` **fails** against the unfixed workflow, **passes** against this one (mutation-checked).
- `tests/test_process_issues.py`: 40 passed (was 1 failed on main).

## Not addressed — needs a product decision

23 of 44 issue templates are archived features pre-filled with dead actions (e.g. `challenge_battle`). Issue #21021 used one and failed with `Unknown action`. Under current policy an unknown action is a real error and goes red, so the platform ships templates that guarantee red runs. Removing them, or rejecting archived actions without failing, is a direction call — flagging rather than guessing.