### PR TITLE
Consume Dreamcatcher search plans at inbox merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,13 @@ GitHub Issues (labeled actions)
   → state/*.json (canonical state)
 ```
 
+### Dreamcatcher consumer seam
+Private Dreamcatcher turns worktree diffs into `dreamcatcher-delta/1.0`
+search plans. Rappterbook only validates that public plan and, when
+`DREAMCATCHER_DELTA_MANIFEST` is set, consumes its planned
+`state/inbox/*.json` files. Diff generation and merge logic stay private;
+`main` remains the serialized publisher of canonical state.
+
 ### Read path
 ```
 state/*.json → raw.githubusercontent.com (direct JSON)

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,39 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.38 — 2026-08-22 — Dreamcatcher plans stop broad inbox scans
+
+**Session**: gpt-5.4 via Copilot CLI / operator: kody-w
+**Read state**: 9e76dd7b02d65083bdf286e86f71b6efbfdad5af on feature/dreamcatcher-delta — clean sparse checkout with historical state content intentionally absent
+
+### Hypothesis tested
+If private Dreamcatcher emits a canonical search plan, Rappterbook can validate that public wire artifact and constrain inbox processing without publishing the private generator, diff parser, frame loop, prompts, reducer, or merge algorithm. This user-directed reliability/performance integration explicitly superseded Entry 003.37's recommended public-discovery verification for this session.
+
+### What I built
+- Copied the canonical `dreamcatcher-delta/1.0` and `dreamcatcher-batch/1.0` wire schemas into clearly named files under `schema/`.
+- Added `scripts/dreamcatcher_seam.py`, a stdlib-only consumer that verifies canonical IDs, normalized state-relative paths, exact search-plan/change correspondence, planned file freshness, and inbox containment.
+- Updated `scripts/process_inbox.py` so `DREAMCATCHER_DELTA_MANIFEST` scopes processing in the existing queue order and invalid plans fail before state loading or writes; the no-environment GitHub Issues path is unchanged.
+- Added focused seam regressions and a concise architecture note. No state file, workflow, private engine implementation, or merge behavior was added here.
+- Committed the verified branch locally as `Consume Dreamcatcher search plans at inbox merge`; it was not pushed or merged.
+
+### What worked
+- The two public schema files are byte-for-byte SHA-256 matches for the canonical private wire artifacts.
+- Focused seam suite: **14 passed**.
+- Existing process-inbox and workflow-contract regressions: **77 passed, 1 skipped**; the skip is the existing size-dependent posted-log rotation fixture.
+- Changed Python files compiled successfully, both schema files parsed as JSON, and diff whitespace validation passed.
+
+### What failed
+- Direct Windows execution of the existing process-inbox tests still hits the repository's pre-existing Unix-only `fcntl` import. Validation used a test-only in-process no-op `fcntl` shim; production files were not changed to widen this task.
+- The full repository suite was not run because this sparse checkout intentionally omits historical `state/` content. The checkout was not widened and no state content was touched.
+
+### Lessons for next session
+1. A public consumer can enforce freshness and scope from blob hashes and canonical IDs without owning the private computation that produced them.
+2. Manifest order is not queue order; the consumer must reapply Rappterbook's numeric-Issue/FIFO ordering after selection.
+3. Optional protocol integration is safest when validation happens before even loading mutable state and the absent-environment path remains byte-for-byte behaviorally compatible.
+
+### Recommended next move
+After this local branch is integrated by the operator, run one private Dreamcatcher 0.2.0 manifest against a disposable Rappterbook inbox and one ordinary no-environment Process Inbox dispatch. Verify only planned deltas publish, the GitHub Issues path remains unchanged, and then resume Entry 003.37's public-discovery verification.
+
 ## Entry 003.37 — 2026-08-15 — Public discovery now waits for complete comment detail
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: kody-w

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,36 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.39 — 2026-08-22 — Dreamcatcher closes Windows inbox aliases
+
+**Session**: gpt-5.4 via Copilot CLI / operator: kody-w
+**Read state**: 13accad910b9f51d94a14601fb9b6cf60f35e0cb on feature/dreamcatcher-delta — clean local follow-up branch, one commit ahead of origin/main
+
+### Hypothesis tested
+Canonical POSIX spelling alone is not enough when path components are later joined by Windows `pathlib`: a component such as `C:agents.json` can become drive-relative and select canonical state outside the intended inbox. Rejecting colon-qualified components before joining, then requiring the resolved file parent to equal the resolved configured inbox, should close that gap without importing private Dreamcatcher engine logic.
+
+### What I built
+- Hardened `scripts/dreamcatcher_seam.py` so every repository path component rejects colon and drive aliases, while resolved inbox files must be direct children of resolved `STATE_DIR/inbox`.
+- Synced the finalized public delta schema and required `repository.path_filter`; the consumer now validates its schema fields plus sorted, unique, normalized paths.
+- Added regressions for `state/inbox/C:agents.json`, colon aliases in multiple components, Windows canonical-state remapping, and missing or noncanonical path filters.
+- Prepared the local follow-up commit `Harden Dreamcatcher inbox path containment`; it was not pushed or merged.
+
+### What worked
+- Focused Dreamcatcher seam suite: **25 passed**.
+- Existing process-inbox and workflow-contract suites: **77 passed, 1 skipped**.
+- Changed Python files compiled successfully, no seam function exceeds 50 lines, schema SHA-256 matched the finalized private artifact byte-for-byte, and diff whitespace validation passed.
+
+### What failed
+- Direct Windows process-inbox testing still needs the repository's existing test-only no-op `fcntl` shim. Production portability changes remain outside this consumer hardening.
+
+### Lessons for next session
+1. A wire path can be POSIX-relative yet become drive-relative when individual components are passed to Windows `Path.joinpath`; component validation must happen before native path construction.
+2. State-root containment is weaker than the inbox contract. Files selected for consumption must also prove `resolved.parent == resolved_inbox`.
+3. Public provenance fields such as `path_filter` need canonical ordering and path validation at the consumer boundary, not trust in the private producer.
+
+### Recommended next move
+After the operator integrates this branch, run one finalized Dreamcatcher 0.2.0 manifest with `repository.path_filter` against a disposable Windows Rappterbook inbox, then run one ordinary no-environment Process Inbox dispatch. Verify only planned deltas publish, canonical state cannot be selected through aliases, and the GitHub Issues path remains unchanged before resuming Entry 003.37's public-discovery verification.
+
 ## Entry 003.38 — 2026-08-22 — Dreamcatcher plans stop broad inbox scans
 
 **Session**: gpt-5.4 via Copilot CLI / operator: kody-w

--- a/schema/dreamcatcher-batch-1.0.schema.json
+++ b/schema/dreamcatcher-batch-1.0.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rappter.com/schemas/dreamcatcher-batch-1.0.json",
+  "title": "Dreamcatcher Worktree Delta Batch",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "producer",
+    "base_commit",
+    "ready",
+    "ordered_manifest_ids",
+    "sources",
+    "collisions",
+    "conflicts",
+    "search_plan",
+    "batch_id"
+  ],
+  "properties": {
+    "schema": {"const": "dreamcatcher-batch/1.0"},
+    "producer": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": {"const": "twin-dreamcatcher"},
+        "version": {"type": "string", "minLength": 1}
+      }
+    },
+    "base_commit": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+    "ready": {"type": "boolean"},
+    "ordered_manifest_ids": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+      "uniqueItems": true
+    },
+    "sources": {"type": "array", "items": {"type": "object"}},
+    "collisions": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/collision"}
+    },
+    "conflicts": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/collision"}
+    },
+    "search_plan": {"type": "object"},
+    "batch_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+  },
+  "$defs": {
+    "collision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind", "manifest_ids"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "kind": {"enum": ["identical", "disjoint-hunks", "conflict"]},
+        "manifest_ids": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+          "minItems": 2,
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/schema/dreamcatcher-delta-1.0.schema.json
+++ b/schema/dreamcatcher-delta-1.0.schema.json
@@ -29,11 +29,16 @@
     "repository": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["base_commit", "head_commit", "includes_worktree"],
+      "required": ["base_commit", "head_commit", "includes_worktree", "path_filter"],
       "properties": {
         "base_commit": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
         "head_commit": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
-        "includes_worktree": {"type": "boolean"}
+        "includes_worktree": {"type": "boolean"},
+        "path_filter": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        }
       }
     },
     "source": {

--- a/schema/dreamcatcher-delta-1.0.schema.json
+++ b/schema/dreamcatcher-delta-1.0.schema.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rappter.com/schemas/dreamcatcher-delta-1.0.json",
+  "title": "Dreamcatcher Worktree Delta",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "producer",
+    "repository",
+    "source",
+    "changes",
+    "search_plan",
+    "manifest_id"
+  ],
+  "properties": {
+    "schema": {
+      "const": "dreamcatcher-delta/1.0"
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": {"const": "twin-dreamcatcher"},
+        "version": {"type": "string", "minLength": 1}
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base_commit", "head_commit", "includes_worktree"],
+      "properties": {
+        "base_commit": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+        "head_commit": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+        "includes_worktree": {"type": "boolean"}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "branch"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "branch": {"type": ["string", "null"]},
+        "frame": {"type": "integer", "minimum": 0},
+        "tile": {"type": "string", "minLength": 1}
+      }
+    },
+    "changes": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/change"}
+    },
+    "search_plan": {
+      "$ref": "#/$defs/searchPlan"
+    },
+    "manifest_id": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
+  "$defs": {
+    "blob": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["sha256", "bytes"],
+      "properties": {
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "bytes": {"type": "integer", "minimum": 0}
+      }
+    },
+    "lineRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["old_start", "old_lines", "new_start", "new_lines"],
+      "properties": {
+        "old_start": {"type": "integer", "minimum": 0},
+        "old_lines": {"type": "integer", "minimum": 0},
+        "new_start": {"type": "integer", "minimum": 0},
+        "new_lines": {"type": "integer", "minimum": 0}
+      }
+    },
+    "change": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "path",
+        "before",
+        "after",
+        "line_ranges",
+        "entity_ids",
+        "search_scopes"
+      ],
+      "properties": {
+        "status": {"enum": ["A", "M", "D", "R", "C", "T", "U"]},
+        "path": {"type": "string", "minLength": 1},
+        "old_path": {"type": "string", "minLength": 1},
+        "similarity": {"type": "integer", "minimum": 0, "maximum": 100},
+        "before": {"$ref": "#/$defs/blob"},
+        "after": {"$ref": "#/$defs/blob"},
+        "line_ranges": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/lineRange"}
+        },
+        "entity_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "search_scopes": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        }
+      }
+    },
+    "searchPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "paths",
+        "deleted_paths",
+        "renamed_paths",
+        "entity_ids",
+        "scopes",
+        "queries"
+      ],
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "deleted_paths": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "renamed_paths": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["from", "to"],
+            "properties": {
+              "from": {"type": "string", "minLength": 1},
+              "to": {"type": "string", "minLength": 1}
+            }
+          }
+        },
+        "entity_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "scopes": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "queries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "value"],
+            "properties": {
+              "kind": {"enum": ["entity", "path", "scope"]},
+              "value": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/dreamcatcher_seam.py
+++ b/scripts/dreamcatcher_seam.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Validate Dreamcatcher plans for the public Rappterbook inbox seam."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+from pathlib import Path, PurePosixPath
+
+SCHEMA = "dreamcatcher-delta/1.0"
+PRODUCER = {"name": "twin-dreamcatcher", "version": "0.2.0"}
+STATUSES = {"A", "M", "D", "R", "C", "T", "U"}
+HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+MANIFEST_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+WINDOWS_ABSOLUTE_PATTERN = re.compile(r"^[A-Za-z]:/")
+
+
+class DreamcatcherManifestError(ValueError):
+    """A Dreamcatcher manifest is malformed, stale, or unsafe to consume."""
+
+
+def _reject_non_finite(value: str) -> None:
+    """Reject non-standard JSON numeric constants."""
+    raise DreamcatcherManifestError(
+        f"non-finite JSON value {value!r} is not allowed"
+    )
+
+
+def _parse_finite_float(value: str) -> float:
+    """Reject JSON numbers that overflow Python floats."""
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise DreamcatcherManifestError(
+            f"non-finite JSON number {value!r} is not allowed"
+        )
+    return parsed
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict:
+    """Build an object while rejecting duplicate JSON keys."""
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise DreamcatcherManifestError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _load_manifest(path: Path) -> dict:
+    """Load one regular, non-symlink manifest with strict JSON semantics."""
+    if path.suffix != ".json":
+        raise DreamcatcherManifestError(f"manifest must be a .json file: {path}")
+    if path.is_symlink():
+        raise DreamcatcherManifestError(f"manifest must not be a symlink: {path}")
+    if not path.exists() or not path.is_file():
+        raise DreamcatcherManifestError(f"manifest does not exist: {path}")
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_non_finite,
+            parse_float=_parse_finite_float,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DreamcatcherManifestError(
+            f"manifest is not valid UTF-8 JSON: {exc}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise DreamcatcherManifestError("manifest must be a JSON object")
+    return value
+
+
+def _normalize_path(value: object, field: str) -> str:
+    """Require one normalized repository-relative POSIX path."""
+    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+        raise DreamcatcherManifestError(f"{field} is not a normalized path")
+    if value.startswith("/") or WINDOWS_ABSOLUTE_PATTERN.match(value):
+        raise DreamcatcherManifestError(f"{field} must be relative: {value!r}")
+    path = PurePosixPath(value)
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise DreamcatcherManifestError(f"{field} escapes its root: {value!r}")
+    if path.as_posix() != value:
+        raise DreamcatcherManifestError(f"{field} is not normalized: {value!r}")
+    return value
+
+
+def _string_list(value: object, field: str) -> list[str]:
+    """Require unique, non-empty strings."""
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise DreamcatcherManifestError(
+            f"{field} must be a list of non-empty strings"
+        )
+    if len(value) != len(set(value)):
+        raise DreamcatcherManifestError(f"{field} contains duplicates")
+    return value
+
+
+def _validate_blob(value: object, field: str) -> None:
+    """Validate one optional blob summary used for freshness checks."""
+    if value is None:
+        return
+    if not isinstance(value, dict) or set(value) != {"sha256", "bytes"}:
+        raise DreamcatcherManifestError(f"{field} is invalid")
+    digest = value["sha256"]
+    size = value["bytes"]
+    if not isinstance(digest, str) or not HASH_PATTERN.fullmatch(digest):
+        raise DreamcatcherManifestError(f"{field}.sha256 is invalid")
+    if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+        raise DreamcatcherManifestError(f"{field}.bytes is invalid")
+
+
+def _validate_change(change: object, index: int) -> str:
+    """Validate the change fields needed to trust its search-plan record."""
+    required = {
+        "status", "path", "before", "after", "line_ranges",
+        "entity_ids", "search_scopes",
+    }
+    allowed = required | {"old_path", "similarity"}
+    if not isinstance(change, dict):
+        raise DreamcatcherManifestError(f"changes[{index}] must be an object")
+    if required - set(change) or set(change) - allowed:
+        raise DreamcatcherManifestError(
+            f"changes[{index}] has unsupported or missing fields"
+        )
+    status = change["status"]
+    if status not in STATUSES:
+        raise DreamcatcherManifestError(f"changes[{index}].status is invalid")
+    path = _normalize_path(change["path"], f"changes[{index}].path")
+    if status in {"R", "C"}:
+        _normalize_path(change.get("old_path"), f"changes[{index}].old_path")
+    elif "old_path" in change:
+        raise DreamcatcherManifestError(
+            f"changes[{index}].old_path is only valid for rename or copy"
+        )
+    _validate_blob(change["before"], f"changes[{index}].before")
+    _validate_blob(change["after"], f"changes[{index}].after")
+    if status == "A" and (change["before"] is not None or change["after"] is None):
+        raise DreamcatcherManifestError(f"changes[{index}] has invalid add blobs")
+    if status == "D" and (change["before"] is None or change["after"] is not None):
+        raise DreamcatcherManifestError(f"changes[{index}] has invalid delete blobs")
+    if status not in {"A", "D"} and (
+        change["before"] is None or change["after"] is None
+    ):
+        raise DreamcatcherManifestError(
+            f"changes[{index}] requires before and after blobs"
+        )
+    if not isinstance(change["line_ranges"], list):
+        raise DreamcatcherManifestError(f"changes[{index}].line_ranges is invalid")
+    _string_list(change["entity_ids"], f"changes[{index}].entity_ids")
+    _string_list(change["search_scopes"], f"changes[{index}].search_scopes")
+    return path
+
+
+def _expected_search_plan(changes: list[dict]) -> dict:
+    """Derive the canonical public query plan from validated changes."""
+    paths: set[str] = set()
+    deleted_paths: set[str] = set()
+    renamed_paths: list[dict[str, str]] = []
+    entity_ids: set[str] = set()
+    scopes: set[str] = set()
+    queries: set[tuple[str, str]] = set()
+    for change in changes:
+        path = change["path"]
+        paths.add(path)
+        queries.add(("path", path))
+        if change["status"] == "D":
+            deleted_paths.add(path)
+        if change["status"] == "R":
+            renamed_paths.append({"from": change["old_path"], "to": path})
+        if change.get("old_path"):
+            queries.add(("path", change["old_path"]))
+        for entity_id in change["entity_ids"]:
+            entity_ids.add(entity_id)
+            queries.add(("entity", entity_id))
+        for scope in change["search_scopes"]:
+            scopes.add(scope)
+            queries.add(("scope", scope))
+    return {
+        "paths": sorted(paths),
+        "deleted_paths": sorted(deleted_paths),
+        "renamed_paths": sorted(
+            renamed_paths,
+            key=lambda item: (item["from"], item["to"]),
+        ),
+        "entity_ids": sorted(entity_ids),
+        "scopes": sorted(scopes),
+        "queries": [
+            {"kind": kind, "value": value}
+            for kind, value in sorted(queries)
+        ],
+    }
+
+
+def _canonical_id(manifest: dict) -> str:
+    """Compute the canonical content ID without manifest_id."""
+    payload = {
+        key: value for key, value in manifest.items()
+        if key != "manifest_id"
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _validate_manifest(manifest: dict) -> dict[str, dict]:
+    """Validate the consumer contract and index changes by path."""
+    fields = {
+        "schema", "producer", "repository", "source",
+        "changes", "search_plan", "manifest_id",
+    }
+    if set(manifest) != fields:
+        raise DreamcatcherManifestError("manifest fields do not match the schema")
+    if manifest["schema"] != SCHEMA:
+        raise DreamcatcherManifestError(
+            f"unsupported schema {manifest['schema']!r}"
+        )
+    if manifest["producer"] != PRODUCER:
+        raise DreamcatcherManifestError(
+            "producer must be twin-dreamcatcher 0.2.0"
+        )
+    if not isinstance(manifest["repository"], dict):
+        raise DreamcatcherManifestError("repository must be an object")
+    if not isinstance(manifest["source"], dict):
+        raise DreamcatcherManifestError("source must be an object")
+    changes = manifest["changes"]
+    if not isinstance(changes, list):
+        raise DreamcatcherManifestError("changes must be an array")
+    changes_by_path = {}
+    for index, change in enumerate(changes):
+        path = _validate_change(change, index)
+        if path in changes_by_path:
+            raise DreamcatcherManifestError(f"duplicate changed path {path}")
+        changes_by_path[path] = change
+    expected = sorted(
+        changes,
+        key=lambda item: (item["path"], item.get("old_path", ""), item["status"]),
+    )
+    if changes != expected:
+        raise DreamcatcherManifestError("changes must be deterministically sorted")
+    if manifest["search_plan"] != _expected_search_plan(changes):
+        raise DreamcatcherManifestError(
+            "search_plan does not match change records"
+        )
+    manifest_id = manifest["manifest_id"]
+    if (
+        not isinstance(manifest_id, str)
+        or not MANIFEST_ID_PATTERN.fullmatch(manifest_id)
+        or manifest_id != _canonical_id(manifest)
+    ):
+        raise DreamcatcherManifestError(
+            "manifest_id does not match the canonical payload"
+        )
+    return changes_by_path
+
+
+def _state_relative(wire_path: str) -> PurePosixPath:
+    """Map a wire path into the configured STATE_DIR namespace."""
+    parts = PurePosixPath(wire_path).parts
+    if len(parts) < 2 or parts[0] != "state":
+        raise DreamcatcherManifestError(
+            f"planned path is outside configured STATE_DIR: {wire_path}"
+        )
+    return PurePosixPath(*parts[1:])
+
+
+def _planned_file(
+    state_dir: Path,
+    state_root: Path,
+    relative: PurePosixPath,
+    wire_path: str,
+) -> tuple[Path, Path]:
+    """Resolve one current planned file without symlinks or root escapes."""
+    candidate = state_dir.joinpath(*relative.parts)
+    current = state_dir
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            raise DreamcatcherManifestError(
+                f"planned path must not use symlinks: {wire_path}"
+            )
+    if not candidate.exists():
+        raise DreamcatcherManifestError(
+            f"planned file does not exist: {wire_path}"
+        )
+    if not candidate.is_file():
+        raise DreamcatcherManifestError(
+            f"planned path is not a regular file: {wire_path}"
+        )
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(state_root)
+    except (OSError, ValueError) as exc:
+        raise DreamcatcherManifestError(
+            f"planned path is outside configured STATE_DIR: {wire_path}"
+        ) from exc
+    return candidate, resolved
+
+
+def _verify_blob(candidate: Path, change: dict, wire_path: str) -> None:
+    """Verify the current file bytes against the planned after blob."""
+    summary = change.get("after")
+    if not isinstance(summary, dict):
+        raise DreamcatcherManifestError(
+            f"planned file has no after blob: {wire_path}"
+        )
+    try:
+        content = candidate.read_bytes()
+    except OSError as exc:
+        raise DreamcatcherManifestError(
+            f"cannot read planned file {wire_path}: {exc}"
+        ) from exc
+    digest = hashlib.sha256(content).hexdigest()
+    if len(content) != summary["bytes"] or digest != summary["sha256"]:
+        raise DreamcatcherManifestError(
+            f"planned file does not match manifest blob: {wire_path}"
+        )
+
+
+def _planned_inbox_paths(
+    manifest: dict,
+    changes_by_path: dict[str, dict],
+    state_dir: Path,
+) -> list[Path]:
+    """Validate planned files and select direct inbox JSON deltas."""
+    if not state_dir.exists() or not state_dir.is_dir():
+        raise DreamcatcherManifestError(
+            f"configured STATE_DIR does not exist: {state_dir}"
+        )
+    state_root = state_dir.resolve(strict=True)
+    selected: list[Path] = []
+    seen_files: set[str] = set()
+    for wire_path in manifest["search_plan"]["paths"]:
+        relative = _state_relative(wire_path)
+        change = changes_by_path[wire_path]
+        if change["status"] == "D":
+            if relative.parts[0] == "inbox":
+                raise DreamcatcherManifestError(
+                    f"planned inbox path is deleted: {wire_path}"
+                )
+            continue
+        candidate, resolved = _planned_file(
+            state_dir, state_root, relative, wire_path
+        )
+        _verify_blob(candidate, change, wire_path)
+        if relative.parts[0] != "inbox":
+            continue
+        if len(relative.parts) != 2 or candidate.suffix != ".json":
+            raise DreamcatcherManifestError(
+                f"planned inbox path must match state/inbox/*.json: {wire_path}"
+            )
+        file_key = os.path.normcase(str(resolved))
+        if file_key in seen_files:
+            raise DreamcatcherManifestError(
+                f"duplicate planned inbox path: {wire_path}"
+            )
+        seen_files.add(file_key)
+        selected.append(candidate)
+    return selected
+
+
+def load_planned_inbox_paths(
+    manifest_path: Path,
+    state_dir: Path,
+) -> list[Path]:
+    """Load a Dreamcatcher manifest and return its safe inbox delta paths."""
+    manifest = _load_manifest(Path(manifest_path))
+    changes_by_path = _validate_manifest(manifest)
+    for change in manifest["changes"]:
+        _state_relative(change["path"])
+        if change.get("old_path"):
+            _state_relative(change["old_path"])
+    return _planned_inbox_paths(manifest, changes_by_path, Path(state_dir))

--- a/scripts/dreamcatcher_seam.py
+++ b/scripts/dreamcatcher_seam.py
@@ -14,6 +14,7 @@ SCHEMA = "dreamcatcher-delta/1.0"
 PRODUCER = {"name": "twin-dreamcatcher", "version": "0.2.0"}
 STATUSES = {"A", "M", "D", "R", "C", "T", "U"}
 HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
 MANIFEST_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 WINDOWS_ABSOLUTE_PATTERN = re.compile(r"^[A-Za-z]:/")
 
@@ -79,9 +80,14 @@ def _normalize_path(value: object, field: str) -> str:
         raise DreamcatcherManifestError(f"{field} is not a normalized path")
     if value.startswith("/") or WINDOWS_ABSOLUTE_PATTERN.match(value):
         raise DreamcatcherManifestError(f"{field} must be relative: {value!r}")
-    path = PurePosixPath(value)
-    if any(part in {"", ".", ".."} for part in path.parts):
+    components = value.split("/")
+    if any(":" in component for component in components):
+        raise DreamcatcherManifestError(
+            f"{field} contains a drive-qualified or colon path component"
+        )
+    if any(component in {"", ".", ".."} for component in components):
         raise DreamcatcherManifestError(f"{field} escapes its root: {value!r}")
+    path = PurePosixPath(value)
     if path.as_posix() != value:
         raise DreamcatcherManifestError(f"{field} is not normalized: {value!r}")
     return value
@@ -112,6 +118,42 @@ def _validate_blob(value: object, field: str) -> None:
         raise DreamcatcherManifestError(f"{field}.sha256 is invalid")
     if not isinstance(size, int) or isinstance(size, bool) or size < 0:
         raise DreamcatcherManifestError(f"{field}.bytes is invalid")
+
+
+def _validate_repository(value: object) -> None:
+    """Validate repository identity and its canonical generation path filter."""
+    fields = {
+        "base_commit", "head_commit", "includes_worktree", "path_filter",
+    }
+    if not isinstance(value, dict) or set(value) != fields:
+        raise DreamcatcherManifestError(
+            "repository fields must include path_filter and match the schema"
+        )
+    for field in ("base_commit", "head_commit"):
+        commit = value[field]
+        if not isinstance(commit, str) or not COMMIT_PATTERN.fullmatch(commit):
+            raise DreamcatcherManifestError(f"repository.{field} is invalid")
+    if not isinstance(value["includes_worktree"], bool):
+        raise DreamcatcherManifestError(
+            "repository.includes_worktree must be a boolean"
+        )
+    path_filter = value["path_filter"]
+    if not isinstance(path_filter, list):
+        raise DreamcatcherManifestError(
+            "repository.path_filter must be an array"
+        )
+    normalized = [
+        _normalize_path(path, f"repository.path_filter[{index}]")
+        for index, path in enumerate(path_filter)
+    ]
+    if len(normalized) != len(set(normalized)):
+        raise DreamcatcherManifestError(
+            "repository.path_filter contains duplicates"
+        )
+    if normalized != sorted(normalized):
+        raise DreamcatcherManifestError(
+            "repository.path_filter must be deterministically sorted"
+        )
 
 
 def _validate_change(change: object, index: int) -> str:
@@ -228,8 +270,7 @@ def _validate_manifest(manifest: dict) -> dict[str, dict]:
         raise DreamcatcherManifestError(
             "producer must be twin-dreamcatcher 0.2.0"
         )
-    if not isinstance(manifest["repository"], dict):
-        raise DreamcatcherManifestError("repository must be an object")
+    _validate_repository(manifest["repository"])
     if not isinstance(manifest["source"], dict):
         raise DreamcatcherManifestError("source must be an object")
     changes = manifest["changes"]
@@ -278,6 +319,7 @@ def _planned_file(
     state_root: Path,
     relative: PurePosixPath,
     wire_path: str,
+    expected_parent: Path | None = None,
 ) -> tuple[Path, Path]:
     """Resolve one current planned file without symlinks or root escapes."""
     candidate = state_dir.joinpath(*relative.parts)
@@ -303,6 +345,11 @@ def _planned_file(
         raise DreamcatcherManifestError(
             f"planned path is outside configured STATE_DIR: {wire_path}"
         ) from exc
+    if expected_parent is not None and resolved.parent != expected_parent:
+        raise DreamcatcherManifestError(
+            "planned inbox file does not resolve directly under "
+            f"configured STATE_DIR/inbox: {wire_path}"
+        )
     return candidate, resolved
 
 
@@ -326,6 +373,22 @@ def _verify_blob(candidate: Path, change: dict, wire_path: str) -> None:
         )
 
 
+def _resolved_inbox_root(state_dir: Path, state_root: Path) -> Path:
+    """Resolve and validate the configured inbox directory."""
+    inbox_dir = state_dir / "inbox"
+    try:
+        inbox_root = (state_root / "inbox").resolve(strict=True)
+    except OSError as exc:
+        raise DreamcatcherManifestError(
+            f"configured STATE_DIR/inbox does not exist: {inbox_dir}"
+        ) from exc
+    if not inbox_root.is_dir():
+        raise DreamcatcherManifestError(
+            f"configured STATE_DIR/inbox is not a directory: {inbox_dir}"
+        )
+    return inbox_root
+
+
 def _planned_inbox_paths(
     manifest: dict,
     changes_by_path: dict[str, dict],
@@ -337,27 +400,33 @@ def _planned_inbox_paths(
             f"configured STATE_DIR does not exist: {state_dir}"
         )
     state_root = state_dir.resolve(strict=True)
+    inbox_root = _resolved_inbox_root(state_dir, state_root)
     selected: list[Path] = []
     seen_files: set[str] = set()
     for wire_path in manifest["search_plan"]["paths"]:
         relative = _state_relative(wire_path)
         change = changes_by_path[wire_path]
+        is_inbox_path = relative.parts[0] == "inbox"
         if change["status"] == "D":
-            if relative.parts[0] == "inbox":
+            if is_inbox_path:
                 raise DreamcatcherManifestError(
                     f"planned inbox path is deleted: {wire_path}"
                 )
             continue
-        candidate, resolved = _planned_file(
-            state_dir, state_root, relative, wire_path
-        )
-        _verify_blob(candidate, change, wire_path)
-        if relative.parts[0] != "inbox":
-            continue
-        if len(relative.parts) != 2 or candidate.suffix != ".json":
+        if is_inbox_path and (len(relative.parts) != 2 or relative.suffix != ".json"):
             raise DreamcatcherManifestError(
                 f"planned inbox path must match state/inbox/*.json: {wire_path}"
             )
+        candidate, resolved = _planned_file(
+            state_dir,
+            state_root,
+            relative,
+            wire_path,
+            inbox_root if is_inbox_path else None,
+        )
+        _verify_blob(candidate, change, wire_path)
+        if not is_inbox_path:
+            continue
         file_key = os.path.normcase(str(resolved))
         if file_key in seen_files:
             raise DreamcatcherManifestError(

--- a/scripts/process_inbox.py
+++ b/scripts/process_inbox.py
@@ -25,6 +25,10 @@ DOCS_DIR = Path(os.environ.get("DOCS_DIR", "docs"))
 DEPENDENCY_GRACE = timedelta(hours=2)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from dreamcatcher_seam import (
+    DreamcatcherManifestError,
+    load_planned_inbox_paths,
+)
 from state_io import load_json, save_json, now_iso
 from actions import HANDLERS
 from actions.media import eligible_media_submission_ids, publish_verified_media
@@ -439,6 +443,21 @@ def _queue_sort_key(path: Path) -> tuple[int, object]:
     return (1, path.name)
 
 
+def _inbox_delta_files(inbox_dir: Path) -> list[Path]:
+    """Return all deltas or the validated Dreamcatcher-planned subset."""
+    manifest_variable = "DREAMCATCHER_DELTA_MANIFEST"
+    if manifest_variable not in os.environ:
+        paths = inbox_dir.glob("*.json") if inbox_dir.exists() else []
+        return sorted(paths, key=_queue_sort_key)
+    manifest_value = os.environ[manifest_variable].strip()
+    if not manifest_value:
+        raise DreamcatcherManifestError(
+            f"{manifest_variable} must name a manifest JSON file"
+        )
+    planned = load_planned_inbox_paths(Path(manifest_value), STATE_DIR)
+    return sorted(planned, key=_queue_sort_key)
+
+
 def _apply_delta(
     delta: dict,
     state: dict,
@@ -634,13 +653,13 @@ def _fire_webhooks(state: dict, processed: int) -> None:
 def main() -> int:
     """Process inbox deltas with retryable and terminal outcomes."""
     inbox_dir = STATE_DIR / "inbox"
+    try:
+        delta_files = _inbox_delta_files(inbox_dir)
+    except DreamcatcherManifestError as exc:
+        print(f"Invalid Dreamcatcher delta manifest: {exc}", file=sys.stderr)
+        return 2
     state = load_state(STATE_DIR)
     eligible_media_ids = eligible_media_submission_ids(state["flags"])
-    delta_files = (
-        sorted(inbox_dir.glob("*.json"), key=_queue_sort_key)
-        if inbox_dir.exists()
-        else []
-    )
     dirty_keys: Set[str] = set()
     agent_action_count: dict = {}
     terminal: list[tuple[Path, dict]] = []

--- a/tests/test_dreamcatcher_seam.py
+++ b/tests/test_dreamcatcher_seam.py
@@ -109,6 +109,7 @@ def _write_manifest(path: Path, changes: list[dict]) -> Path:
             "base_commit": "0" * 40,
             "head_commit": "1" * 40,
             "includes_worktree": True,
+            "path_filter": ["state/inbox"],
         },
         "source": {
             "id": "pytest",
@@ -124,6 +125,19 @@ def _write_manifest(path: Path, changes: list[dict]) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def _write_rehashed_manifest(path: Path, manifest: dict) -> None:
+    """Write a modified manifest with a fresh canonical content ID."""
+    payload = {
+        key: value for key, value in manifest.items()
+        if key != "manifest_id"
+    }
+    manifest["manifest_id"] = _canonical_id(payload)
+    path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _wire_path(state_dir: Path, file_path: Path) -> str:
@@ -334,6 +348,105 @@ def test_manifest_rejects_path_escape(
     assert result.returncode == 2
     assert "path" in result.stderr.lower()
     assert _state_snapshot(tmp_state) == before
+
+
+@pytest.mark.parametrize(
+    "wire_path",
+    [
+        "state/inbox/C:agents.json",
+        "state/in:box/agents.json",
+        "state/C:inbox/agents.json",
+        "state/inbox/agents.json:stream",
+    ],
+)
+def test_manifest_rejects_colon_path_aliases(
+    tmp_state: Path,
+    tmp_path: Path,
+    wire_path: str,
+) -> None:
+    """Every wire-path component rejects Windows drive and stream aliases."""
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(wire_path)],
+    )
+    before = _state_snapshot(tmp_state)
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "colon path component" in result.stderr
+    assert _state_snapshot(tmp_state) == before
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows drive-relative semantics")
+def test_drive_relative_alias_cannot_map_to_canonical_state(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """A drive-relative inbox name cannot select a canonical state file."""
+    canonical_state = tmp_state / "agents.json"
+    alias_name = f"{tmp_state.drive}agents.json"
+    assert tmp_state.joinpath("inbox", alias_name) == canonical_state
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(f"state/inbox/{alias_name}", canonical_state)],
+    )
+    before = _state_snapshot(tmp_state)
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "colon path component" in result.stderr
+    assert _state_snapshot(tmp_state) == before
+
+
+def test_manifest_requires_repository_path_filter(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """The finalized public delta contract requires repository.path_filter."""
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change("state/inbox/missing.json")],
+    )
+    value = json.loads(manifest.read_text(encoding="utf-8"))
+    del value["repository"]["path_filter"]
+    _write_rehashed_manifest(manifest, value)
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "path_filter" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "path_filter",
+    [
+        ["state/zeta", "state/alpha"],
+        ["state/inbox", "state/inbox"],
+        ["state/inbox/../agents.json"],
+        [r"state\inbox"],
+        ["state/inbox/C:agents.json"],
+    ],
+)
+def test_manifest_rejects_noncanonical_repository_path_filter(
+    tmp_state: Path,
+    tmp_path: Path,
+    path_filter: list[str],
+) -> None:
+    """Repository path filters must be sorted, unique, normalized paths."""
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change("state/inbox/missing.json")],
+    )
+    value = json.loads(manifest.read_text(encoding="utf-8"))
+    value["repository"]["path_filter"] = path_filter
+    _write_rehashed_manifest(manifest, value)
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "path_filter" in result.stderr
 
 
 def test_manifest_rejects_missing_planned_file(

--- a/tests/test_dreamcatcher_seam.py
+++ b/tests/test_dreamcatcher_seam.py
@@ -1,0 +1,467 @@
+"""Focused tests for the public Dreamcatcher inbox consumer seam."""
+
+import copy
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from conftest import RECENT_TS, write_delta
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "process_inbox.py"
+MANIFEST_ENV = "DREAMCATCHER_DELTA_MANIFEST"
+pytestmark = pytest.mark.no_llm_mock
+WINDOWS_BOOTSTRAP = (
+    "import runpy,sys,types;"
+    "module=types.ModuleType('fcntl');"
+    "module.LOCK_EX=1;module.LOCK_NB=2;module.LOCK_UN=8;"
+    "module.flock=lambda *_args: None;"
+    "sys.modules['fcntl']=module;"
+    "runpy.run_path(sys.argv[1],run_name='__main__')"
+)
+
+
+def _canonical_id(payload: dict) -> str:
+    """Compute a wire-compatible manifest content ID."""
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _search_plan(changes: list[dict]) -> dict:
+    """Build the canonical search plan for test change records."""
+    paths = {change["path"] for change in changes}
+    deleted = {
+        change["path"] for change in changes if change["status"] == "D"
+    }
+    renamed = [
+        {"from": change["old_path"], "to": change["path"]}
+        for change in changes
+        if change["status"] == "R"
+    ]
+    entities = {
+        value for change in changes for value in change["entity_ids"]
+    }
+    scopes = {
+        value for change in changes for value in change["search_scopes"]
+    }
+    queries = {("path", change["path"]) for change in changes}
+    queries.update(
+        ("path", change["old_path"])
+        for change in changes
+        if change.get("old_path")
+    )
+    queries.update(("entity", value) for value in entities)
+    queries.update(("scope", value) for value in scopes)
+    return {
+        "paths": sorted(paths),
+        "deleted_paths": sorted(deleted),
+        "renamed_paths": sorted(
+            renamed, key=lambda item: (item["from"], item["to"])
+        ),
+        "entity_ids": sorted(entities),
+        "scopes": sorted(scopes),
+        "queries": [
+            {"kind": kind, "value": value}
+            for kind, value in sorted(queries)
+        ],
+    }
+
+
+def _change(wire_path: str, file_path: Path | None = None) -> dict:
+    """Create one added-file change record."""
+    content = file_path.read_bytes() if file_path is not None else b"missing"
+    return {
+        "status": "A",
+        "path": wire_path,
+        "before": None,
+        "after": {
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "bytes": len(content),
+        },
+        "line_ranges": [],
+        "entity_ids": [],
+        "search_scopes": ["state/inbox"],
+    }
+
+
+def _write_manifest(path: Path, changes: list[dict]) -> Path:
+    """Write a canonical Dreamcatcher delta manifest."""
+    ordered = sorted(
+        changes,
+        key=lambda item: (item["path"], item.get("old_path", ""), item["status"]),
+    )
+    payload = {
+        "schema": "dreamcatcher-delta/1.0",
+        "producer": {"name": "twin-dreamcatcher", "version": "0.2.0"},
+        "repository": {
+            "base_commit": "0" * 40,
+            "head_commit": "1" * 40,
+            "includes_worktree": True,
+        },
+        "source": {
+            "id": "pytest",
+            "branch": "feature/dreamcatcher-delta",
+        },
+        "changes": ordered,
+        "search_plan": _search_plan(ordered),
+    }
+    manifest = dict(payload)
+    manifest["manifest_id"] = _canonical_id(payload)
+    path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _wire_path(state_dir: Path, file_path: Path) -> str:
+    """Return the canonical repository-relative state path."""
+    relative = file_path.relative_to(state_dir).as_posix()
+    return f"state/{relative}"
+
+
+def _run_inbox(state_dir: Path, manifest: Path | None = None) -> subprocess.CompletedProcess:
+    """Run process_inbox.py with an isolated state and optional manifest."""
+    docs_dir = state_dir.parent / "docs"
+    docs_dir.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env["STATE_DIR"] = str(state_dir)
+    env["DOCS_DIR"] = str(docs_dir)
+    env.pop(MANIFEST_ENV, None)
+    if manifest is not None:
+        env[MANIFEST_ENV] = str(manifest)
+    command = [sys.executable, str(SCRIPT)]
+    if os.name == "nt":
+        command = [sys.executable, "-c", WINDOWS_BOOTSTRAP, str(SCRIPT)]
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+
+
+def _write_issue_delta(
+    inbox_dir: Path,
+    issue_number: int,
+    action: str,
+    payload: dict,
+    timestamp: str,
+) -> Path:
+    """Write one authenticated Issue delta for queue-order testing."""
+    delta = {
+        "action": action,
+        "agent_id": "scope-agent",
+        "timestamp": timestamp,
+        "payload": payload,
+        "issue_number": issue_number,
+        "request_id": f"issue:{issue_number}",
+        "submitter_id": 4242,
+    }
+    path = inbox_dir / f"issue-{issue_number}.json"
+    path.write_text(json.dumps(delta, indent=2), encoding="utf-8")
+    return path
+
+
+def _state_snapshot(state_dir: Path) -> dict[str, bytes]:
+    """Capture every regular state file for pre-write failure assertions."""
+    return {
+        path.relative_to(state_dir).as_posix(): path.read_bytes()
+        for path in state_dir.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_scoped_manifest_preserves_existing_queue_order(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """Manifest ordering must not replace numeric Issue queue ordering."""
+    base = datetime.fromisoformat(RECENT_TS.replace("Z", "+00:00"))
+    register = _write_issue_delta(
+        tmp_state / "inbox",
+        2,
+        "register_agent",
+        {"name": "Scoped", "framework": "pytest", "bio": "Original"},
+        RECENT_TS,
+    )
+    update = _write_issue_delta(
+        tmp_state / "inbox",
+        10,
+        "update_profile",
+        {"bio": "Updated through queue order"},
+        (base + timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [
+            _change(_wire_path(tmp_state, register), register),
+            _change(_wire_path(tmp_state, update), update),
+        ],
+    )
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 0, result.stderr
+    agents = json.loads((tmp_state / "agents.json").read_text())
+    assert agents["agents"]["scope-agent"]["bio"] == "Updated through queue order"
+    assert not register.exists()
+    assert not update.exists()
+
+
+def test_scoped_manifest_excludes_unrelated_inbox_files(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """Only manifest-planned inbox deltas are consumed."""
+    planned = write_delta(
+        tmp_state / "inbox",
+        "planned-agent",
+        "register_agent",
+        {"name": "Planned", "framework": "pytest", "bio": "Included"},
+    )
+    unrelated = write_delta(
+        tmp_state / "inbox",
+        "unrelated-agent",
+        "register_agent",
+        {"name": "Unrelated", "framework": "pytest", "bio": "Excluded"},
+    )
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(_wire_path(tmp_state, planned), planned)],
+    )
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 0, result.stderr
+    agents = json.loads((tmp_state / "agents.json").read_text())["agents"]
+    assert "planned-agent" in agents
+    assert "unrelated-agent" not in agents
+    assert not planned.exists()
+    assert unrelated.exists()
+
+
+def test_tampered_manifest_fails_before_state_write(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """A payload change with a stale ID must fail closed."""
+    delta = write_delta(
+        tmp_state / "inbox",
+        "tamper-agent",
+        "register_agent",
+        {"name": "Tamper", "framework": "pytest", "bio": "Blocked"},
+    )
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(_wire_path(tmp_state, delta), delta)],
+    )
+    value = json.loads(manifest.read_text(encoding="utf-8"))
+    value["source"]["id"] = "tampered"
+    manifest.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    before = _state_snapshot(tmp_state)
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "manifest_id" in result.stderr
+    assert _state_snapshot(tmp_state) == before
+
+
+def test_stale_planned_blob_fails_before_state_write(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """A file changed after planning must not reach the inbox processor."""
+    delta = write_delta(
+        tmp_state / "inbox",
+        "stale-agent",
+        "register_agent",
+        {"name": "Stale", "framework": "pytest", "bio": "Original"},
+    )
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(_wire_path(tmp_state, delta), delta)],
+    )
+    value = json.loads(delta.read_text(encoding="utf-8"))
+    value["payload"]["bio"] = "Changed after planning"
+    delta.write_text(json.dumps(value, indent=2), encoding="utf-8")
+    before = _state_snapshot(tmp_state)
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "does not match manifest blob" in result.stderr
+    assert _state_snapshot(tmp_state) == before
+
+
+@pytest.mark.parametrize(
+    "wire_path",
+    [
+        "state/inbox/../outside.json",
+        "/state/inbox/absolute.json",
+        "C:/state/inbox/absolute.json",
+        r"state\inbox\backslash.json",
+    ],
+)
+def test_manifest_rejects_path_escape(
+    tmp_state: Path,
+    tmp_path: Path,
+    wire_path: str,
+) -> None:
+    """Escaping and platform-specific paths are rejected before writes."""
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(wire_path)],
+    )
+    before = _state_snapshot(tmp_state)
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "path" in result.stderr.lower()
+    assert _state_snapshot(tmp_state) == before
+
+
+def test_manifest_rejects_missing_planned_file(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """A canonical plan cannot name a file that is no longer present."""
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change("state/inbox/missing.json")],
+    )
+    before = _state_snapshot(tmp_state)
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "does not exist" in result.stderr
+    assert _state_snapshot(tmp_state) == before
+
+
+def test_no_manifest_preserves_legacy_inbox_behavior(tmp_state: Path) -> None:
+    """Without the environment variable, every queued delta is processed."""
+    delta = write_delta(
+        tmp_state / "inbox",
+        "legacy-agent",
+        "register_agent",
+        {"name": "Legacy", "framework": "pytest", "bio": "Unscoped"},
+    )
+
+    result = _run_inbox(tmp_state)
+
+    assert result.returncode == 0, result.stderr
+    agents = json.loads((tmp_state / "agents.json").read_text())["agents"]
+    assert "legacy-agent" in agents
+    assert not delta.exists()
+
+
+def test_manifest_rejects_non_json_inbox_file(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """The seam never passes a non-JSON inbox file to process_inbox."""
+    text_file = tmp_state / "inbox" / "delta.txt"
+    text_file.write_text("{}", encoding="utf-8")
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(_wire_path(tmp_state, text_file), text_file)],
+    )
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "state/inbox/*.json" in result.stderr
+    assert text_file.exists()
+
+
+def test_manifest_rejects_duplicate_changed_paths(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """Duplicate wire paths are rejected even when the ID is canonical."""
+    delta = write_delta(
+        tmp_state / "inbox",
+        "duplicate-agent",
+        "register_agent",
+        {"name": "Duplicate", "framework": "pytest", "bio": "Blocked"},
+    )
+    change = _change(_wire_path(tmp_state, delta), delta)
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [change, copy.deepcopy(change)],
+    )
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "duplicate changed path" in result.stderr
+    assert delta.exists()
+
+
+def test_manifest_rejects_symlinked_planned_file(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """A planned inbox delta cannot be supplied through a symlink."""
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    linked = tmp_state / "inbox" / "linked.json"
+    try:
+        linked.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(_wire_path(tmp_state, linked), linked)],
+    )
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "symlink" in result.stderr
+
+
+def test_rehashed_search_plan_mismatch_is_rejected(
+    tmp_state: Path,
+    tmp_path: Path,
+) -> None:
+    """A fresh ID cannot legitimize a plan that omits its change."""
+    delta = write_delta(
+        tmp_state / "inbox",
+        "plan-agent",
+        "register_agent",
+        {"name": "Plan", "framework": "pytest", "bio": "Blocked"},
+    )
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        [_change(_wire_path(tmp_state, delta), delta)],
+    )
+    value = json.loads(manifest.read_text(encoding="utf-8"))
+    value["search_plan"]["paths"] = []
+    payload = {
+        key: item for key, item in value.items() if key != "manifest_id"
+    }
+    value["manifest_id"] = _canonical_id(payload)
+    manifest.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+    result = _run_inbox(tmp_state, manifest)
+
+    assert result.returncode == 2
+    assert "search_plan" in result.stderr
+    assert delta.exists()


### PR DESCRIPTION
Consumes the public search-plan seam from `dreamcatcher-delta/1.0` introduced by kody-w/rappter#5 without exposing private engine logic.

## What changed
- adds the public delta/batch schemas and a stdlib-only consumer validator
- scopes `process_inbox.py` to only manifest-planned inbox files when the private engine supplies a plan
- fails before state writes on tampering, missing files, symlinks, traversal, drive-relative aliases, or stale IDs
- preserves the existing no-manifest GitHub Issues workflow
- records the experiment in `LAB_NOTEBOOK.md`

## Validation
- 25 seam tests
- 77 relevant inbox tests (1 existing conditional skip)
- Python compile, schema parity, and diff checks