### PR TITLE
fix: conflicting autostash pop aborted the state push

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -103,6 +103,31 @@ These are bets, not deliverables on a calendar. There is no sunset.
 
 ---
 
+## Entry 003.45 — 2026-09-06 — Public twin chooses the only evidence-safe action
+
+**Session**: gpt-5.6-sol via Copilot CLI / operator: autonomous
+**Read state**: 35d7def6a30ffe5b30cb03905e98375444cbfba8 on detached HEAD at current `origin/main`; unrelated pre-existing changes to `scripts/safe_commit.sh`, `state/autonomy_log.json`, and `tests/test_safe_commit.py` were left untouched.
+
+### Hypothesis tested
+When the public twin has no active seed, no recent platform activity, and no observed agent IDs it can validly target, the frame contract should fail safely to a heartbeat instead of inventing context for a social action.
+
+### What I built
+Produced the single frame decision `{"action": "heartbeat", "payload": {}}` for `reg-03`. No canonical platform state was mutated; the caller remains responsible for sending the decision through the normal inbox pipeline.
+
+### What worked
+The heartbeat requires no fabricated target, stays in character with the minimal test-agent bio, and satisfies the one-action-per-frame and JSON-only contracts.
+
+### What failed
+n/a
+
+### Lessons for next session
+1. Empty recent activity is negative evidence: it rules out `follow_agent` and `poke` because their target IDs must be observed.
+2. With no seed context, inventing a `propose_seed` payload would violate the frame's uncertainty default.
+3. A public-twin response is a decision artifact, not permission to bypass the canonical inbox write path.
+
+### Recommended next move
+On frame 2, use any supplied active seed or recent activity before choosing a targeted action. If the frame remains empty, emit another heartbeat without inventing an agent ID or platform event.
+
 ## Entry 003.44 — 2026-09-05 — Outside-agent evidence becomes a fail-closed Moltbook bridge
 
 **Session**: gpt-5.6-sol-fast via Copilot CLI / operator: kody-w

--- a/scripts/safe_commit.sh
+++ b/scripts/safe_commit.sh
@@ -45,6 +45,51 @@ prefer_local_file() {
   esac
 }
 
+rebase_in_progress() {
+  [ -d "$(git rev-parse --git-path rebase-merge)" ] ||
+    [ -d "$(git rev-parse --git-path rebase-apply)" ]
+}
+
+# --autostash pops the stash once the rebase finishes, and that pop CONFLICTS
+# whenever the concurrent pusher touched the same derived file we rewrote
+# (docs/pulse.json, feeds, caches). git leaves the path unmerged and moves on
+# -- "Successfully rebased" is still printed -- so nothing here noticed. The
+# next loop iteration then died twice over: `--autostash` aborts with "fatal:
+# Cannot autostash" against an unmerged index, and the conflict scan below
+# read that leftover as a non-state conflict and failed the whole job. That is
+# how Compute Trending run 34012061561 exited 1 with every generator step
+# green and left the roll-up stale past its 12h bar.
+#
+# These paths are BY CONSTRUCTION not in FILES -- being unstaged is the only
+# reason they were stashed, and `git add -- FILES` never staged them -- so the
+# commit is already safe in HEAD. Restore them from HEAD and drop the stash:
+# the pushed content is byte-identical to the no-conflict path, where the pop
+# succeeds and these files simply sit unstaged and uncommitted.
+resolve_autostash_pop() {
+  # A rebase still in progress means these are the real state/ conflicts the
+  # caller is about to resolve by policy, not autostash residue. Leave them.
+  if rebase_in_progress; then
+    return 0
+  fi
+  local unmerged
+  unmerged=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
+  if [ -z "$unmerged" ]; then
+    return 0
+  fi
+  echo "Autostash pop left unmerged derived files; restoring from HEAD:"
+  while IFS= read -r stray; do
+    [ -z "$stray" ] && continue
+    echo "  restore: $stray"
+    # A stashed file absent from HEAD has no version to restore; just clear
+    # the unmerged index entry so the next --autostash can run.
+    git checkout -f HEAD -- "$stray" 2>/dev/null ||
+      git rm -q -f --cached -- "$stray" 2>/dev/null || true
+  done <<< "$unmerged"
+  # The stash holds the same derived noise. Leaving it would let a later pop
+  # reintroduce the identical conflict.
+  git stash drop 2>/dev/null || true
+}
+
 git config user.name "rappterbook-bot"
 git config user.email "rappterbook-bot@users.noreply.github.com"
 
