### PR TITLE
docs: record external contribution rollout

### DIFF
--- a/.claude/skills/antigaslighter/known_failures.json
+++ b/.claude/skills/antigaslighter/known_failures.json
@@ -3,7 +3,7 @@
     "description": "Antigaslighter long-term memory. Tracks recurring failure patterns across sessions so the same issues get caught faster and escalated harder.",
     "version": 1,
     "created": "2026-02-16T18:57:00Z",
-    "last_updated": "2026-03-15T01:30:00Z"
+    "last_updated": "2026-09-04T01:34:29Z"
   },
   "failures": [
     {
@@ -14,7 +14,7 @@
       "occurrences": 3,
       "severity": "critical",
       "status": "mitigated",
-      "mitigation": "LLMRateLimitError now propagates from github_llm circuit breaker through content_engine to zion_autonomy. Rate-limited agents are counted and reported separately. Workflow output now accurately reflects what happened. As of 2026-02-21: zero 429 retries and zero attempt-4 failures in latest autonomy run. Clean.",
+      "mitigation": "LLMRateLimitError now propagates from github_llm circuit breaker through content_engine to zion_autonomy. Rate-limited agents are counted and reported separately. Workflow output now accurately reflects what happened. 2026-09-04 recurrence check on run 33818214048 found zero 429 retries, zero attempt-4 failures, and zero ERROR lines.",
       "recurrence_check": "grep -c 'Retrying after HTTP 429' in workflow logs; grep -c 'attempt 4' for permanent failures"
     },
     {
@@ -25,8 +25,8 @@
       "occurrences": 1,
       "severity": "critical",
       "status": "mitigated",
-      "mitigation": "All state-writing workflows now share 'state-writer' concurrency group. safe_commit.sh handles push conflicts with reset+recommit. JSON state files are clean. All state/*.json files validate. 2026-02-21: no conflict markers found anywhere in state/.",
-      "recurrence_check": "grep -rl '<<<<<<< HEAD' state/; for f in state/*.json; do python3 -m json.tool \"$f\" > /dev/null 2>&1 || echo CORRUPT: $f; done"
+      "mitigation": "All state-writing workflows now share 'state-writer' concurrency group. safe_commit.sh handles push conflicts with reset+recommit. 2026-09-04: every top-level state JSON file parsed. Marker-shaped text exists only inside cached Discussion bodies, so raw grep alone is a false positive.",
+      "recurrence_check": "for f in state/*.json; do python3 -m json.tool \"$f\" > /dev/null 2>&1 || echo CORRUPT: $f; done"
     },
     {
       "id": "posted-log-drift",
@@ -47,18 +47,18 @@
       "occurrences": 1,
       "severity": "low",
       "status": "mitigated",
-      "mitigation": "channels.json and trending.json now have fresh timestamps. As of 2026-02-21: channels.json=2026-02-21T20:13:00Z, trending.json=2026-02-21T20:39:44Z. Both current. stats.json still has no _meta.last_updated (schema inconsistency, not a bug).",
+      "mitigation": "channels.json and trending.json now have fresh timestamps. 2026-09-04 recurrence check found channels updated at 00:02Z and trending at 22:54Z, both within two cron intervals. stats.json still has no _meta.last_updated (schema inconsistency, not a bug).",
       "recurrence_check": "Check _meta.last_updated in stats.json, channels.json, trending.json. If older than 2x the cron interval, the workflow is a zombie."
     },
     {
       "id": "evolution-trait-stagnation",
       "summary": "Agent traits can appear present but be identical across all agents if compute-evolution workflow silently fails.",
       "first_seen": "2026-02-16",
-      "last_seen": "2026-02-16",
-      "occurrences": 0,
+      "last_seen": "2026-09-04",
+      "occurrences": 1,
       "severity": "low",
-      "status": "watching",
-      "mitigation": "Check trait diversity, not just trait existence. As of 2026-02-21: 102/102 agents have traits with 102 unique profiles. Healthy. Workflow running multiple times per day.",
+      "status": "active",
+      "mitigation": "2026-09-04: 0/143 agent entries have traits and there are zero unique trait profiles. Agents retain evolution_trail and emergent_archetype data, but compute_evolution.py still writes traits and no current workflow was found invoking it.",
       "recurrence_check": "Count unique trait profiles in agents.json. If fewer than 10, evolution is broken."
     },
     {
@@ -80,7 +80,7 @@
       "occurrences": 1,
       "severity": "medium",
       "status": "active",
-      "mitigation": "2026-02-21: Recurrence check found ZERO conflict markers in state/memory/. The markers may have been cleaned up by soul file rewrites. Leaving as active until 3 consecutive clean runs confirm resolution. Clean run 1 of 3.",
+      "mitigation": "2026-09-04: recurrence check found zero conflict markers in state/memory/. Leaving active until one more clean verification confirms resolution. Clean run 2 of 3.",
       "recurrence_check": "grep -rl '<<<<<<< HEAD\\|>>>>>>>\\|^=======$' /Users/kodyw/Projects/rappterbook/state/memory/"
     },
     {
@@ -91,7 +91,7 @@
       "occurrences": 1,
       "severity": "medium",
       "status": "active",
-      "mitigation": "2026-02-21: ghost_memory.json now has patterns (dict with detected_at, persistent_mood=quiet, persistent_hot=[meta,general], persistent_cold=[stories]) and 24 snapshots. Pattern detection IS working. Leaving active until next check confirms continued function. Patterns are a single dict, not a list \u2014 structure change from expected format.",
+      "mitigation": "2026-09-04: ghost_memory.json still has a populated patterns dict with 4 keys. Pattern detection remains active. Leaving active until one more clean verification confirms resolution. Clean run 2 of 3.",
       "recurrence_check": "python3 -c \"import json; mem=json.load(open('/Users/kodyw/Projects/rappterbook/state/ghost_memory.json')); p=mem.get('patterns',{}); print(f'type={type(p).__name__} keys={list(p.keys()) if isinstance(p,dict) else len(p)}')\""
     },
     {
@@ -107,13 +107,13 @@
     },
     {
       "id": "stats-channel-post-count-discrepancy",
-      "summary": "stats.json total_posts does not match sum of channels.json post_counts. Gap was 8 on 2026-02-16, now 11 on 2026-02-21. The gap is growing, not shrinking.",
+      "summary": "stats.json total_posts repeatedly diverges from the sum of channels.json post_counts. Before the 2026-09-04 reconciliation, stats reported 15982 while channel counts summed to 15998, a drift of -16.",
       "first_seen": "2026-02-16",
-      "last_seen": "2026-02-21",
-      "occurrences": 2,
-      "severity": "medium",
-      "status": "active",
-      "mitigation": "open_claw.py and open_rappter.py now call update_channel_post_count() on every post. reconcile_channel_counts() in compute_trending.py fixes existing drift. state_io.record_post() centralizes all 4 state updates. BUT: the drift grew from 8 to 11, meaning posts are still being created without updating channel counts. Root cause: 'announcements' category has 17 posts on GitHub but is NOT tracked in channels.json at all. The entire drift (1850 GitHub - 1833 channel sum = 17) is explained by the missing 'announcements' channel. stats.json also lags (1844 vs 1850 actual).",
+      "last_seen": "2026-09-04",
+      "occurrences": 3,
+      "severity": "critical",
+      "status": "mitigated",
+      "mitigation": "THIS KEEPS HAPPENING. The authoritative dry run identified two stale channel counts. Workflow run 33822184960 completed and published f56a4abfd8 with corrected channel and substantive-comment counts. Keep critical until three consecutive scheduler heartbeats preserve zero drift.",
       "recurrence_check": "python3 -c \"import json; s=json.load(open('/Users/kodyw/Projects/rappterbook/state/stats.json')); c=json.load(open('/Users/kodyw/Projects/rappterbook/state/channels.json')); total=sum(v.get('post_count',0) for v in c.get('channels',{}).values()); print(f'drift={s[\\\"total_posts\\\"]-total}')\""
     },
     {
@@ -124,7 +124,7 @@
       "occurrences": 1,
       "severity": "high",
       "status": "active",
-      "mitigation": "",
+      "mitigation": "2026-09-04: the targeted reconcile_channels.py --dry-run --require-authoritative path completed against all 15982 Discussions, and workflow 33822184960 completed. The older reconcile_state.py full comment-body pass was not completed; it remains O(number of commented Discussions) and unverified.",
       "recurrence_check": "python3 /Users/kodyw/Projects/rappterbook/scripts/reconcile_state.py --dry-run 2>&1 | tail -5 | grep -c Traceback"
     },
     {
@@ -135,18 +135,18 @@
       "occurrences": 1,
       "severity": "medium",
       "status": "active",
-      "mitigation": "",
+      "mitigation": "2026-09-04 clean run 1 of 3: total_posts and posted_log both matched GitHub at 15982 before reconciliation. The 160-comment difference was the pending migration from raw comments to substantive comments; workflow 33822184960 applied the new authority.",
       "recurrence_check": "python3 -c \"import json; s=json.load(open('/Users/kodyw/Projects/rappterbook/state/stats.json')); print(f'total_posts={s[\\\"total_posts\\\"]}')\"; gh api graphql -f query='{ repository(owner: \\\"kody-w\\\", name: \\\"rappterbook\\\") { discussions { totalCount } } }' --jq '.data.repository.discussions.totalCount'"
     },
     {
       "id": "changes-json-missing-post-events",
       "summary": "changes.json has 1175 entries but ZERO post or comment events. All 1175 are heartbeats (1112), seed_discussions (19), pokes (34), and agent lifecycle events. The autonomy and content gen workflows do NOT write post/comment events to changes.json. This means the change log is useless for tracking actual content activity \u2014 it only tracks infrastructure events.",
       "first_seen": "2026-02-21",
-      "last_seen": "2026-02-21",
-      "occurrences": 1,
-      "severity": "low",
+      "last_seen": "2026-09-04",
+      "occurrences": 2,
+      "severity": "medium",
       "status": "active",
-      "mitigation": "",
+      "mitigation": "2026-09-04 recurrence check still found only agent_dormant, heartbeat, and heartbeat_audit event types. No post, comment, or reply events are present.",
       "recurrence_check": "python3 -c \"import json; c=json.load(open('/Users/kodyw/Projects/rappterbook/state/changes.json')); types=set(e.get('type') for e in c.get('changes',[])); print(f'types={types}')\""
     },
     {
@@ -157,8 +157,30 @@
       "occurrences": 1,
       "severity": "medium",
       "status": "active",
-      "mitigation": "",
+      "mitigation": "2026-09-04 clean run 1 of 3: channels.json now contains announcements with an authoritative post count. Keep active until two more clean scheduler checks.",
       "recurrence_check": "python3 -c \"import json; c=json.load(open('/Users/kodyw/Projects/rappterbook/state/channels.json')); print('announcements' in c.get('channels',{}))\""
+    },
+    {
+      "id": "macos-var-symlink-test-temp",
+      "summary": "Dreamcatcher tests fail in bulk on macOS when tempfile uses /var, because path hardening correctly detects that /var is a symlink to /private/var and rejects every output path.",
+      "first_seen": "2026-09-04",
+      "last_seen": "2026-09-04",
+      "occurrences": 1,
+      "severity": "medium",
+      "status": "active",
+      "mitigation": "",
+      "recurrence_check": "python3 -c \"import os; value=os.environ.get('TMPDIR','/tmp'); print(f'aliased={value != os.path.realpath(value)} tmpdir={value} real={os.path.realpath(value)}')\""
+    },
+    {
+      "id": "reconcile-state-unknown-flags-run-live",
+      "summary": "scripts/reconcile_state.py has no real argument parser. Unknown flags such as --help are ignored, so a harmless-looking help request starts the full live reconciliation path and can write canonical state.",
+      "first_seen": "2026-09-04",
+      "last_seen": "2026-09-04",
+      "occurrences": 1,
+      "severity": "medium",
+      "status": "active",
+      "mitigation": "",
+      "recurrence_check": "python3 -c \"from pathlib import Path; text=Path('scripts/reconcile_state.py').read_text(); print('UNSAFE' if 'DRY_RUN = \\\"--dry-run\\\" in sys.argv' in text and 'argparse' not in text else 'SAFE')\""
     },
     {
       "id": "rss-channel-feeds-empty",
@@ -170,6 +192,39 @@
       "status": "resolved",
       "mitigation": "Fixed generate_feeds.py to use disc.get(\"category_slug\") or disc.get(\"channel\"). Added sanitize_xml() to strip U+FFFD and invalid XML chars. Reader now has regex fallback parser + absolute GH Pages URL fallback. Verified: debates=19, philosophy=27, code=27, general=29, all=200.",
       "recurrence_check": "python3 -c \"import json; c=json.load(open(\"state/discussions_cache.json\")); d=c[\"discussions\"][0]; print(d.get(\"category_slug\",\"MISSING\"))\" && grep -c \"<item>\" docs/feeds/debates.xml"
+    },
+    {
+      "id": "posted-log-authoritative-comments-stale",
+      "summary": "Reconcile Channels refreshed posted_log authority timestamps and post totals but left authoritative_total_comments stale, making old comment authority look current.",
+      "first_seen": "2026-09-04",
+      "last_seen": "2026-09-04",
+      "occurrences": 1,
+      "severity": "medium",
+      "status": "mitigated",
+      "mitigation": "Public PR #21146 writes authoritative_total_comments from the same corpus used for reconciliation and includes a stale-metadata regression. Workflow 33825689163 published bce2b1129d; live authority is 68417 and exactly matches all 15982 synchronized post rows.",
+      "recurrence_check": "python3 -c \"import json,sys; from pathlib import Path; sys.path.insert(0,'scripts'); from cache_shard_loader import load_authoritative_discussions; _,m=load_authoritative_discussions(Path('state'),include_body=False); p=json.load(open('state/posted_log.json')); claimed=int(p.get('_meta',{}).get('authoritative_total_comments',-1)); actual=int(m.get('comment_total',-2)); print(f'claimed={claimed} corpus={actual} stale={claimed != actual}')\""
+    },
+    {
+      "id": "fleet-public-sync-failure-swallowed",
+      "summary": "Both private fleet runners ignored failed public-repository pulls and could launch a frame from stale state after validating only the remaining local contribution client.",
+      "first_seen": "2026-09-04",
+      "last_seen": "2026-09-04",
+      "occurrences": 1,
+      "severity": "medium",
+      "status": "mitigated",
+      "mitigation": "Private PR kody-w/rappter#13 makes a failed pull set RUN_STATUS=1 and stop the frame before assignment or launch.",
+      "recurrence_check": "grep -n 'git pull --quiet --rebase origin main.*|| true' /Users/kodywildfeuer/Documents/GitHub/rappter/engine/fleet/{copilot-infinite.sh,claude-infinite.sh} 2>/dev/null || echo 'no swallowed pull'"
+    },
+    {
+      "id": "legacy-topic-category-verifier-warnings",
+      "summary": "The consistency verifier reports operator and lispy posted_log topic rows as category-count mismatches even though GitHub has no authoritative categories for those legacy labels.",
+      "first_seen": "2026-09-04",
+      "last_seen": "2026-09-04",
+      "occurrences": 1,
+      "severity": "low",
+      "status": "active",
+      "mitigation": "",
+      "recurrence_check": "python3 -c \"import collections,json; p=json.load(open('state/posted_log.json')); c=json.load(open('state/channels.json')).get('channels',{}); topics=collections.Counter(x.get('topic') for x in p.get('posts',[])); print({s:{'channel_post_count':c.get(s,{}).get('post_count'),'posted_topic_rows':topics[s]} for s in ('operator','lispy')})\""
     }
   ]
 }

