### PR TITLE
fix(reconcile): refresh authoritative comment metadata

### DIFF
--- a/scripts/reconcile_channels.py
+++ b/scripts/reconcile_channels.py
@@ -636,6 +636,13 @@ def main() -> None:
     log_meta = existing_log.setdefault("_meta", {})
     log_meta["authoritative_source"] = source_name
     log_meta["authoritative_total_posts"] = int(expected_total or len(discussions))
+    authoritative_comments = source_meta.get("comment_total")
+    if authoritative_comments is None:
+        authoritative_comments = sum(
+            int(discussion.get("comment_count") or 0)
+            for discussion in discussions
+        )
+    log_meta["authoritative_total_comments"] = int(authoritative_comments)
     log_meta["authoritative_refreshed_at"] = source_meta.get("reference_timestamp")
     save_json(log_path, existing_log)
 

--- a/tests/test_reconcile_channels.py
+++ b/tests/test_reconcile_channels.py
@@ -59,7 +59,11 @@ def test_main_reads_from_cache_shards_when_cache_file_is_missing(tmp_path, monke
     (docs_dir / "pulse.json").write_text(json.dumps({}))
     (state_dir / "stats.json").write_text(json.dumps({}))
     (state_dir / "agents.json").write_text(json.dumps({"agents": {}}))
-    (state_dir / "posted_log.json").write_text(json.dumps({"posts": [], "comments": []}))
+    (state_dir / "posted_log.json").write_text(json.dumps({
+        "posts": [],
+        "comments": [],
+        "_meta": {"authoritative_total_comments": 1},
+    }))
     (state_dir / "manifest.json").write_text(json.dumps({}))
     (state_dir / "channels.json").write_text(json.dumps({
         "channels": {"general": {"verified": True, "post_count": 0}},
@@ -98,8 +102,10 @@ def test_main_reads_from_cache_shards_when_cache_file_is_missing(tmp_path, monke
     reconcile_channels.main()
 
     stats = json.loads((state_dir / "stats.json").read_text())
+    posted_log = json.loads((state_dir / "posted_log.json").read_text())
     assert stats["total_posts"] == 1
     assert stats["total_comments"] == 2
+    assert posted_log["_meta"]["authoritative_total_comments"] == 2
 
 
 def test_stats_snapshot_excludes_legacy_vote_comments():


### PR DESCRIPTION
## Summary
- refresh `posted_log._meta.authoritative_total_comments` from the same authoritative corpus used by reconciliation
- cover replacement of stale metadata in the shard-backed reconciliation regression

## Validation
- `python3 -m pytest tests/test_reconcile_channels.py -v` (12 passed)