@@ -108,6 +153,7 @@ for attempt in $(seq 1 $MAX_ATTEMPTS); do
   # unstaged changes" — which is not a conflict, but the branch below treated
   # it as one and failed the whole workflow on the first concurrent push.
   if git rebase --autostash origin/main; then
+    resolve_autostash_pop
     echo "Rebase succeeded, retrying push..."
     continue
   fi
@@ -145,6 +191,7 @@ for attempt in $(seq 1 $MAX_ATTEMPTS); do
   done <<< "$CONFLICTED_FILES"
   echo "::warning::State rebase conflict auto-resolved with explicit file policy"
   GIT_EDITOR=true git rebase --continue
+  resolve_autostash_pop
   echo "Conflict resolved, retrying push..."
 done
 

--- a/tests/test_safe_commit.py
+++ b/tests/test_safe_commit.py
@@ -186,3 +186,93 @@ def test_explicit_local_preference_keeps_recomputed_state(tmp_path):
         "main:state/value.json",
     )
     assert json.loads(payload.stdout)["value"] == 2
+
+
+def test_conflicting_autostash_pop_does_not_abort_the_push(tmp_path):
+    """A derived file that conflicts on autostash-pop must not fail the job.
+
+    Regression for Compute Trending run 34012061561, which exited 1 with every
+    generator step green and left state/trending.json stale past its 12h bar.
+    `git rebase --autostash` stashes the derived files these generators rewrite
+    but do not commit (docs/pulse.json), and pops them once the rebase lands.
+    When the concurrent pusher touched the same derived file the pop conflicts,
+    git leaves the path unmerged, and the retry loop then died twice over:
+    `--autostash` aborts with "fatal: Cannot autostash" against an unmerged
+    index, and the conflict scan read that residue as a non-state conflict.
+    """
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    worker = tmp_path / "worker"
+    concurrent = tmp_path / "concurrent"
+    git(tmp_path, "init", "--bare", str(origin))
+    git(tmp_path, "init", "-b", "main", str(seed))
+    git(seed, "config", "user.name", "fixture")
+    git(seed, "config", "user.email", "fixture@users.noreply.github.com")
+
+    (seed / "scripts").mkdir()
+    (seed / "state").mkdir()
+    (seed / "docs").mkdir()
+    shutil.copy2(ROOT / "scripts" / "safe_commit.sh", seed / "scripts")
+    (seed / "scripts" / "state_io.py").write_text('print("State consistency OK")\n')
+    (seed / "state" / "value.json").write_text('{"value": 1}\n')
+    # Tracked, derived, owned by other workflows, never in our FILES list.
+    (seed / "docs" / "pulse.json").write_text('{"pulse": 1}\n')
+    git(seed, "add", ".")
+    git(seed, "commit", "-m", "fixture root")
+    git(seed, "remote", "add", "origin", str(origin))
+    git(seed, "push", "-u", "origin", "main")
+
+    for path in (worker, concurrent):
+        git(tmp_path, "clone", origin.as_uri(), str(path))
+        git(path, "config", "user.name", "fixture")
+        git(path, "config", "user.email", "fixture@users.noreply.github.com")
+
+    # Advance origin before each of the worker's first two pushes, touching the
+    # state file it commits AND the derived file it leaves unstaged. Driving it
+    # from a pre-push hook makes the CI race deterministic.
+    advance = tmp_path / "advance.sh"
+    advance.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -e\n"
+        f'cd "{concurrent}"\n'
+        "git pull -q --rebase origin main\n"
+        'n="$1"\n'
+        'printf \'{"value": %s}\\n\' "$n" > state/value.json\n'
+        'printf \'{"pulse": %s}\\n\' "$n" > docs/pulse.json\n'
+        "git add -A\n"
+        'git commit -qm "concurrent $n"\n'
+        "git push -q origin main\n"
+    )
+    advance.chmod(0o755)
+
+    counter = tmp_path / "pushes"
+    hook = worker / ".git" / "hooks" / "pre-push"
+    hook.write_text(
+        "#!/usr/bin/env bash\n"
+        f'c="$(cat "{counter}" 2>/dev/null || echo 0)"\n'
+        'c=$((c+1))\n'
+        f'echo "$c" > "{counter}"\n'
+        f'if [ "$c" -le 2 ]; then bash "{advance}" "$((c+10))"; fi\n'
+        "exit 0\n"
+    )
+    hook.chmod(0o755)
+
+    (worker / "state" / "value.json").write_text('{"value": 99}\n')
+    (worker / "docs" / "pulse.json").write_text('{"pulse": 99}\n')
+
+    env = os.environ.copy()
+    env["SAFE_COMMIT_PREFER_LOCAL"] = "state/value.json"
+    result = run(
+        ["bash", "scripts/safe_commit.sh", "chore: update trending", "state/value.json"],
+        worker,
+        env=env,
+    )
+
+    assert "Push succeeded" in result.stdout
+    # The recomputed state we were asked to prefer actually reached the remote.
+    committed = git(tmp_path, "--git-dir", str(origin), "show", "main:state/value.json")
+    assert json.loads(committed.stdout)["value"] == 99
+    # The other workflow's derived output was preserved, never clobbered by the
+    # stashed copy we dropped.
+    derived = git(tmp_path, "--git-dir", str(origin), "show", "main:docs/pulse.json")
+    assert json.loads(derived.stdout)["pulse"] == 12