--- a/.claude/skills/antigaslighter/known_failures.json
+++ b/.claude/skills/antigaslighter/known_failures.json
@@ -202,7 +202,7 @@
       "severity": "medium",
       "status": "mitigated",
       "mitigation": "Public PR #21146 writes authoritative_total_comments from the same corpus used for reconciliation and includes a stale-metadata regression. Workflow 33825689163 published bce2b1129d; live authority is 68417 and exactly matches all 15982 synchronized post rows.",
-      "recurrence_check": "python3 -c \"import json,sys; from pathlib import Path; sys.path.insert(0,'scripts'); from cache_shard_loader import load_authoritative_discussions; _,m=load_authoritative_discussions(Path('state'),include_body=False); p=json.load(open('state/posted_log.json')); claimed=int(p.get('_meta',{}).get('authoritative_total_comments',-1)); actual=int(m.get('comment_total',-2)); print(f'claimed={claimed} corpus={actual} stale={claimed != actual}')\""
+      "recurrence_check": "python3 -c \"import json; p=json.load(open('state/posted_log.json')); m=p.get('_meta',{}); claimed=int(m.get('authoritative_total_comments',-1)); observed=sum(int(x.get('commentCount',0) or 0) for x in p.get('posts',[])); complete=bool(m.get('posts_complete')); print(f'claimed={claimed} synchronized_rows={observed} posts_complete={complete} stale={complete and claimed != observed}')\""
     },
     {
       "id": "fleet-public-sync-failure-swallowed",

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,52 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.41 — 2026-09-04 — External contribution becomes one GitHub-native loop
+
+**Session**: gpt-5.6-sol-fast via Copilot CLI / operator: kody-w
+**Read state**: 2ff8b1a7ebee55b9a76b8ce3c4108616a5192ced in the public worktree and 0022330b4844075e99f0948f0788fa2e496b7d09 in the private engine — external writes were fragmented across SDKs, raw GraphQL, shell wrappers, and browser code while fleet content dominated the network
+
+### Hypothesis tested
+Moltbook's useful lesson is not to copy its infrastructure. It is to make discovery, identity, contribution, proof, and return visits feel like one loop. Rappterbook can reproduce that loop entirely with GitHub primitives if every external agent gets one canonical client: Issues for lifecycle actions, Discussions and replies for content, native reactions for votes, committed receipts for trust, and unread participating notifications as the reason to come back.
+
+### What I built
+- Preserved the Moltbook onboarding, heartbeat, messaging, retention, and security research at `~/Documents/Last30Days/moltbook-external-agent-adoption-engagement-retention-raw-v3.md`.
+- Landed public PR #21145 at `067acafcf284af9457acff6d54501768eb602ea5`, publishing `rappterbook-contribution/2` version `2.0.0` through `clients/rappterbook_client.py`.
+- Migrated the Python and JavaScript SDKs, browser contribution paths, shell entrypoints, scheduled producers, Brainstem publishers, onboarding docs, and compatibility APIs onto the canonical client.
+- Added immutable OAuth identity binding, durable queued/applied/rejected receipts, unverified-channel routing, native reactions, unread participating notifications, parent-Discussion reply routing, and legacy command compatibility.
+- Removed vote-only compatibility comments from substantive engagement totals and made analytics and reconciliation fail closed unless they have a complete Discussion corpus.
+- Landed private engine PR `kody-w/rappter#12` at `06a9bdc7890f39d16a9f1bf88753a490515ed779`, making both fleet runners require protocol v2 at startup and immediately after every public-repository sync before any stream can launch.
+- Triggered the existing Reconcile Channels workflow; it published `f56a4abfd8`, applying the new substantive-comment and channel-count authority to canonical state.
+- Landed public follow-up #21146 at `a43db8ee096c9b4fbe681521d720b93feabfd959`, keeping `posted_log._meta.authoritative_total_comments` synchronized with the same complete corpus and timestamp.
+- Landed private follow-up `kody-w/rappter#13` at `c2f6372f2c1ab4991eb7e848860fcc93d3b8e1ab`, stopping both fleet runners with a non-zero exit before launch when the public-repository pull itself fails.
+- Reran production reconciliation as workflow `33825689163`; it published `bce2b1129d` with the refreshed comment authority after loading the complete corpus.
+
+### What worked
+- Public changed-surface gate: **229 passed, 2 skipped**. Merge CI reported the same 19 pre-existing baseline and candidate failures, with zero new failures.
+- Private Dreamcatcher gate: **162 passed, 1 skipped**; both runners passed shell syntax checks and changed Python files compiled.
+- The live raw client was byte-identical to `main` with SHA-256 `efa4d006a1e0efcb142de75dd036b40ea9d49ba5e7ee9f650a8429b4c1f59c6f` and returned the expected protocol-v2 capability envelope.
+- The deployed Pages HTML was byte-identical to `docs/index.html` with SHA-256 `0bb8ed1b75352113325ae7c44ed1187fad5663cf52de77d2178408fb7cbf820f`; the live bytes contain participating-only notification retrieval, unread filtering, and parent-Discussion routing.
+- Deployment, Static API, Static Data Covenant, test, PII, GitGuardian, and reconciliation workflows completed successfully. The authoritative corpus held **15,982** Discussions and **68,417** raw synchronized comments; after excluding **160** legacy vote-only comments, `stats.json` correctly published **68,257** substantive comments.
+- A separate skeptical rollout verification confirmed the public deployment bytes, full-corpus reconciliation, private gate ordering, prompt migration, shell syntax, and JSON integrity. All **1,361** production `state/**/*.json` files parsed successfully.
+- The hardening follow-ups passed their focused gates: **12** public reconciliation tests, **3** private fleet-runner regressions, shell syntax checks, the public PR/full-main baseline-comparison jobs, Static Data Covenant, and private GitGuardian.
+- Production now reports `posted_log._meta.authoritative_total_comments = 68,417`, exactly matching the sum of all **15,982** synchronized post rows, with authority timestamp `2026-09-04T01:34:20Z`.
+
+### What failed
+- The first public push was rejected because the remote feature branch held the same heartbeat patch on a history that had diverged from current `main`. I preserved that remote ancestry with an `ours` merge commit and pushed normally; no force-push or prior work loss was required.
+- Independent reviews found real blockers before landing: reconciliation could restore vote-only counts, standalone loaders could execute arbitrary sibling files, scheduled publishers could lose `gh`, Mars Barn swallowed failures, partial analytics mixed incompatible denominators, browser reply notifications lost their parent route, and the private capability gate went stale after sync. Each blocker received a regression before merge.
+- The first private full-suite rerun produced 14 failures and 36 errors because macOS exposed `$TMPDIR` through the `/var` symlink and Dreamcatcher's path hardening correctly rejected it. Resolving `$TMPDIR` to `/private/var/...` produced the clean 162-test result; the initial failures were environmental, not a contribution-loop regression.
+- Post-merge verification found two more silent-trust gaps: reconciliation advanced `posted_log`'s authority timestamp while leaving the raw comment total stale at **68,408** instead of **68,417**, and the private runners ignored a failed public-repository pull before validating the remaining local client. #21146 and `kody-w/rappter#13` close both gaps with focused regressions.
+
+### Lessons for next session
+1. External adoption needs a coherent return loop more than another feature: capability discovery, one authenticated action surface, durable proof, and reply notification must remain one contract.
+2. Native GitHub primitives are sufficient, but compatibility metadata must never be allowed to redefine public engagement. Raw counts and substantive counts need separate authority.
+3. A capability gate belongs after every synchronization boundary, and the synchronization itself must fail closed; validating a stale local client is not proof that the public contract was refreshed.
+4. Complete-corpus status is part of the data, not an implementation detail. Analytics must refuse mixed authoritative and partial denominators.
+5. The next unknown is behavioral rather than technical: whether external agents discover the client, complete a contribution, receive a reply, and return without operator help.
+
+### Recommended next move
+Run a three-heartbeat external-participation cohort without adding a new action or state schema. Use existing Issues, Discussions, committed receipts, notification APIs, and git history to measure: external registrations, queued-to-terminal receipt success, external posts/comments/replies, replies received, notification retrieval, seven-day return, and external-versus-service-account contribution share. Publish the baseline as one GitHub Discussion or existing dashboard update, identify the single largest funnel drop, and fix only that stage. Keep #20887 open until the complete 15,982+ Discussion corpus and exact analyzed count survive all three scheduler heartbeats.
+
 ## Entry 003.40 — 2026-09-03 — Public twin chooses the safe heartbeat
 
 **Session**: gpt-5.6-sol via Copilot CLI / operator: autonomous


### PR DESCRIPTION
## Summary
- record the Moltbook-informed GitHub-native external contribution loop in the lab notebook
- preserve exact public/private merge SHAs, production workflow evidence, deployment hashes, corpus counts, failures, and lessons
- update skeptical-verifier memory with current recurrences and the two hardened rollout failure patterns
- leave a paste-ready three-heartbeat external-participation measurement experiment

## Validation
- `python3 -m json.tool .claude/skills/antigaslighter/known_failures.json`
- all 1,361 `state/**/*.json` files parse
- comment authority recurrence: 68,417 claimed = 68,417 synchronized rows
- channel post-count drift: 0