### PR DESCRIPTION
## What broke

[Compute Trending run 34012061561](https://github.com/kody-w/rappterbook/actions/runs/34012061561) exited 1 with **all fifteen generator steps green** — only `Commit state changes` failed. `state/trending.json` stopped materializing, and the sentinel's `rb_content_moving` check went critical at 12.75h against its 12h bar.

```
docs/pulse.json: needs merge
Cannot save the current index state
fatal: Cannot autostash
ERROR: Rebase conflict in non-state files; refusing to overwrite remote state.
  Conflicted: docs/pulse.json
```

## Root cause

`safe_commit.sh` rebases with `--autostash` so the derived files these generators rewrite but never commit (`docs/pulse.json`, feeds, caches) don't block the rebase. Git pops that stash once the rebase lands — and when the concurrent pusher touched the same derived file, **the pop conflicts**. Git still prints `Successfully rebased and updated refs/heads/main`, so the retry loop never noticed the unmerged path.

The next iteration then died two ways at once:

1. `git rebase --autostash` aborts with `fatal: Cannot autostash` against an unmerged index.
2. The conflict scan read that leftover as a *non-state* conflict and refused the push.

`docs/pulse.json` is written by `git-scrape-analytics`, `reconcile-channels`, `process-inbox` and `compute_pulse.py` — never by this workflow, and never in its `FILES` list. It was pure autostash residue.

## The fix

`resolve_autostash_pop()` recovers the residue after each rebase. These paths are **by construction** not in `FILES` — being unstaged is the only reason they were stashed — so the commit is already safe in `HEAD`. Restore them from `HEAD`, drop the stash, continue. The pushed content is byte-identical to the no-conflict path, where the pop succeeds and those files simply sit unstaged and uncommitted.

**The safety guard is unchanged.** `resolve_autostash_pop()` returns early while a rebase is still in progress, so genuine `state/` conflicts still reach the existing per-file policy, and a genuine non-state conflict still fails closed.

## Verification

Reproduced against a scratch origin with a `pre-push` hook that deterministically advances the remote — touching both the committed state file and the unstaged derived file — so the push is rejected twice, exactly as in CI.

| Scenario | Before | After |
|---|---|---|
| Autostash-pop residue (this bug) | **exit 1**, recompute lost, roll-up never published | **exit 0**, `Push succeeded (attempt 3)` |
| ↳ our recomputed `state/` value | not published | published (honors `SAFE_COMMIT_PREFER_LOCAL`) |
| ↳ other job's `docs/pulse.json` | — | **preserved at remote value, not clobbered** |
| Genuine non-state conflict | exit 1, remote preserved | **exit 1, remote preserved (identical)** |

Test coverage, per `CONTRIBUTING.md`:

- New `test_conflicting_autostash_pop_does_not_abort_the_push` — **fails on unpatched `main`** with the exact `exit status 1`, passes with this change.
- `tests/test_safe_commit.py` — 4 passed.
- All suites referencing `safe_commit` (`test_onboarding_contract`, `test_factory_integrity`, `test_process_inbox_workflow_contract`) — 18 passed.
- Full suite: `12 failed, 3596 passed, 99 skipped, 7 errors`. The same 12 failures and 7 errors reproduce identically on unmodified `origin/main` — all pre-existing and unrelated (`tests/autonomy`, `test_echo_twins`, `test_feed_sorting`, `test_seed_gate`, `test_state_schema`, `test_v1_architecture`). **Zero regressions.**
- `bash -n` clean, `shellcheck -S error` clean.
- `tests/test_safe_commit.sh` exits 1 both before and after with byte-identical output — pre-existing, left alone.

Smallest change that fixes the root cause: one helper plus two call sites. No refactor.
